### PR TITLE
Filter outer on blocks and parents

### DIFF
--- a/addon/utils/ce/editor/select.js
+++ b/addon/utils/ce/editor/select.js
@@ -186,8 +186,8 @@ function selectContext([start,end], options = {}) {
   }
 
   if ( options.scope == 'outer' || ( options.scope == 'auto' && !foundInnerMatch ) ) {
-    // The rdfaBlocks returned by the context scanner don't include the upper part of the dom tree.
-    // As we are filtering on an outer scope, we might need those parent blocks.
+    /* The rdfaBlocks returned by the context scanner don't include the upper part of the dom tree.
+       As we are filtering on an outer scope, we might need those parent blocks. */
     let parentBlocks = [];
     rdfaBlocks.forEach(block => {
       parentBlocks = parentBlocks.concat(block.getParentBlocks(block));
@@ -382,22 +382,6 @@ function filterOuter(blocks, filter, [start, end]) {
 
   return selections;
 }
-
-/* function getParentBlocks(richNode, parentBlocks=[]) {
-  if (richNode.rdfaAttributes) {
-    parentBlocks.push(EmberObject.create({
-      context: rdfaAttributesToTriples(richNode.rdfaContext),
-      richNode: richNode,
-      semanticNode: richNode
-    }));
-  }
-
-  if (!richNode.parent) {
-    return parentBlocks;
-  } else {
-    return getParentBlocks(richNode.parent, parentBlocks);
-  }
-} */
 
 export {
   selectCurrentSelection,

--- a/addon/utils/ce/editor/select.js
+++ b/addon/utils/ce/editor/select.js
@@ -1,7 +1,5 @@
-import EmberObject from '@ember/object';
 import { positionInRange } from '@lblod/marawa/range-helpers';
 import { analyse as scanContexts } from '@lblod/marawa/rdfa-context-scanner';
-import { rdfaAttributesToTriples } from '@lblod/marawa/rdfa-helpers';
 
 /**
  * Fake class to list helper functions

--- a/addon/utils/ce/editor/select.js
+++ b/addon/utils/ce/editor/select.js
@@ -186,17 +186,14 @@ function selectContext([start,end], options = {}) {
   }
 
   if ( options.scope == 'outer' || ( options.scope == 'auto' && !foundInnerMatch ) ) {
-
     // The rdfaBlocks returned by the context scanner don't include the upper part of the dom tree.
-    // But as we are filtering on an outer scope, we might need those parent blocks.
-
-    let parents = [];
-
+    // As we are filtering on an outer scope, we might need those parent blocks.
+    let parentBlocks = [];
     rdfaBlocks.forEach(block => {
-      parents = parents.concat(getParentBlocks(block.semanticNode, block.richNodes[0].rdfaContext));
+      parentBlocks = parentBlocks.concat(block.getParentBlocks(block));
     });
 
-    selections = filterOuter(rdfaBlocks.concat(parents), filter, [start, end]);
+    selections = filterOuter(rdfaBlocks.concat(parentBlocks), filter, [start, end]);
   }
 
   return { selections };
@@ -370,7 +367,7 @@ function filterOuter(blocks, filter, [start, end]) {
   let selections = [];
 
   blocks
-    .filter(block => block.semanticNode.rdfaAttributes)
+    .filter(block => block.semanticNode && block.semanticNode.rdfaAttributes)
     .filter(block => block.semanticNode.containsRegion(start, end))
     .forEach( function(block) {
       if ( isMatchingContext(block, filter) ) {
@@ -386,23 +383,21 @@ function filterOuter(blocks, filter, [start, end]) {
   return selections;
 }
 
-function getParentBlocks(semanticNode, contexts, parentBlocks=[]) {
-  if (semanticNode.rdfaAttributes) {
-    console.log(contexts);
-    console.log(rdfaAttributesToTriples([semanticNode.rdfaAttributes]))
-
+/* function getParentBlocks(richNode, parentBlocks=[]) {
+  if (richNode.rdfaAttributes) {
     parentBlocks.push(EmberObject.create({
-      context: rdfaAttributesToTriples([semanticNode.rdfaAttributes]),
-      semanticNode: semanticNode
+      context: rdfaAttributesToTriples(richNode.rdfaContext),
+      richNode: richNode,
+      semanticNode: richNode
     }));
   }
 
-  if (!semanticNode.parent) {
+  if (!richNode.parent) {
     return parentBlocks;
   } else {
-    return getParentBlocks(semanticNode.parent, contexts, parentBlocks);
+    return getParentBlocks(richNode.parent, parentBlocks);
   }
-}
+} */
 
 export {
   selectCurrentSelection,


### PR DESCRIPTION
When using the `outer` scope of the `selectContext` method, we were only checking the blocks given by marawa's context scanner. Those blocks are strictly contained in the range given by the `selectContext` method. It can be an issue as we could want the parents of those blocks when filtering with an outer scope.

This PR uses the current blocks and their parents when filtering with an `outer` scope.

/!\ Needs to be merged after [this PR](https://github.com/lblod/marawa/pull/4) is merged and bumped in the editor. /!\