### PR TITLE
don't indent/unindent when not in list

### DIFF
--- a/addon/components/rdfa/editor-toolbar.js
+++ b/addon/components/rdfa/editor-toolbar.js
@@ -6,6 +6,8 @@ import boldProperty from '../../utils/rdfa/bold-property';
 import italicProperty from '../../utils/rdfa/italic-property';
 import underlineProperty from '../../utils/rdfa/underline-property';
 import strikethroughProperty from '../../utils/rdfa/strikethrough-property';
+import { isInList } from '@lblod/ember-rdfa-editor/utils/ce/list-helpers';
+import { getWindowSelection } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 
 /**
  * RDFa editor toolbar component
@@ -37,12 +39,38 @@ export default class EditorToolbar extends Component {
 
   @action
   insertIndent() {
-    this.contentEditable.insertIndent();
+    const selection = getWindowSelection();
+    if (selection.isCollapsed) {
+      // colllapsed selections that are not in a list are not properly handled, this is a temporary workaround until we have a better toolbar.
+      if (isInList(selection.anchorNode)) {
+        this.contentEditable.insertIndent();
+      }
+      else {
+        //refocus editor
+        this.contentEditable.rootNode.focus();
+      }
+    }
+    else {
+      this.contentEditable.insertIndent();
+    }
   }
 
   @action
   insertUnindent() {
-    this.contentEditable.insertUnindent();
+    const selection = getWindowSelection();
+    if (selection.isCollapsed) {
+      // colllapsed selections that are not in a list are not properly handled, this is a temporary workaround until we have a better toolbar.
+      if (isInList(selection.anchorNode)) {
+        this.contentEditable.insertUnindent();
+      }
+      else {
+        //refocus editor
+        this.contentEditable.rootNode.focus();
+      }
+    }
+    else {
+      this.contentEditable.insertUnindent();
+    }
   }
 
   @action


### PR DESCRIPTION
this only addresses (un)indenting for collapsed selections, as true selections do not throw an error at this time.