### PR TITLE
Feature/fix tests

### DIFF
--- a/addon/model/operations/attribute-operation.ts
+++ b/addon/model/operations/attribute-operation.ts
@@ -35,7 +35,7 @@ export default class AttributeOperation extends Operation {
     }
   }
 
-  execute() {
+  execute(): ModelRange {
 
     this.canExecute();
 
@@ -43,6 +43,7 @@ export default class AttributeOperation extends Operation {
     for (const node of this.range.start.parent.children) {
       node.setAttribute(this._key, this._value);
     }
+    return this.range;
 
   }
 }

--- a/addon/model/writers/html-text-writer.ts
+++ b/addon/model/writers/html-text-writer.ts
@@ -18,7 +18,7 @@ export default class HtmlTextWriter implements Writer<ModelText, Node | null> {
   constructor(private model: Model) {
   }
   write(modelNode: ModelText): Node | null {
-    if(modelNode.length === 0 && this.model.selection.anchor?.parent !== modelNode) {
+    if(modelNode.length === 0) {
       return null;
     }
     const result = new Text(modelNode.content);

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -44,8 +44,8 @@ import ModelSelectionTracker from "@lblod/ember-rdfa-editor/utils/ce/model-selec
 @classic
 class RawEditor extends EmberObject {
   registeredCommands: Map<string, Command> = new Map()
-  modelSelectionTracker: ModelSelectionTracker;
-  model: Model;
+  modelSelectionTracker!: ModelSelectionTracker;
+  model!: Model;
   protected tryOutVdom = true;
 
   /**
@@ -117,9 +117,6 @@ class RawEditor extends EmberObject {
 
   set rootNode(rootNode: HTMLElement) {
     if (rootNode) {
-      if (this.model) {
-        this.model.modelSelectionTracker.stopTracking();
-      }
       this.initialize(rootNode);
       this.model.read();
       this.model.write();

--- a/tests/unit/commands/remove-list-command-test.ts
+++ b/tests/unit/commands/remove-list-command-test.ts
@@ -3,9 +3,6 @@ import ModelTestContext from "dummy/tests/utilities/model-test-context";
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
 import RemoveListCommand from "@lblod/ember-rdfa-editor/commands/remove-list-command";
-import {setupTest} from "ember-qunit";
-import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
-import {AssertionError} from "@lblod/ember-rdfa-editor/utils/errors";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import {vdom} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
@@ -13,7 +10,6 @@ import {vdom} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
 module("Unit | commands | remove-list-command", hooks => {
   const ctx = new ModelTestContext();
   let command: RemoveListCommand;
-  setupTest(hooks);
   hooks.beforeEach(() => {
     ctx.reset();
     command = new RemoveListCommand(ctx.model);

--- a/tests/unit/model/model-range-test.ts
+++ b/tests/unit/model/model-range-test.ts
@@ -170,6 +170,63 @@ module("Unit | model | model-range", () => {
     });
   });
 
+  module("Unit | model | model-range | getMinimumConfinedRanges", () => {
+    // language=XML
+    const xml = `
+
+<div contenteditable="" class="say-editor__inner say-content"><div property="prov:generated" resource="http://data.lblod.info/id/besluiten/0be6f42c-590e-46d3-92ef-f725680c558f" typeof="besluit:Besluit ext:BesluitNieuweStijl"><text>
+  </text><p><text>Openbare titel besluit:</text></p><text>
+  </text><h4 class="h4" property="eli:title" datatype="xsd:string"><span class="mark-highlight-manual"><text>Geef titel besluit op</text></span></h4><text>
+  </text><span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept"><text> </text></span><text>
+  </text><br/><text>
+  </text><p><text>Korte openbare beschrijving:</text></p><text>
+  </text><p property="eli:description" datatype="xsd:string"><span class="mark-highlight-manual"><text>Geef korte beschrijving op</text></span></p><text>
+  </text><br/><text>
+
+  </text><div property="besluit:motivering" lang="nl"><text>
+    </text><p><text>
+      </text><span class="mark-highlight-manual"><text>geef bestuursorgaan op</text></span><text>,
+    </text></p><text>
+    </text><br/><text>
+
+    </text><h5><text>Bevoegdheid</text></h5><text>
+    </text><ul class="bullet-list"><li><span class="mark-highlight-manual"><text>Rechtsgrond die bepaald dat dit orgaan bevoegd is.</text></span></li></ul><text>
+    </text><br/><text>
+
+    </text><h5><text>Juridische context</text></h5><text>
+    </text><ul class="bullet-list"><li><span class="mark-highlight-manual"><text>Voeg juridische context in</text></span></li></ul><text>
+    </text><br/><text>
+
+    </text><h5><text>Feitelijke context en argumentatie</text></h5><text>
+    </text><ul class="bullet-list"><li><span class="mark-highlight-manual"><text>Voeg context en argumentatie in</text></span></li></ul><text>
+  </text></div><text>
+  </text><br/><text>
+  </text><br/><text>
+
+  </text><h5><text>Beslissing</text></h5><text>
+
+  </text><div property="prov:value" datatype="xsd:string"><text>
+    </text><div property="eli:has_part" resource="http://data.lblod.info/artikels/814b58fc-d8be-4890-ad36-781fc8b34a82" typeof="besluit:Artikel"><text>
+      </text><div property="eli:number" datatype="xsd:string"><text>Artikel 1</text></div><text>
+      </text><span style="display:none;" property="eli:language" resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept"><text> </text></span><text>
+      </text><div property="prov:value" datatype="xsd:string"><text>
+        </text><span class="mark-highlight-manual"><text>Voer inhoud in</text></span><text>
+      </text></div><text>
+    </text></div><text>
+    </text><br/><text>
+    </text><div class="mark-highlight-manual"><text highlighted="true">Voeg nieuw artikel in</text></div><text> 
+    </text><br/><text>
+  </text></div><text>
+
+</text></div><text>
+</text></div>
+`;
+    const { root, textNodes: {rangeStart, rangeEnd}} = parseXml(xml);
+    const range = ModelRange.fromPaths(root as ModelElement, [0, 50, 17], [0, 50, 17, 21]);
+    const ranges = range.getMinimumConfinedRanges();
+    // TODO add asserts
+  });
+
   module("Unit | model | model-range | getMaximizedRange", () => {
     test("gets the same range when start and end in commonAncestor", assert => {
       // language=XML

--- a/tests/unit/model/model-selection-tracker-test.ts
+++ b/tests/unit/model/model-selection-tracker-test.ts
@@ -19,13 +19,12 @@ module("Unit | model | model-selection-tracker", hooks => {
 
     const {model} = ctx;
     const testRoot = document.getElementById("ember-testing-container")!;
-    const rootNode = document.createElement("div");
+    const rootNode = model.rootNode;
     testRoot.appendChild(rootNode);
     const selection = getWindowSelection();
     const text = new Text("abc");
     const tracker = new ModelSelectionTracker(ctx.model);
     rootNode.appendChild(text);
-    ctx.model.rootNode = rootNode;
     sync();
 
     selection.collapse(rootNode.childNodes[0]);

--- a/tests/unit/model/readers/xml-reader-test.ts
+++ b/tests/unit/model/readers/xml-reader-test.ts
@@ -1,7 +1,7 @@
 import {module, test} from "qunit";
 import {parseXml} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
 
-module("Unit | model | readers | xml-reader-test", hooks => {
+module("Unit | model | readers | xml-reader-test", () => {
   test("test xml", assert => {
     // language=XML
     const xml = `

--- a/tests/unit/model/utils/tree-walker-test.ts
+++ b/tests/unit/model/utils/tree-walker-test.ts
@@ -6,7 +6,7 @@ import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
 import {vdom} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
 
-module("Unit | model | utils | tree-walker-test", hooks => {
+module("Unit | model | utils | tree-walker-test", () => {
   test("finds root when its the only node and position starts there", assert => {
     const root = new ModelElement("div", {debugInfo: "root"});
 
@@ -186,7 +186,7 @@ module("Unit | model | utils | tree-walker-test", hooks => {
 
 
     // language=XML
-    const {root, textNodes: {startRange, endRange}, elements: {insideConfinedRange1}} = vdom`
+    const {textNodes: {startRange, endRange}, elements: {insideConfinedRange1}} = vdom`
       <div>
         <p>
           <span>

--- a/tests/unit/model/writers/xml-writer-test.ts
+++ b/tests/unit/model/writers/xml-writer-test.ts
@@ -1,7 +1,7 @@
 import {module, test} from "qunit";
 import {printModel, vdom} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
 
-module("Unit | model | writers | xml-writer-test", hooks => {
+module("Unit | model | writers | xml-writer-test", () => {
   test("writes out a sensible document", assert => {
 
     // language=XML

--- a/tests/utilities/model-test-context.ts
+++ b/tests/utilities/model-test-context.ts
@@ -8,32 +8,12 @@ export default class ModelTestContext {
   model!: Model;
   modelSelection!: ModelSelection;
   domSelection!: Selection;
-  testRoot!: HTMLElement;
 
   reset() {
-    this.testRoot = document.getElementById("ember-testing")!;
-    if(this.testRoot) {
-      for (const child of this.testRoot.childNodes) {
-        this.testRoot.removeChild(child);
-      }
-    }
-
     this.rootNode = document.createElement("div");
-    this.testRoot.appendChild(this.rootNode);
-    this.model = new Model();
-    this.model.rootNode = this.rootNode;
-    this.model.read();
-    this.model.write();
+    this.model = new Model(this.rootNode);
+    this.model.read(false);
     this.modelSelection = this.model.selection;
-    this.domSelection = getWindowSelection();
-
-  }
-  destroy() {
-    if(this.testRoot) {
-      for (const child of this.testRoot.childNodes) {
-        this.testRoot.removeChild(child);
-      }
-    }
 
   }
 }


### PR DESCRIPTION
Doing this in a separate pr cause there could be some hidden issues

This fixes the non-determinism in the tests, or rather avoids it completely by slightly adjusting the way the model is set up.
The problems all centered around the window.getSelection() method, and by extension the modification of the testing-dom in the tests. Qunit and ember-qunit documentation is extremely sparse on this topic. (can you tell I'm really not a qunit fan)

The good news is that we don't really need the selection at all to perform model tests. We can work with a Range instead, which we can create on detached document tree (i.e. one that is not rendered at all, the result of a simple `document.createElement()` without attaching the node anywhere). Since the logic for converting the domselection immediately and trivially drops down to its ranges, we can be confident that this will be enough for almost all usecases.

The changes needed for this were mainly the ability to create a model without a tracker, and to do a model.read without also reading the selection. Both are added in this PR.

Because this changes the way the model is initialized, and also moves the selectionTracker into the RawEditor instead of the model, it's possible something broke on the boundary between pernet and vdom code.

Sidenote: I am still not happy with the way the `RawEditor` and the model are initialized, but I think it will do for now.

depends on #67 