### PR TITLE
Bugfix/insert list

### DIFF
--- a/addon/commands/insert-newLi-command.ts
+++ b/addon/commands/insert-newLi-command.ts
@@ -7,8 +7,8 @@ import ModelElement from "../model/model-element";
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
 import ModelTreeWalker from "@lblod/ember-rdfa-editor/model/util/model-tree-walker";
-import { PropertyState } from "@lblod/ember-rdfa-editor/model/util/types";
 import { INVISIBLE_SPACE } from "@lblod/ember-rdfa-editor/model/util/constants";
+import {elementHasType} from "@lblod/ember-rdfa-editor/model/util/predicate-utils";
 
 export default class InsertNewLiCommand extends Command {
   name = "insert-newLi";
@@ -18,11 +18,10 @@ export default class InsertNewLiCommand extends Command {
   }
 
   canExecute(selection: ModelSelection = this.model.selection): boolean {
-    if (selection.isInside(["ul", "ol"]) === PropertyState.enabled) {
-      return true;
-    } else {
+    if(!selection.lastRange) {
       return false;
     }
+    return selection.lastRange.hasCommonAncestorWhere(elementHasType("ul", "ol"));
   }
   execute(): void {
     const selection = this.model.selection;

--- a/addon/model/model-position.ts
+++ b/addon/model/model-position.ts
@@ -1,6 +1,6 @@
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
-import {ModelError, NotImplementedError, PositionError} from "@lblod/ember-rdfa-editor/utils/errors";
+import {NotImplementedError, PositionError} from "@lblod/ember-rdfa-editor/utils/errors";
 import {RelativePosition} from "@lblod/ember-rdfa-editor/model/util/types";
 import ArrayUtils from "@lblod/ember-rdfa-editor/model/util/array-utils";
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
@@ -197,7 +197,6 @@ export default class ModelPosition {
       throw new PositionError("cannot compare nodes with different roots");
     }
 
-    debugger;
     const leftLength = this.path.length;
     const rightLength = other.path.length;
     const lengthDiff = leftLength - rightLength;

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -111,7 +111,6 @@ export default class ModelRange {
   * findCommonAncestorsWhere(predicate: Predicate<ModelElement>): Generator<ModelElement, void, void> {
     let commonAncestor: ModelElement | null = this.getCommonAncestor();
     while (commonAncestor) {
-      console.log(commonAncestor.toXml());
       if (predicate(commonAncestor)) {
         yield commonAncestor;
       }

--- a/addon/model/model-selection.ts
+++ b/addon/model/model-selection.ts
@@ -8,9 +8,9 @@ import ModelNodeFinder from "@lblod/ember-rdfa-editor/model/util/model-node-find
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
 import {Direction, FilterAndPredicate, PropertyState,} from "@lblod/ember-rdfa-editor/model/util/types";
-import {listTypes} from "@lblod/ember-rdfa-editor/model/util/constants";
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import ModelTreeWalker, {FilterResult} from "@lblod/ember-rdfa-editor/model/util/model-tree-walker";
+import {nodeIsElementOfType} from "@lblod/ember-rdfa-editor/model/util/predicate-utils";
 
 /**
  * Utility interface describing a selection with an non-null anchor and focus
@@ -262,30 +262,25 @@ export default class ModelSelection {
   }
 
   get inListState(): PropertyState {
-    const config = {
-      filter: ModelNode.isModelElement,
-      predicate: (node: ModelElement) => listTypes.has(node.type),
-    };
-    let result = !!this.findFirstInSelection(config);
-    if (!result) {
-      result = !!this.getCommonAncestor()?.parent.findAncestor(node => ModelNode.isModelElement(node) && listTypes.has(node.type));
+    if (ModelSelection.isWellBehaved(this)) {
+      const range = this.lastRange;
+      const predicate = nodeIsElementOfType("li", "ul", "ol");
+      const result = range.containsNodeWhere(predicate) || range.hasCommonAncestorWhere(predicate);
+      return result ? PropertyState.enabled : PropertyState.disabled;
+    } else {
+      return PropertyState.unknown;
     }
-
-    return result ? PropertyState.enabled : PropertyState.disabled;
-
   }
 
   get inTableState(): PropertyState {
-    const config = {
-      filter: ModelNode.isModelElement,
-      predicate: (node: ModelElement) => node.type === 'table',
-    };
-    let result = !!this.findFirstInSelection(config);
-    if(!result) {
-      result = !!this.getCommonAncestor()?.parent.findAncestor(node => ModelNode.isModelElement(node) && node.type === 'table');
+    if (ModelSelection.isWellBehaved(this)) {
+      const range = this.lastRange;
+      const predicate = nodeIsElementOfType("table");
+      const result = range.containsNodeWhere(predicate) || range.hasCommonAncestorWhere(predicate);
+      return result ? PropertyState.enabled : PropertyState.disabled;
+    } else {
+      return PropertyState.unknown;
     }
-
-    return result ? PropertyState.enabled : PropertyState.disabled;
 
   }
 

--- a/addon/model/model-selection.ts
+++ b/addon/model/model-selection.ts
@@ -8,7 +8,6 @@ import ModelNodeFinder from "@lblod/ember-rdfa-editor/model/util/model-node-find
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
 import {Direction, FilterAndPredicate, PropertyState,} from "@lblod/ember-rdfa-editor/model/util/types";
-import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import ModelTreeWalker, {FilterResult} from "@lblod/ember-rdfa-editor/model/util/model-tree-walker";
 import {nodeIsElementOfType} from "@lblod/ember-rdfa-editor/model/util/predicate-utils";
 

--- a/addon/model/model-selection.ts
+++ b/addon/model/model-selection.ts
@@ -289,51 +289,6 @@ export default class ModelSelection {
 
   }
 
-  isInside(types: string[]): PropertyState{
-    //1. get all selected nodes
-    if (ModelSelection.isWellBehaved(this)) {
-      const range = this.lastRange;
-      const treeWalker = new ModelTreeWalker({
-        range: range,
-      });
-      const resultArr = Array.from(treeWalker);
-      if(resultArr.length){
-        let prevType;
-        //2. check if every node has the same parent type
-        for(let i=0; i<resultArr.length; i++){
-          const node=resultArr[i];
-          const type=node.findAncestor(node => ModelNode.isModelElement(node) && types.includes(node.type));
-          //3. else return false
-          if(!type){
-            return PropertyState.disabled;
-          }
-          else if(i>0 && type!=prevType){
-            return PropertyState.disabled;
-          }
-          else{
-            prevType=type;
-          }
-        }
-        return PropertyState.enabled;
-      }
-    }
-    return PropertyState.disabled;
-  }
-  contains(types:string[]): PropertyState{
-    if (ModelSelection.isWellBehaved(this)) {
-      const range = this.lastRange;
-      const treeWalker = new ModelTreeWalker({
-        range: range,
-        filter: node => ModelNode.isModelElement(node) && types.includes(node.type)  ? FilterResult.FILTER_ACCEPT : FilterResult.FILTER_SKIP
-      });
-      const result = Array.from(treeWalker);
-      if(result.length){
-        return PropertyState.enabled;
-      }
-    }
-
-    return PropertyState.disabled;
-  }
   get rdfaSelection() {
     if (!this.domSelection) return;
     return this.calculateRdfaSelection(this.domSelection);

--- a/addon/model/model-selection.ts
+++ b/addon/model/model-selection.ts
@@ -227,39 +227,6 @@ export default class ModelSelection {
     }
   }
 
-  /**
-   * @param config
-   * @deprecated use {@link ModelTreeWalker} instead
-   */
-  findAllInSelectionOrAncestors<T extends ModelNode = ModelNode>(config: FilterAndPredicate<T>) {
-    const noop = () => true;
-    const filter = config.filter || noop;
-    const predicate = config.predicate || noop;
-
-    const iter = this.findAllInSelection(config);
-    let result = iter && [...iter];
-    if (!result || result.length === 0) {
-      const secondTry = this.getCommonAncestor()?.parent.findAncestor(node => filter(node) && predicate(node));
-      if (secondTry) {
-        result = [secondTry as T];
-      }
-    }
-    return result;
-  }
-
-  /**
-   * @param config
-   * @deprecated use {@link ModelTreeWalker} instead
-   */
-  findFirstInSelection<T extends ModelNode = ModelNode>(config: FilterAndPredicate<T>): T | null {
-    const iterator = this.findAllInSelection<T>(config);
-    if (!iterator) {
-      return null;
-    }
-    return iterator[Symbol.iterator]().next().value as T | null;
-
-  }
-
   get inListState(): PropertyState {
     if (ModelSelection.isWellBehaved(this)) {
       const range = this.lastRange;

--- a/addon/model/util/predicate-utils.ts
+++ b/addon/model/util/predicate-utils.ts
@@ -1,4 +1,6 @@
 import ModelElement, {ElementType} from "@lblod/ember-rdfa-editor/model/model-element";
+import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
+
 export type Predicate<T> = (item: T) => boolean;
 
 /**
@@ -12,6 +14,16 @@ export const elementHasType = (...types: ElementType[]): Predicate<ModelElement>
   if (types.length) {
     const typeSet = new Set(types);
     predicate = (elem: ModelElement) => typeSet.has(elem.type);
+  } else {
+    predicate = () => true;
+  }
+  return predicate;
+};
+export const nodeIsElementOfType = (...types: ElementType[]): Predicate<ModelNode> => {
+  let predicate;
+  if (types.length) {
+    const typeSet = new Set(types);
+    predicate = (node: ModelNode) => ModelNode.isModelElement(node) && typeSet.has(node.type);
   } else {
     predicate = () => true;
   }

--- a/tests/unit/model-selection-test.ts
+++ b/tests/unit/model-selection-test.ts
@@ -5,9 +5,6 @@ import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
 import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
 import {AssertionError} from "@lblod/ember-rdfa-editor/utils/errors";
-import {vdom} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
-import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
-import {INVISIBLE_SPACE} from "@lblod/ember-rdfa-editor/model/util/constants";
 
 module("Unit | model | model-selection", hooks => {
   const ctx = new ModelTestContext();
@@ -75,88 +72,6 @@ module("Unit | model | model-selection", hooks => {
     assert.strictEqual(result[2], li011);
     assert.strictEqual(result[3], li012);
 
-  });
-  test("collapsed selection inside an element", assert => {
-    // language=XML
-    const {root: initial, elements: {testLi}} = vdom`
-      <div>
-        <ul>
-          <li __id="testLi">
-            <text>${INVISIBLE_SPACE}</text>
-          </li>
-        </ul>
-      </div>
-    `;
-
-    ctx.model.rootModelNode.addChild(initial);
-    ctx.modelSelection.clearRanges();
-    ctx.modelSelection.selectRange(ModelRange.fromInElement(testLi, 0, 0));
-
-    assert.true(ctx.modelSelection.isInside(["li"])==="enabled");
-  });
-  test("collapsed selection does not contain an element", assert => {
-    // language=XML
-    const {root: initial, elements: {testLi}} = vdom`
-      <div>
-        <ul>
-          <li __id="testLi">
-            <text>${INVISIBLE_SPACE}</text>
-          </li>
-        </ul>
-      </div>
-    `;
-
-    ctx.model.rootModelNode.addChild(initial);
-    ctx.modelSelection.clearRanges();
-    ctx.modelSelection.selectRange(ModelRange.fromInElement(testLi, 0, 0));
-
-    assert.true(ctx.modelSelection.contains(["li"])==="disabled");
-  });
-  test("expanded selection not inside an element", assert => {
-    // language=XML
-    const {root: initial, textNodes: {testText}, elements: {testLi}} = vdom`
-      <div>
-        <text __id="testText">before li</text>
-        <ul>
-          <li __id="testLi">
-            <text>${INVISIBLE_SPACE}</text>
-          </li>
-        </ul>
-      </div>
-    `;
-
-    // debugger;
-    ctx.model.rootModelNode.addChild(initial);
-    const startPosition = ModelPosition.fromInTextNode(testText, 0);
-    const endPosition = ModelPosition.fromInElement(testLi, 0);
-    const range = new ModelRange(startPosition, endPosition);
-    ctx.modelSelection.clearRanges();
-    ctx.modelSelection.addRange(range);
-
-    assert.true(ctx.modelSelection.isInside(["li"])==="disabled");
-  });
-  test("expanded selection contains an element", assert => {
-    // language=XML
-    const {root: initial, textNodes: {testText}, elements: {testLi}} = vdom`
-      <div>
-        <text __id="testText">before li</text>
-        <ul>
-          <li __id="testLi">
-            <text>${INVISIBLE_SPACE}</text>
-          </li>
-        </ul>
-      </div>
-    `;
-
-    // debugger;
-    ctx.model.rootModelNode.addChild(initial);
-    const startPosition = ModelPosition.fromInTextNode(testText, 0);
-    const endPosition = ModelPosition.fromInElement(testLi, 0);
-    const range = new ModelRange(startPosition, endPosition);
-    ctx.modelSelection.clearRanges();
-    ctx.modelSelection.addRange(range);
-
-    assert.true(ctx.modelSelection.contains(["li"])==="enabled");
   });
 
 });

--- a/tests/unit/model/model-position-test.ts
+++ b/tests/unit/model/model-position-test.ts
@@ -58,7 +58,7 @@ module("Unit | model | model-position", () => {
 
     test("returns correct common ancestor for collapsed range at end", assert => {
       // language=XML
-      const {elements:{common},  textNodes:{rangeStart, rangeEnd}} = vdom`
+      const {elements:{common}} = vdom`
         <modelRoot>
           <div __id="common">
             <text>abcd</text>

--- a/tests/unit/model/model-position-test.ts
+++ b/tests/unit/model/model-position-test.ts
@@ -38,6 +38,41 @@ module("Unit | model | model-position", () => {
       assert.strictEqual(p1.getCommonAncestor(p2), common);
     });
 
+    test("returns correct common ancestor 2", assert => {
+      // language=XML
+      const {elements:{common},  textNodes:{rangeStart, rangeEnd}} = vdom`
+        <modelRoot>
+          <div __id="common">
+            <text __id="rangeStart">abcd</text>
+            <div>
+              <text __id="rangeEnd">efgh</text>
+            </div>
+          </div>
+        </modelRoot>
+      `;
+
+      const p1 = ModelPosition.fromInTextNode(rangeStart, 2);
+      const p2 = ModelPosition.fromInTextNode(rangeEnd, 2);
+      assert.strictEqual(p1.getCommonAncestor(p2), common);
+    });
+
+    test("returns correct common ancestor for collapsed range at end", assert => {
+      // language=XML
+      const {elements:{common},  textNodes:{rangeStart, rangeEnd}} = vdom`
+        <modelRoot>
+          <div __id="common">
+            <text>abcd</text>
+            <div>
+              <text>efgh</text>
+            </div>
+          </div>
+        </modelRoot>
+      `;
+
+      const p1 = ModelPosition.fromInElement(common, common.getMaxOffset());
+      const p2 = ModelPosition.fromInElement(common, common.getMaxOffset());
+      assert.strictEqual(p1.getCommonAncestor(p2), common);
+    });
   });
   module("Unit | model | model-position | split", () => {
     test("splits text nodes correctly", assert => {

--- a/tests/unit/model/model-range-test.ts
+++ b/tests/unit/model/model-range-test.ts
@@ -5,6 +5,8 @@ import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
 import {parseXml, vdom} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
 import {stackOverFlowOnGetMinimumConfinedRanges} from "dummy/tests/unit/model/testing-vdoms";
+import {INVISIBLE_SPACE} from "@lblod/ember-rdfa-editor/model/util/constants";
+import {elementHasType, nodeIsElementOfType} from "@lblod/ember-rdfa-editor/model/util/predicate-utils";
 
 module("Unit | model | model-range", () => {
 
@@ -262,6 +264,86 @@ module("Unit | model | model-range", () => {
       assert.deepEqual(maximized.start.path, [0, 0]);
       assert.deepEqual(maximized.end.path, [0, 3]);
 
+    });
+
+    module("Unit | model | model-range | findCommonAncestorsWhere", () => {
+
+      test("collapsed selection inside an element", assert => {
+        // language=XML
+        const {elements: {testLi}} = vdom`
+          <div>
+            <ul>
+              <li __id="testLi">
+                <text>${INVISIBLE_SPACE}</text>
+              </li>
+            </ul>
+          </div>
+        `;
+
+        const range = ModelRange.fromInElement(testLi, 0, 0);
+
+        assert.true(range.hasCommonAncestorWhere(elementHasType("li")));
+      });
+
+      test("uncollapsed selection does not have common ancestors of type", assert => {
+        // language=XML
+        const {textNodes: {testText}, elements: {testLi}} = vdom`
+          <div>
+            <text __id="testText">before li</text>
+            <ul>
+              <li __id="testLi">
+                <text>${INVISIBLE_SPACE}</text>
+              </li>
+            </ul>
+          </div>
+        `;
+
+        // debugger;
+        const startPosition = ModelPosition.fromInTextNode(testText, 0);
+        const endPosition = ModelPosition.fromInElement(testLi, 0);
+        const range = new ModelRange(startPosition, endPosition);
+
+        assert.false(range.hasCommonAncestorWhere(elementHasType("li")));
+      });
+    });
+    module("Unit | model | model-range | findContainedNodesWhere", () => {
+      test("collapsed range does not contain an element", assert => {
+        // language=XML
+        const {elements: {testLi}} = vdom`
+          <div>
+            <ul>
+              <li __id="testLi">
+                <text>${INVISIBLE_SPACE}</text>
+              </li>
+            </ul>
+          </div>
+        `;
+
+        const range = ModelRange.fromInElement(testLi, 0, 0);
+
+        assert.false(range.containsNodeWhere(nodeIsElementOfType("li")));
+      });
+
+      test("uncollapsed selection contains an element", assert => {
+        // language=XML
+        const {textNodes: {testText}, elements: {testLi}} = vdom`
+          <div>
+            <text __id="testText">before li</text>
+            <ul>
+              <li __id="testLi">
+                <text>${INVISIBLE_SPACE}</text>
+              </li>
+            </ul>
+          </div>
+        `;
+
+        // debugger;
+        const startPosition = ModelPosition.fromInTextNode(testText, 0);
+        const endPosition = ModelPosition.fromInElement(testLi, 0);
+        const range = new ModelRange(startPosition, endPosition);
+
+        assert.true(range.containsNodeWhere(nodeIsElementOfType("li")));
+      });
     });
 
   });


### PR DESCRIPTION
- reworks and fixes bugs in inLIstState and inTableState methods
- renames and reworks isInside selection method to hasCommonAncestorWhere and moves it to modelrange
- renames and reworks contains selection method to containsNodeWhere and moves it to modelrange
- adds tests for and fixes broken algorithm of getCommonAncestor method
- remove some unused and deprecated selection methods
- fixes selection issues in make-list command

the latter is a hotfix rather than the necessary rework, though I don't think the rework would have solved the issue anyway. The problem is that while the operation and mutator methods do return useful ranges to select, when you run a cleaner after them that sort of ruins the whole affair. 

The current fix leaves you with a predictable albeit maybe slightly unexpected selection (when making a list of the line right after an existing list, you end up with the whole merged list selected)
This also fixes the reported issue in an empty document.