### PR TITLE
Bugfix/first use css

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  name: require('./package').name;
+  name: require('./package').name,
 
   included() {
     let hasSass = !!app.registry.availablePlugins['ember-cli-sass'];

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
   name: require('./package').name,
 
   included() {
+    let app = this._findHost();
     let hasSass = !!app.registry.availablePlugins['ember-cli-sass'];
 
     // Don't include the precompiled css file if the user uses a supported CSS preprocessor

--- a/index.js
+++ b/index.js
@@ -1,5 +1,14 @@
 'use strict';
 
 module.exports = {
-  name: require('./package').name
+  name: require('./package').name;
+
+  included() {
+    let hasSass = !!app.registry.availablePlugins['ember-cli-sass'];
+
+    // Don't include the precompiled css file if the user uses a supported CSS preprocessor
+    if (!hasSass) {
+      app.import('vendor/ember-rdfa-editor.css');
+    }
+  },
 };

--- a/index.js
+++ b/index.js
@@ -4,9 +4,13 @@ module.exports = {
   name: require('./package').name,
 
   included() {
+    /**
+     * detect whether the parent app has sass installed. only import css if sass isn't installed
+     * this was inspired by https://github.com/cibernox/ember-power-select/blob/1d867972607784354cf819740e9e716db1cb923a/index.js
+     */
     let app = this._findHost();
     let hasSass = !!app.registry.availablePlugins['ember-cli-sass'];
-
+     this._super.included.apply(this, arguments);
     // Don't include the precompiled css file if the user uses a supported CSS preprocessor
     if (!hasSass) {
       app.import('vendor/ember-rdfa-editor.css');


### PR DESCRIPTION
This should fix the issue with the CSS not being included in the `vendor.css` when installing the addon.
I think this was because the `index.js` was missing the CSS import include statement.

Took some inspiration from https://github.com/cibernox/ember-power-select/blob/master/index.js to check if Sass is used.

My initial tests seem to be working but some further testing and code review seems necessary to check if the blueprint and import is done correctly.