### PR TITLE
Add helper function to easen hints removal

### DIFF
--- a/addon/utils/rdfa/hints-registry.js
+++ b/addon/utils/rdfa/hints-registry.js
@@ -292,6 +292,32 @@ export default class HinstRegistry extends EmberObject {
   }
 
   /**
+   * Removes hints which occur in a set of rdfaBlocks.
+   *
+   * This is a helper method which makes functional plugins a lot
+   * easier to write.  These plugins remove all hints as a starting
+   * point, calculate where the hints should be, and supply all of the
+   * new hints to the HinstRegistry.  In case there are no performance
+   * issues to recalculate the hints, this approach is easy to
+   * understand.  This particular call cleans up such plugins.
+   *
+   * @method removeHintsInRdfaBlocks
+   *
+   * @param {Array} rdfaBlocks Objects for which the region is in the
+   * `region` property.
+   * @param {Object} [hrIdx] Index of the registry else registry at
+   * current index is provided
+   * @param {string} [identifier] Name of the plugin to filter on
+   *
+   * @public
+   */
+  removeHintsInRdfaBlocks(rdfaBlocks, hrId, identifier) {
+    rdfaBlocks.forEach( (block) => {
+      this.removeHintsInRegion( block.region, hrId, identifier );
+    });
+  }
+
+  /**
    * This function executes multiple hints updates as a batch.
    * WHY
    * ---

--- a/addon/utils/rdfa/hints-registry.js
+++ b/addon/utils/rdfa/hints-registry.js
@@ -252,7 +252,6 @@ export default class HinstRegistry extends EmberObject {
     if(updatedRegistry.get('length') !== this.get('registry').get('length')){
       this.replaceRegistryAndNotify(updatedRegistry);
     }
-
   }
 
   /**
@@ -288,7 +287,40 @@ export default class HinstRegistry extends EmberObject {
     this.set('registry', updatedRegistry);
 
     next(() => { this.batchProcessHighlightsUpdates.perform(); });
+  }
 
+  /**
+   * Generic interface for removing hints
+   *
+   * @method removeHints
+   *
+   * @param {Object} options Indicates which hints should be removed
+   * @param {Object} options.hrId Index of the HintsRegistry relative
+   * to which the hints should be removed.
+   * @param {String} options.scope Scope for which the hints should be
+   * removed.  This is most often the name of the plugin.
+   * @param {Array} [options.region] If region is supplied, the hints
+   * in the supplied region will be removed.  A region is an array
+   * containing a start and an end.
+   * @param {Array} [options.rdfaBlocks] If an array of rdfaBlocks is
+   * supplied, hinst will be removed for each of the rdfaBlocks.
+   *
+   * @public
+   */
+  removeHints( options ) {
+    const { hrId, scope } = options;
+
+    if( ! options.rdfaBlocks && ! options.region ){
+      console.warn( "HinstRegistry#removeHints was called without rdfaBlocks or location, no hints will be removed." );
+    }
+
+    if( options.rdfaBlocks ) {
+      this.removeHintsInRdfaBlocks( options.rdfaBlocks, hrId, scope );
+    }
+
+    if( options.region ) {
+      this.removeHintsInRegion( options.region, hrId, scope );
+    }
   }
 
   /**


### PR DESCRIPTION
 plugins remove all of the hints for the region they are currently scanning.  Doing this with the old API requires some basic logic, but it's repeated everywhere.

## What is this?

This PR introduces a new method to easen the burden.  It removes the hints for all the regions which an array of rdfaBlocks cover.  The
implementation itself is rather silly and could be improved over time, yet plugins do become easier to read by it.

The commit originated from the cleaning effort of lblod/ember-rdfa-editor-wikipedia-slug-plugin#1 and from simplifications in the [ember-rdfa-editor-plugin-generator](https://github.com/lblod/ember-rdfa-editor-plugin-generator).

## Example

The standard way of implementing a plugin service would be transformed into something that looks much easier to thing about.  There are less surprises in the following code because the natural flow of the code is also the one which works:

    execute(hrId, rdfaBlocks, hintsRegistry, editor) {
      hintsRegistry.removeHintsInRdfaBlocks( rdfaBlocks, hrId, "hello-hint-scope" );

      for( const rdfaBlock of rdfaBlocks ){
        if( ... ) {
          hintsRegistry.addHint( hrId, "hello-hint-scope", {
            location: absoluteLocation,
            card: "editor-plugins/hello-hint-card",
            info: { ... }
          });
        }
      }
    }

## To discuss

  - The name of this method is fairly long.  If we could find a shorter or easier to remember name that would be nice.
  - Also introducing a `removeHints` method which detects the received argument and is smart about region vs rdfaBlock would make the code a lot easier to read.  Can we extend the current PR to include this or is that over-the-top?