### PR TITLE
Bugfix/collapse selection

### DIFF
--- a/addon/commands/insert-newLi-command.ts
+++ b/addon/commands/insert-newLi-command.ts
@@ -141,7 +141,7 @@ export default class InsertNewLiCommand extends Command {
         }
       }
       firstParentLi.parent!.addChild(newLi, firstParentLi.index! + 1);
-      this.model.selection.collapseOn(newText, 0);
+      this.model.selection.collapseIn(newText, 0);
 
     }
     this.model.write();
@@ -177,7 +177,7 @@ export default class InsertNewLiCommand extends Command {
     //remove left siblings
     sibling = leftSideSecondLi;
     this.deleteLeft(sibling);
-    this.model.selection.collapseOn(rightSideSecondLi, 0);
+    this.model.selection.collapseIn(rightSideSecondLi, 0);
   }
 
   private deleteLeft(node: ModelNode): void {

--- a/addon/commands/remove-table-column-command.ts
+++ b/addon/commands/remove-table-column-command.ts
@@ -46,7 +46,7 @@ export default class RemoveTableColumnCommand extends Command {
     }
     const cellToSelect = table.getCell(cellXToSelect, position.y);
     if(cellToSelect) {
-      selection.collapseOn(cellToSelect);
+      selection.collapseIn(cellToSelect);
     }
     this.model.write();
 

--- a/addon/commands/remove-table-command.ts
+++ b/addon/commands/remove-table-command.ts
@@ -32,9 +32,9 @@ export default class RemoveTableCommand extends Command {
     if(table.parent) {
       const offset = table.parent.getChildIndex(table);
       if(offset) {
-        selection.collapseOn(table.parent, offset);
+        selection.collapseIn(table.parent, offset);
       } else {
-        selection.collapseOn(table.parent);
+        selection.collapseIn(table.parent);
       }
       this.model.write();
     }

--- a/addon/commands/remove-table-row-command.ts
+++ b/addon/commands/remove-table-row-command.ts
@@ -40,14 +40,14 @@ export default class RemoveTableRowCommand extends Command {
     }
 
     const tableDimensions = table.getDimensions();
-    
+
     let cellYToSelect = position.y + 1;
     if(cellYToSelect >= tableDimensions.y) {
       cellYToSelect = position.y -1;
     }
     const cellToSelect = table.getCell(position.x, cellYToSelect);
     if(cellToSelect) {
-      selection.collapseOn(cellToSelect);
+      selection.collapseIn(cellToSelect);
     }
     this.model.write();
 

--- a/addon/model/model-position.ts
+++ b/addon/model/model-position.ts
@@ -28,24 +28,6 @@ export default class ModelPosition {
   }
 
 
-  /**
-   * Build a position from a root, a parent and an offset. Especially useful for converting
-   * from a DOM position
-   * @param root
-   * @param parent
-   * @param offset
-   * @deprecated use {@link fromInTextNode} or {@link fromInElement}
-   */
-  static fromParent(root: ModelElement, parent: ModelNode, offset: number): ModelPosition {
-    if (offset < 0 || offset > parent.length) {
-      throw new SelectionError("offset out of range");
-    }
-    const result = new ModelPosition(root);
-    result.path = parent.getOffsetPath();
-    result.path.push(offset);
-    return result;
-  }
-
   static fromAfterNode(node: ModelNode): ModelPosition {
     const basePath = node.getOffsetPath();
     basePath[basePath.length - 1] += node.offsetSize;

--- a/addon/model/model-position.ts
+++ b/addon/model/model-position.ts
@@ -66,7 +66,7 @@ export default class ModelPosition {
   }
 
   static fromInElement(element: ModelElement, offset: number) {
-    if(element.type === "br") {
+    if (element.type === "br") {
       return ModelPosition.fromBeforeNode(element);
     }
     if (offset < 0 || offset > element.getMaxOffset()) {
@@ -75,6 +75,16 @@ export default class ModelPosition {
     const path = element.getOffsetPath();
     path.push(offset);
     return ModelPosition.fromPath(element.root, path);
+  }
+
+  static fromInNode(node: ModelNode, offset: number) {
+    if (ModelNode.isModelText(node)) {
+      return ModelPosition.fromInTextNode(node, offset);
+    } else if (ModelNode.isModelElement(node)) {
+      return ModelPosition.fromInElement(node, offset);
+    } else {
+      throw new NotImplementedError("Unsupported node type");
+    }
   }
 
   static getCommonPosition(pos1: ModelPosition, pos2: ModelPosition): ModelPosition | null {
@@ -134,7 +144,7 @@ export default class ModelPosition {
     if (this.parentCache) {
       return this.parentCache;
     }
-    if(this.path.length === 0) {
+    if (this.path.length === 0) {
       this.parentCache = this.root;
       return this.root;
     }
@@ -218,12 +228,12 @@ export default class ModelPosition {
       throw new PositionError("cannot compare nodes with different roots");
     }
     const commonPath = ArrayUtils.findCommonSlice(this.path, other.path);
-    if(commonPath.length === 0) {
+    if (commonPath.length === 0) {
       return this.root;
     }
     const temp = ModelPosition.fromPath(this.root, commonPath);
     const rslt = temp.nodeAfter() || temp.nodeBefore();
-    if(!rslt) {
+    if (!rslt) {
       throw new PositionError("Could not find a commonAncestor");
     }
     return rslt as ModelElement;
@@ -265,8 +275,8 @@ export default class ModelPosition {
   split() {
     const before = this.nodeBefore();
     const after = this.nodeAfter();
-    if(ModelNode.isModelText(before)) {
-      if(before === after) {
+    if (ModelNode.isModelText(before)) {
+      if (before === after) {
         before.split(this.parentOffset - before.getOffset());
       }
       this.parentCache = null;

--- a/addon/model/model-position.ts
+++ b/addon/model/model-position.ts
@@ -1,6 +1,6 @@
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
-import {NotImplementedError, PositionError, SelectionError} from "@lblod/ember-rdfa-editor/utils/errors";
+import {NotImplementedError, PositionError} from "@lblod/ember-rdfa-editor/utils/errors";
 import {RelativePosition} from "@lblod/ember-rdfa-editor/model/util/types";
 import ArrayUtils from "@lblod/ember-rdfa-editor/model/util/array-utils";
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
@@ -26,7 +26,6 @@ export default class ModelPosition {
     result.path = path;
     return result;
   }
-
 
   static fromAfterNode(node: ModelNode): ModelPosition {
     const basePath = node.getOffsetPath();
@@ -76,33 +75,6 @@ export default class ModelPosition {
     const commonPath = ArrayUtils.findCommonSlice(pos1.path, pos2.path);
 
     return ModelPosition.fromPath(pos1.root, commonPath);
-  }
-
-  /**
-   * Get a slice of child positions of the commonAncestor between pos1 and pos2
-   * @param pos1
-   * @param pos2
-   * @deprecated use {@link ModelTreeWalker} instead
-   */
-  static getTopPositionsBetween(pos1: ModelPosition, pos2: ModelPosition): ModelPosition[] | null {
-    const commonAncestor = ModelPosition.getCommonPosition(pos1, pos2);
-    if (!commonAncestor) {
-      return null;
-    }
-    const cutoff = commonAncestor.path.length;
-    const root = commonAncestor.root;
-
-    const commonPath = commonAncestor.path;
-    const path1 = pos1.path.slice(0, cutoff + 1);
-    const path2 = pos2.path.slice(0, cutoff + 1);
-
-    const results = [];
-
-    for (let i = path1[path1.length - 1]; i <= path2[path2.length - 1]; i++) {
-      results.push(ModelPosition.fromPath(root, commonPath.concat([i, 0])));
-    }
-    return results;
-
   }
 
   constructor(root: ModelElement) {
@@ -251,8 +223,6 @@ export default class ModelPosition {
    * Split the textnode at the position. If position is not inside a
    * textNode, do nothing.
    * If position is at the end or start of a textnode, do nothing;
-   * If splitting of elements is needed, use
-   * {@link splitParent}.
    */
   split() {
     const before = this.nodeBefore();
@@ -264,14 +234,6 @@ export default class ModelPosition {
       this.parentCache = null;
     }
 
-  }
-
-  /**
-   * Split the parent element at this position
-   * TODO implement this
-   */
-  splitParent() {
-    throw new NotImplementedError();
   }
 
   /**

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -1,10 +1,8 @@
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
 import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
-import ModelNodeFinder from "@lblod/ember-rdfa-editor/model/util/model-node-finder";
-import {Direction, FilterAndPredicate, RelativePosition} from "@lblod/ember-rdfa-editor/model/util/types";
+import {RelativePosition} from "@lblod/ember-rdfa-editor/model/util/types";
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
-import ModelTreeWalker, {ModelNodeFilter} from "@lblod/ember-rdfa-editor/model/util/model-tree-walker";
 import ArrayUtils from "@lblod/ember-rdfa-editor/model/util/array-utils";
 
 /**
@@ -96,57 +94,6 @@ export default class ModelRange {
   getCommonAncestor(): ModelElement {
     return this.start.getCommonAncestor(this.end);
   }
-
-
-  /**
-   * Get all child positions of the commonAncestor that are touched by the selection
-   * @deprecated
-   */
-  getSelectedTopPositions(): ModelPosition[] | null {
-    return ModelPosition.getTopPositionsBetween(this.start, this.end);
-  }
-
-  /**
-   * Get a {@link ModelNodeFinder} which searches for nodes between start and end, or the other way round
-   * @param direction
-   * @param config
-   * @deprecated use {@link ModelTreeWalker} instead
-   */
-  getNodeFinder<T extends ModelNode = ModelNode>(direction: Direction = Direction.FORWARDS, config: FilterAndPredicate<T>): ModelNodeFinder<T> {
-    const {filter, predicate} = config;
-    return new ModelNodeFinder({
-      startNode: this.start.parent,
-      endNode: this.end.parent,
-      rootNode: this.start.root,
-      nodeFilter: filter,
-      predicate,
-      direction
-    });
-
-  }
-
-  /**
-   * Eagerly get all nodes between start and end, filtered by filter
-   * @param config
-   * @deprecated use {@link ModelTreeWalker} instead
-   */
-  getNodes<T extends ModelNode = ModelNode>(config: FilterAndPredicate<T> = {}): T[] {
-    const finder = this.getNodeFinder<T>(Direction.FORWARDS, config);
-    return [...finder];
-  }
-
-  getWalker(filter?: ModelNodeFilter) {
-    return new ModelTreeWalker({range: this, filter});
-  }
-
-  /**
-   * Get all {@link ModelText} nodes between start and end
-   * @deprecated use {@link ModelTreeWalker} instead
-   */
-  getTextNodes(): ModelText[] {
-    return this.getNodes({filter: ModelNode.isModelText});
-  }
-
 
   /**
    * Whether this range is confined, aka it is fully contained within one parentElement

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -51,6 +51,7 @@ export default class ModelRange {
 
 
   }
+
   static fromInElement(element: ModelElement, startOffset: number, endOffset: number) {
     const start = ModelPosition.fromInElement(element, startOffset);
     const end = ModelPosition.fromInElement(element, endOffset);
@@ -60,6 +61,12 @@ export default class ModelRange {
   static fromInTextNode(node: ModelText, startOffset: number, endOffset: number) {
     const start = ModelPosition.fromInTextNode(node, startOffset);
     const end = ModelPosition.fromInTextNode(node, endOffset);
+    return new ModelRange(start, end);
+  }
+
+  static fromInNode(node: ModelNode, startOffset: number, endOffset: number) {
+    const start = ModelPosition.fromInNode(node, startOffset);
+    const end = ModelPosition.fromInNode(node, endOffset);
     return new ModelRange(start, end);
   }
 
@@ -174,7 +181,6 @@ export default class ModelRange {
   }
 
 
-
   /**
    * Return a new range that is expanded to include all children
    * of the commonAncestor that are "touched" by this range
@@ -214,7 +220,7 @@ export default class ModelRange {
     while (startCur.path.length > commonLength + 1) {
       const parent = startCur.parent;
       const range = new ModelRange(startCur, ModelPosition.fromInElement(parent, parent.getMaxOffset()));
-      if(!range.collapsed) {
+      if (!range.collapsed) {
         result.push(range);
       }
       startCur = ModelPosition.fromAfterNode(parent);
@@ -225,7 +231,7 @@ export default class ModelRange {
     while (endCur.path.length > commonLength + 1) {
       const parent = endCur.parent;
       const range = new ModelRange(ModelPosition.fromInElement(parent, 0), endCur);
-      if(!range.collapsed) {
+      if (!range.collapsed) {
         temp.push(range);
       }
       endCur = ModelPosition.fromBeforeNode(parent);

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -5,7 +5,6 @@ import {Direction, FilterAndPredicate, RelativePosition} from "@lblod/ember-rdfa
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import ModelTreeWalker, {ModelNodeFilter} from "@lblod/ember-rdfa-editor/model/util/model-tree-walker";
-import {NotImplementedError} from "@lblod/ember-rdfa-editor/utils/errors";
 import ArrayUtils from "@lblod/ember-rdfa-editor/model/util/array-utils";
 
 /**
@@ -15,10 +14,6 @@ import ArrayUtils from "@lblod/ember-rdfa-editor/model/util/array-utils";
 export default class ModelRange {
   private _start: ModelPosition;
   private _end: ModelPosition;
-
-  static fromParents(root: ModelElement, start: ModelNode, startOffset: number, end: ModelNode, endOffset: number): ModelRange {
-    return new ModelRange(ModelPosition.fromParent(root, start, startOffset), ModelPosition.fromParent(root, end, endOffset));
-  }
 
   static fromPaths(root: ModelElement, path1: number[], path2: number[]) {
     //TODO: should we copy here? or leave it to the caller?
@@ -30,26 +25,6 @@ export default class ModelRange {
     } else {
       return new ModelRange(pos1, pos2);
     }
-  }
-
-  static fromChildren(element: ModelElement) {
-    const basePath = element.getOffsetPath();
-    return ModelRange.fromPaths(element.root, [...basePath, 0], [...basePath, element.getMaxOffset()]);
-  }
-
-  static fromInnerContent(node: ModelNode) {
-    if (ModelNode.isModelElement(node)) {
-      return ModelRange.fromChildren(node);
-    } else if (ModelNode.isModelText(node)) {
-      const basePath = node.getOffsetPath();
-      const endPath = [...basePath];
-      endPath[endPath.length - 1] += node.length;
-      return ModelRange.fromPaths(node.root, basePath, endPath);
-    } else {
-      throw new NotImplementedError("Node type not supported");
-    }
-
-
   }
 
   static fromInElement(element: ModelElement, startOffset: number, endOffset: number) {

--- a/addon/model/model-selection.ts
+++ b/addon/model/model-selection.ts
@@ -378,27 +378,17 @@ export default class ModelSelection {
 
   collapseIn(node: ModelNode, offset = 0) {
     this.clearRanges();
-    this.addRange(Mode)
-    const position = ModelPosition.fromParent(this.model.rootModelNode, node, offset);
-    this.addRange(new ModelRange(position, position));
+    this.addRange(ModelRange.fromInNode(node, offset, offset));
   }
 
   setStartAndEnd(start: ModelNode, startOffset: number, end: ModelNode, endOffset: number) {
-    const range = ModelRange.fromParents(this.model.rootModelNode, start, startOffset, end, endOffset);
+    const startPos = ModelPosition.fromInNode(start, startOffset);
+    const endPos = ModelPosition.fromInNode(end, endOffset);
+    const range = new ModelRange(startPos, endPos);
     this.clearRanges();
     this.addRange(range);
   }
 
-  /**
-   * Select a full ModelText node
-   * @param node
-   */
-  selectNode(node: ModelNode) {
-    this.clearRanges();
-    const start = ModelPosition.fromParent(this.model.rootModelNode, node, 0);
-    const end = ModelPosition.fromParent(this.model.rootModelNode, node, node.length);
-    this.addRange(new ModelRange(start, end));
-  }
 
   calculateRdfaSelection(selection: Selection) {
     if (selection.type === 'Caret') {

--- a/addon/model/model-selection.ts
+++ b/addon/model/model-selection.ts
@@ -376,8 +376,9 @@ export default class ModelSelection {
   }
 
 
-  collapseOn(node: ModelNode, offset = 0) {
+  collapseIn(node: ModelNode, offset = 0) {
     this.clearRanges();
+    this.addRange(Mode)
     const position = ModelPosition.fromParent(this.model.rootModelNode, node, offset);
     this.addRange(new ModelRange(position, position));
   }

--- a/addon/utils/plugins/table/tab-input-plugin.ts
+++ b/addon/utils/plugins/table/tab-input-plugin.ts
@@ -65,7 +65,7 @@ export default class TableTabInputPlugin implements TabInputPlugin {
         };
       } else {
         if(table.nextSibling) {
-          selection.collapseOn(table.nextSibling);
+          selection.collapseIn(table.nextSibling);
           editor.model.write();
         }
         return;
@@ -83,7 +83,7 @@ export default class TableTabInputPlugin implements TabInputPlugin {
         };
       } else {
         if(table.previousSibling) {
-          selection.collapseOn(table.previousSibling);
+          selection.collapseIn(table.previousSibling);
           editor.model.write();
         }
         return;
@@ -93,7 +93,7 @@ export default class TableTabInputPlugin implements TabInputPlugin {
     }
     const newSelectedCell = table?.getCell(newPosition.x, newPosition.y);
     if(!newSelectedCell) return;
-    selection.collapseOn(newSelectedCell);
+    selection.collapseIn(newSelectedCell);
     editor.model.write();
   };
 }

--- a/tests/unit/commands/remove-list-command-test.ts
+++ b/tests/unit/commands/remove-list-command-test.ts
@@ -27,7 +27,7 @@ module("Unit | commands | remove-list-command", hooks => {
     ul.addChild(li);
     li.addChild(content);
 
-    modelSelection.collapseOn(content);
+    modelSelection.collapseIn(content);
     command.execute();
 
     assert.strictEqual(model.rootModelNode.firstChild, content);
@@ -51,7 +51,7 @@ module("Unit | commands | remove-list-command", hooks => {
     ul2.addChild(li2);
     li2.addChild(content);
 
-    modelSelection.collapseOn(content);
+    modelSelection.collapseIn(content);
     command.execute();
 
     assert.strictEqual(model.rootModelNode.firstChild, content);
@@ -90,7 +90,7 @@ module("Unit | commands | remove-list-command", hooks => {
 
     li2.addChild(content2);
 
-    modelSelection.collapseOn(content10);
+    modelSelection.collapseIn(content10);
     command.execute();
 
     assert.strictEqual(model.rootModelNode.length, 3);
@@ -170,7 +170,7 @@ module("Unit | commands | remove-list-command", hooks => {
                 li7
     */
 
-    modelSelection.collapseOn(content1);
+    modelSelection.collapseIn(content1);
     command.execute();
 
     assert.strictEqual(model.rootModelNode.children[0], ul);

--- a/tests/unit/commands/unindent-list-command-test.ts
+++ b/tests/unit/commands/unindent-list-command-test.ts
@@ -60,7 +60,7 @@ module("Unit | commands | unindent-list-command-test", hooks => {
 
     li12.addChild(ul21, 1);
 
-    modelSelection.collapseOn(content21, 2);
+    modelSelection.collapseIn(content21, 2);
 
     command.execute();
 

--- a/tests/unit/model-selection-test.ts
+++ b/tests/unit/model-selection-test.ts
@@ -21,7 +21,7 @@ module("Unit | model | model-selection", hooks => {
     const content = new ModelText("test");
     model.rootModelNode.addChild(p);
     p.addChild(content);
-    modelSelection.collapseOn(content);
+    modelSelection.collapseIn(content);
     assert.true(modelSelection.isCollapsed);
     assert.true(modelSelection.focus?.sameAs(ModelPosition.fromParent(model.rootModelNode, content, 0)));
 

--- a/tests/unit/model-selection-test.ts
+++ b/tests/unit/model-selection-test.ts
@@ -23,7 +23,7 @@ module("Unit | model | model-selection", hooks => {
     p.addChild(content);
     modelSelection.collapseIn(content);
     assert.true(modelSelection.isCollapsed);
-    assert.true(modelSelection.focus?.sameAs(ModelPosition.fromParent(model.rootModelNode, content, 0)));
+    assert.true(modelSelection.focus?.sameAs(ModelPosition.fromInNode(content, 0)));
 
   });
 


### PR DESCRIPTION
Long overdue

Clears out some deprecated and unused selection/range/position methods and fixes the ones that were broken.
No more "ah yeah but you shouldn't use this method anymore" from me :see_no_evil: 

Most notably renames the selection.collapseOn method to collapseIn, it makes it more obvious what it does and reflects the names of the methods it delegates to.