### PR TITLE
Bugfix/br in br

### DIFF
--- a/addon/commands/insert-newLine-command.ts
+++ b/addon/commands/insert-newLine-command.ts
@@ -25,9 +25,6 @@ export default class InsertNewLineCommand extends Command {
     const br = new ModelElement("br");
     this.model.change(mutator => {
       mutator.insertNodes(range, br);
-    }, false);
-    const cursorPos = ModelPosition.fromAfterNode(br);
-    this.model.selection.selectRange(new ModelRange(cursorPos, cursorPos));
-    this.model.writeSelection();
+    });
   }
 }

--- a/addon/commands/insert-newLine-command.ts
+++ b/addon/commands/insert-newLine-command.ts
@@ -18,13 +18,10 @@ export default class InsertNewLineCommand extends Command {
     return true;
   }
 
-  execute(): void {
-
-    const selection = this.model.selection;
-    if (!ModelSelection.isWellBehaved(selection)) {
+  execute(range: ModelRange | null = this.model.selection.lastRange): void {
+    if(!range) {
       throw new MisbehavedSelectionError();
     }
-    const range = selection.lastRange;
     const br = new ModelElement("br");
     this.model.change(mutator => {
       mutator.insertNodes(range, br);

--- a/addon/commands/insert-newLine-command.ts
+++ b/addon/commands/insert-newLine-command.ts
@@ -25,6 +25,9 @@ export default class InsertNewLineCommand extends Command {
     const br = new ModelElement("br");
     this.model.change(mutator => {
       mutator.insertNodes(range, br);
-    });
+    }, false);
+    const cursorPos = ModelPosition.fromAfterNode(br);
+    this.model.selection.selectRange(new ModelRange(cursorPos, cursorPos));
+    this.model.writeSelection();
   }
 }

--- a/addon/editor/input-handlers/enter-handler.ts
+++ b/addon/editor/input-handlers/enter-handler.ts
@@ -23,6 +23,7 @@ export default class EnterHandler implements InputHandler {
 
 
   handleEvent(_event: Event) {
+    console.log("enter")
     //TODO (sergey):this is hacky and very quick should be redone
     if(this.rawEditor.canExecuteCommand('insert-newLi')){
       this.rawEditor.executeCommand('insert-newLi');

--- a/addon/editor/input-handlers/enter-handler.ts
+++ b/addon/editor/input-handlers/enter-handler.ts
@@ -23,7 +23,6 @@ export default class EnterHandler implements InputHandler {
 
 
   handleEvent(_event: Event) {
-    console.log("enter")
     //TODO (sergey):this is hacky and very quick should be redone
     if(this.rawEditor.canExecuteCommand('insert-newLi')){
       this.rawEditor.executeCommand('insert-newLi');

--- a/addon/model/model-position.ts
+++ b/addon/model/model-position.ts
@@ -67,6 +67,9 @@ export default class ModelPosition {
   }
 
   static fromInElement(element: ModelElement, offset: number) {
+    if(element.type === "br") {
+      return ModelPosition.fromBeforeNode(element);
+    }
     if (offset < 0 || offset > element.getMaxOffset()) {
       throw new PositionError(`Offset ${offset} out of range of element with maxOffset ${element.getMaxOffset()}`);
     }

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -22,7 +22,7 @@ export default class Model {
    * so we trick typescript into assuming it is never null
    * @private
    */
-  private _rootModelNode!: ModelElement;
+  protected _rootModelNode!: ModelElement;
   private reader: HtmlReader;
   private writer: HtmlWriter;
   private nodeMap: WeakMap<Node, ModelNode>;

--- a/addon/model/operations/insert-operation.ts
+++ b/addon/model/operations/insert-operation.ts
@@ -22,9 +22,14 @@ export default class InsertOperation extends Operation {
   }
 
   execute(): ModelRange {
+    if(!this.nodes.length) {
+      return this.range;
+    }
     OperationAlgorithms.insert(this.range, ...this.nodes);
     if(this.range.collapsed) {
-      return this.range;
+      const last = this.nodes[this.nodes.length - 1];
+      const pos = ModelPosition.fromAfterNode(last);
+      return new ModelRange(pos, pos);
     }
     const first = this.nodes[0];
     const last = this.nodes[this.nodes.length - 1];

--- a/addon/model/readers/selection-reader.ts
+++ b/addon/model/readers/selection-reader.ts
@@ -17,7 +17,6 @@ export default class SelectionReader implements Reader<Selection, ModelSelection
   }
 
   read(from: Selection): ModelSelection {
-    console.log("READING SELECTION");
     const ranges = [];
 
     const rslt = new ModelSelection(this.model);
@@ -126,7 +125,6 @@ export default class SelectionReader implements Reader<Selection, ModelSelection
     if (!resultingNode) {
       throw new NotImplementedError();
     }
-    console.log("RESULT", resultingNode);
     const modelNode = this.model.getModelNodeFor(resultingNode) as ModelText;
     return ModelPosition.fromInTextNode(modelNode, modelNode.length);
 

--- a/addon/model/readers/selection-reader.ts
+++ b/addon/model/readers/selection-reader.ts
@@ -75,12 +75,8 @@ export default class SelectionReader implements Reader<Selection, ModelSelection
       return this.findPositionForTextPopertyNode(container, domOffset);
     } else if (isElement(container)) {
       const modelContainer = this.model.getModelNodeFor(container) as ModelElement;
-      const basePath = modelContainer.getOffsetPath();
-
       const finalOffset = modelContainer.indexToOffset(domOffset);
-      basePath.push(finalOffset);
-      rslt = ModelPosition.fromPath(modelContainer.root, basePath);
-
+      rslt = ModelPosition.fromInElement(modelContainer, finalOffset);
 
     } else if (isTextNode(container)) {
       const modelTextNode = this.model.getModelNodeFor(container) as ModelText;

--- a/addon/model/readers/selection-reader.ts
+++ b/addon/model/readers/selection-reader.ts
@@ -17,6 +17,7 @@ export default class SelectionReader implements Reader<Selection, ModelSelection
   }
 
   read(from: Selection): ModelSelection {
+    console.log("READING SELECTION");
     const ranges = [];
 
     const rslt = new ModelSelection(this.model);

--- a/addon/model/readers/xml-element-reader.ts
+++ b/addon/model/readers/xml-element-reader.ts
@@ -4,12 +4,19 @@ import XmlNodeReader from "@lblod/ember-rdfa-editor/model/readers/xml-node-reade
 import {XmlNodeRegistry} from "@lblod/ember-rdfa-editor/model/readers/xml-reader";
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
 
-export default class XmlElementReader implements Reader<Element, ModelElement> {
+export default class XmlElementReader implements Reader<Element, ModelElement, void> {
   constructor(private elementRegistry: XmlNodeRegistry<ModelElement>, private textRegistry: XmlNodeRegistry<ModelText>) {
   }
 
   read(from: Element): ModelElement {
-    const rslt = new ModelElement(from.tagName as keyof HTMLElementTagNameMap);
+    let rslt;
+    if(from.tagName === "modelRoot") {
+      rslt = new ModelElement("div");
+      rslt.setAttribute("contenteditable", "");
+      rslt.setAttribute("class", "say-editor_inner say_content");
+    } else {
+      rslt = new ModelElement(from.tagName as keyof HTMLElementTagNameMap);
+    }
     const nodeReader = new XmlNodeReader(this.elementRegistry, this.textRegistry);
     for (const attribute of from.attributes) {
       if (attribute.name === "__id") {

--- a/addon/model/util/array-utils.ts
+++ b/addon/model/util/array-utils.ts
@@ -17,4 +17,22 @@ export default class ArrayUtils {
 
   }
 
+  /**
+   * indexOf for iterable things that don't have it for some reason
+   * (looking at you element.childNodes...)
+   * @param item
+   * @param iter
+   */
+  static indexOf<I, T extends Iterable<I>>(item: I, iter: T): number | null {
+    let counter = 0;
+    for(const it of iter) {
+      if(item === it) {
+        return counter;
+      }
+      counter++;
+    }
+    return null;
+
+  }
+
 }

--- a/addon/model/util/xml-utils.ts
+++ b/addon/model/util/xml-utils.ts
@@ -49,7 +49,7 @@ export function dom(strings: TemplateStringsArray, ...expressions: any[]) {
  * @param strings
  * @param expressions
  */
-export function domStripped(strings: TemplateStringsArray, ...expressions: any[]) {
+export function domStripped(strings: TemplateStringsArray, ...expressions: any[]): HTMLDocument {
   const htmlStr = oneLineTrim(strings, ...expressions);
   return parseHtml(htmlStr);
 }

--- a/addon/model/writers/selection-writer.ts
+++ b/addon/model/writers/selection-writer.ts
@@ -4,6 +4,9 @@ import {getWindowSelection} from "@lblod/ember-rdfa-editor/utils/dom-helpers";
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
 import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
+import {ModelError} from "@lblod/ember-rdfa-editor/utils/errors";
+import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
+import ArrayUtils from "@lblod/ember-rdfa-editor/model/util/array-utils";
 
 /**
  * Writer to convert a {@link ModelSelection} to a {@link Selection}
@@ -31,6 +34,7 @@ export default class SelectionWriter implements Writer<ModelSelection, void> {
     rslt.setStart(startPos.anchor, startPos.offset);
     rslt.setEnd(endPos.anchor, endPos.offset);
 
+    console.log("WRITING RANGE", rslt);
     return rslt;
   }
 
@@ -41,16 +45,25 @@ export default class SelectionWriter implements Writer<ModelSelection, void> {
    */
   writeDomPosition(position: ModelPosition): { anchor: Node, offset: number } {
 
-    let modelAnchor = position.parent.childAtOffset(position.parentOffset);
-    if(!modelAnchor) {
-      // position is after last child
-      modelAnchor = position.parent;
-      const resultOffset = modelAnchor.length;
-      return {anchor: modelAnchor.boundNode!, offset: resultOffset};
-
+    const nodeAfter = position.nodeAfter();
+    const nodeBefore = position.nodeBefore();
+    if (!nodeAfter) {
+      return {anchor: position.parent.boundNode!, offset: position.parent.boundNode!.childNodes.length};
     }
-    const resultOffset = position.parentOffset - modelAnchor.getOffset();
-    return {anchor: modelAnchor.boundNode!, offset: resultOffset};
+    if (ModelElement.isModelText(nodeAfter)) {
+      return {anchor: nodeAfter.boundNode!, offset: position.parentOffset - nodeAfter.getOffset()};
+
+    } else if (ModelElement.isModelText(nodeBefore)) {
+      // we prefer textnode anchors, so we look both ways
+      return {anchor: nodeBefore.boundNode!, offset: position.parentOffset - nodeBefore.getOffset()}
+
+    } else if (ModelElement.isModelElement(nodeAfter)) {
+      const domAnchor = position.parent.boundNode!;
+      const domIndex = ArrayUtils.indexOf(nodeAfter.boundNode!, (domAnchor as HTMLElement).childNodes)!;
+      return {anchor: position.parent.boundNode!, offset: domIndex};
+    } else {
+      throw new ModelError("Unsupported nodetype");
+    }
 
   }
 

--- a/addon/model/writers/selection-writer.ts
+++ b/addon/model/writers/selection-writer.ts
@@ -34,7 +34,6 @@ export default class SelectionWriter implements Writer<ModelSelection, void> {
     rslt.setStart(startPos.anchor, startPos.offset);
     rslt.setEnd(endPos.anchor, endPos.offset);
 
-    console.log("WRITING RANGE", rslt);
     return rslt;
   }
 

--- a/addon/model/writers/selection-writer.ts
+++ b/addon/model/writers/selection-writer.ts
@@ -3,6 +3,7 @@ import ModelSelection from "@lblod/ember-rdfa-editor/model/model-selection";
 import {getWindowSelection} from "@lblod/ember-rdfa-editor/utils/dom-helpers";
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
+import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
 
 /**
  * Writer to convert a {@link ModelSelection} to a {@link Selection}
@@ -41,6 +42,10 @@ export default class SelectionWriter implements Writer<ModelSelection, void> {
   writeDomPosition(position: ModelPosition): { anchor: Node, offset: number } {
 
     let modelAnchor = position.parent.childAtOffset(position.parentOffset);
+    if(ModelNode.isModelElement(modelAnchor) && modelAnchor.type === "br") {
+      console.log(position);
+
+    }
     if(!modelAnchor) {
       // position is after last child
       modelAnchor = position.parent;

--- a/addon/model/writers/selection-writer.ts
+++ b/addon/model/writers/selection-writer.ts
@@ -42,10 +42,6 @@ export default class SelectionWriter implements Writer<ModelSelection, void> {
   writeDomPosition(position: ModelPosition): { anchor: Node, offset: number } {
 
     let modelAnchor = position.parent.childAtOffset(position.parentOffset);
-    if(ModelNode.isModelElement(modelAnchor) && modelAnchor.type === "br") {
-      console.log(position);
-
-    }
     if(!modelAnchor) {
       // position is after last child
       modelAnchor = position.parent;

--- a/tests/unit/commands/insert-new-line-test.ts
+++ b/tests/unit/commands/insert-new-line-test.ts
@@ -83,6 +83,8 @@ module("Unit | commands | insert-new-line-test", hooks => {
       </modelRoot>
     `;
     ctx.model.fillRoot(initial);
+    ctx.model.disableSelectionWriting();
+    console.log(ctx.model.toXml());
     const range = ModelRange.fromInTextNode(rangeMarker, rangeMarker.length, rangeMarker.length);
     command.execute(range);
 

--- a/tests/unit/commands/insert-new-line-test.ts
+++ b/tests/unit/commands/insert-new-line-test.ts
@@ -1,0 +1,94 @@
+import {module, test} from "qunit";
+import {vdom} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
+import {INVISIBLE_SPACE} from "@lblod/ember-rdfa-editor/model/util/constants";
+import ModelTestContext from "dummy/tests/utilities/model-test-context";
+import InsertNewLineCommand from "@lblod/ember-rdfa-editor/commands/insert-newLine-command";
+import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
+import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
+
+module("Unit | commands | insert-new-line-test", hooks => {
+  const ctx = new ModelTestContext();
+  let command: InsertNewLineCommand;
+  hooks.beforeEach(() => {
+    ctx.reset();
+    command = new InsertNewLineCommand(ctx.model);
+  });
+  test("inserts a new line before a table", assert => {
+
+    // language=XML
+    const {root: initial, textNodes:{rangeMarker}} = vdom`
+      <modelRoot>
+        <text>
+        </text>
+        <text __id="rangeMarker">Before the table${INVISIBLE_SPACE}</text>
+        <table class="say-table">
+          <thead>
+            <tr>
+              <th>
+                <text>h1${INVISIBLE_SPACE}</text>
+              </th>
+              <th>
+                <text>h2${INVISIBLE_SPACE}</text>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <text>c1${INVISIBLE_SPACE}</text>
+              </td>
+              <td>
+                <text>c2${INVISIBLE_SPACE}</text>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <text>${INVISIBLE_SPACE}After the table
+        </text>
+      </modelRoot>
+    `;
+
+
+    // language=XML
+    const {root: expected} = vdom`
+      <modelRoot>
+        <text>
+        </text>
+        <text>Before the table${INVISIBLE_SPACE}</text>
+        <br />
+        <table class="say-table">
+          <thead>
+            <tr>
+              <th>
+                <text>h1${INVISIBLE_SPACE}</text>
+              </th>
+              <th>
+                <text>h2${INVISIBLE_SPACE}</text>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <text>c1${INVISIBLE_SPACE}</text>
+              </td>
+              <td>
+                <text>c2${INVISIBLE_SPACE}</text>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <text>${INVISIBLE_SPACE}After the table
+        </text>
+      </modelRoot>
+    `;
+    ctx.model.fillRoot(initial);
+    const range = ModelRange.fromInTextNode(rangeMarker, rangeMarker.length, rangeMarker.length);
+    command.execute(range);
+
+    assert.true(ctx.model.rootModelNode.sameAs(expected));
+    assert.deepEqual(ctx.modelSelection.lastRange?.start.path.length, range.start.path.length);
+    assert.deepEqual(ctx.modelSelection.lastRange?.start.parentOffset, range.start.parentOffset + 1);
+
+  });
+});

--- a/tests/unit/model/readers/xml-reader-test.ts
+++ b/tests/unit/model/readers/xml-reader-test.ts
@@ -1,9 +1,21 @@
 import {module, test} from "qunit";
-import {parseXml} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
+import {parseXml, vdom} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
+import ModelTestContext from "dummy/tests/utilities/model-test-context";
 
 module("Unit | model | readers | xml-reader-test", () => {
-  test("test xml", assert => {
+
+  test("rootNode gets read as a modelrootnode", assert => {
+    const context = new ModelTestContext();
+    context.reset();
+
     // language=XML
+    const {root} = vdom`<modelRoot />`;
+    console.log(root.toXml());
+    console.log(context.model.rootModelNode.toXml());
+    assert.true(root.sameAs(context.model.rootModelNode));
+
+  });
+  test("test xml", assert => {
     const xml = `
       <div>
         this text will be ignored because it's not inside a text node

--- a/tests/utilities/model-test-context.ts
+++ b/tests/utilities/model-test-context.ts
@@ -1,17 +1,19 @@
 import Model from "@lblod/ember-rdfa-editor/model/model";
 import ModelSelection from "@lblod/ember-rdfa-editor/model/model-selection";
-import {getWindowSelection} from "@lblod/ember-rdfa-editor/utils/dom-helpers";
+import TestModel from "dummy/tests/utilities/test-model";
 
 export default class ModelTestContext {
 
   rootNode!: HTMLElement;
-  model!: Model;
+  model!: TestModel;
   modelSelection!: ModelSelection;
   domSelection!: Selection;
 
   reset() {
     this.rootNode = document.createElement("div");
-    this.model = new Model(this.rootNode);
+    this.rootNode.setAttribute("contenteditable", "");
+    this.rootNode.setAttribute("class", "say-editor_inner say_content");
+    this.model = new TestModel(this.rootNode);
     this.model.read(false);
     this.modelSelection = this.model.selection;
 

--- a/tests/utilities/test-model.ts
+++ b/tests/utilities/test-model.ts
@@ -1,0 +1,15 @@
+import Model from "@lblod/ember-rdfa-editor/model/model";
+import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
+import {ModelError} from "@lblod/ember-rdfa-editor/utils/errors";
+
+export default class TestModel extends Model{
+  fillRoot(node: ModelNode) {
+    if(ModelNode.isModelElement(node)) {
+      this._rootModelNode.children = node.children;
+    } else if (ModelNode.isModelText(node)) {
+      this.rootModelNode.addChild(node);
+    } else {
+      throw new ModelError("Non-element, non-text nodes not supported here");
+    }
+  }
+}

--- a/tests/utilities/test-model.ts
+++ b/tests/utilities/test-model.ts
@@ -3,6 +3,7 @@ import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
 import {ModelError} from "@lblod/ember-rdfa-editor/utils/errors";
 
 export default class TestModel extends Model{
+  private shouldWriteSelection = true;
   fillRoot(node: ModelNode) {
     if(ModelNode.isModelElement(node)) {
       this._rootModelNode.children = node.children;
@@ -10,6 +11,17 @@ export default class TestModel extends Model{
       this.rootModelNode.addChild(node);
     } else {
       throw new ModelError("Non-element, non-text nodes not supported here");
+    }
+  }
+  disableSelectionWriting() {
+    this.shouldWriteSelection = false;
+  }
+  enableSelectionWriting() {
+    this.shouldWriteSelection = true;
+  }
+  writeSelection() {
+    if(this.shouldWriteSelection) {
+      super.writeSelection();
     }
   }
 }


### PR DESCRIPTION
Fixes a bug where a br could appear inside a br

Was a bit of a fundamental issue with the way we convert dom positions.
Unclear how the dom selection ended up inside the br in the first place, but this can 
be just browser behavior (a position inside a br is perfectly valid in the dom spec) so we need to be able to handle this case anyway.

Update:
it is now clear how the dom selection ended up there: the selectionWriter was just plain wrong. Kind of amazing that we didn't notice before
Could possibly have been the cause for many other headaches weve head.

The new algorithm seems a lot more sound. It hinges on the fact that a position in front of an element is visually identical to a position _inside_ that element at (dom) offfset 0