### PR TITLE
Add an option to set the tag on update

### DIFF
--- a/addon/utils/ce/editor/update.js
+++ b/addon/utils/ce/editor/update.js
@@ -134,7 +134,7 @@ function updateEditorStateAfterUpdate(selection, relativePosition, currentNode) 
 }
 
 // rdfa attributes we understand, currently ignoring src and href
-const RDFAKeys = ['about', 'property','datatype','typeof','resource', 'rel', 'rev', 'content', 'vocab', 'prefix'];
+const RDFAKeys = ['about', 'property','datatype','typeof','resource', 'rel', 'rev', 'content', 'vocab', 'prefix', 'tag'];
 const WRAP = "wrap";
 const UPDATE = "update";
 const NEST = "nest";
@@ -162,6 +162,15 @@ function insertNodeOnSelection(rootNode, selection, domPosition){
     console.warn('Currently we assume if highlight is selected, only textNodes will be selected. Prepend/Append not possible'); // eslint-disable-line no-console
     return;
   }
+
+  // If a tag is specified we use it, otherwise we set <div> as default
+  let tag = (before ? before.tag : false) ||  (after ? after.tag : false) || (prepend ? prepend.tag : false) || (append ? append.tag : false) || "div";
+  const allowedTags = ["div", "p", "span", "a", "li"]
+  if(!allowedTags.includes(tag)){
+    console.warn('We currently support only the following tags: "div", "p", "span", "a", "li"'); // eslint-disable-line no-console
+    return;
+  }
+
   let selectionOfInterest = null;
   if(selection.selectedHighlightRange){
     let cleanedSelections = splitSelectionsToPotentiallyFitInRange(selection.selectedHighlightRange, selection.selections);
@@ -184,7 +193,7 @@ function insertNodeOnSelection(rootNode, selection, domPosition){
 
   if (isRDFAUpdate({ before, after, prepend, append }) || isInnerContentUpdate({ before, after, prepend, append })) {
     let referenceNode = selectionOfInterest.richNode.domNode;
-    let newDomNode = document.createElement('div'); //TODO: now only div, but this must be determined in a smart way.
+    let newDomNode = document.createElement(tag);
 
     if(isRDFAUpdate({ before, after, prepend, append }) && isInnerContentUpdate({ before, after, prepend, append })){
       updateRDFA([ newDomNode ], { set: (before || after || prepend || append) });

--- a/addon/utils/ce/editor/update.js
+++ b/addon/utils/ce/editor/update.js
@@ -134,7 +134,7 @@ function updateEditorStateAfterUpdate(selection, relativePosition, currentNode) 
 }
 
 // rdfa attributes we understand, currently ignoring src and href
-const RDFAKeys = ['about', 'property', 'datatype', 'typeof', 'resource', 'rel', 'rev', 'content', 'vocab', 'prefix', 'tag'];
+const RDFAKeys = ['about', 'property', 'datatype', 'typeof', 'resource', 'rel', 'rev', 'content', 'vocab', 'prefix'];
 const WRAP = "wrap";
 const UPDATE = "update";
 const NEST = "nest";
@@ -165,9 +165,9 @@ function insertNodeOnSelection(rootNode, selection, domPosition){
 
   // If a tag is specified we use it, otherwise we set <div> as default
   let tag = (before ? before.tag : false) ||  (after ? after.tag : false) || (prepend ? prepend.tag : false) || (append ? append.tag : false) || "div";
-  const allowedTags = ["div", "p", "span", "a", "li"]
+  const allowedTags = ["div", "p", "span", "li", "a", "link"]
   if(!allowedTags.includes(tag)){
-    console.warn('We currently support only the following tags: "div", "p", "span", "a", "li"'); // eslint-disable-line no-console
+    console.warn('We currently support only the following tags: "div", "p", "span", "li", "a", "link"'); // eslint-disable-line no-console
     return;
   }
 
@@ -529,9 +529,9 @@ function cleanPrefixObject(prefixes){
 function wrapSelection(selection, {remove, add, set, desc}) {
   // If a tag is specified we use it, otherwise we set <div> as default
   let tag = (remove ? remove.tag : false) ||  (add ? add.tag : false) || (set ? set.tag : false) || (desc ? desc.tag : false) || "div";
-  const allowedTags = ["div", "p", "span", "a", "li"]
+  const allowedTags = ["div", "p", "span", "li", "a", "link"]
   if(!allowedTags.includes(tag)){
-    console.warn('We currently support only the following tags: "div", "p", "span", "a", "li"'); // eslint-disable-line no-console
+    console.warn('We currently support only the following tags: "div", "p", "span", "li", "a", "link"'); // eslint-disable-line no-console
     return;
   }
 

--- a/addon/utils/ce/editor/update.js
+++ b/addon/utils/ce/editor/update.js
@@ -814,7 +814,7 @@ function updateRDFA(domNodes, { remove, add, set } ) {
         const optionHasResourceOrHref = set["href"]!=null || set["resource"]!=null || add["href"]!=null || add["resource"]!=null;
 
         if (tagIsHrefCompatible && !(nodeHasResourceOrHref || optionHasResourceOrHref)) {
-          console.warn(`<${domNode.tagName}> tag should have a resource or a href.`);
+          console.warn(`<${domNode.tagName}> tag should have a resource or a href.`); // eslint-disable-line no-console
           return true;
         }
 


### PR DESCRIPTION
This small PR allow us to choose which tag we want to insert on an update. It would be useful for certain plugins, such as the citaten plugin where we need to add html in a `<a>` tag.