### PR TITLE
Update LoadMonitor to use Ember's get for plugins

### DIFF
--- a/addon/components/rdfa/load-monitor.js
+++ b/addon/components/rdfa/load-monitor.js
@@ -27,12 +27,29 @@ export default class LoadMonitor extends Component {
  rdfaEditorDispatcher;
 
  /**
+  * All services which have an async task
+  * @property taskServices
+  * @type array
+  * @private
+  */
+ @computed('rdfaEditorDispatcher.pluginServices.[]')
+ get taskServices(){
+   const tasks = [];
+   for ( const thing of get( this, "rdfaEditorDispatcher.pluginServices") || [] ) {
+     if( get( thing, "execute.perform") )
+       tasks.push( thing );
+   }
+
+   return tasks;
+ }
+
+ /**
   * plugins available in the dispatcher
   * @property tasks
   * @type array
   * @protected
   */
- @mapBy('rdfaEditorDispatcher.pluginServices', 'execute')
+ @mapBy('taskServices', 'execute')
  tasks;
 
  /**

--- a/addon/components/rdfa/load-monitor.js
+++ b/addon/components/rdfa/load-monitor.js
@@ -1,3 +1,4 @@
+import { get } from '@ember/object';
 import classic from "ember-classic-decorator";
 import { layout as templateLayout } from "@ember-decorators/component";
 import { computed } from "@ember/object";
@@ -54,7 +55,7 @@ export default class LoadMonitor extends Component {
   */
  @computed('tasks.@each.isRunning')
  get anyPluginBusy() {
-   return this.tasks.find(t => t.get('isRunning') == true);
+   return this.tasks.find(t => get( t, 'isRunning') == true);
  }
 
  /**
@@ -83,7 +84,7 @@ export default class LoadMonitor extends Component {
   */
  @computed('tasks.@each.isRunning')
  get busyPluginsCount() {
-   return this.tasks.filter(t => t.get('isRunning') == true).length;
+   return this.tasks.filter(t => get( t, 'isRunning') == true).length;
  }
 
  /**


### PR DESCRIPTION
This is a starting point with the clear focus to get
https://github.com/lblod/ember-rdfa-editor-dbpedia-info-plugin/tree/feature/mr-proper
working with an unpatched version of this library.

Some of this code could be cleaned and polished.  That seemed out of
scope for my current intentions.