### PR TITLE
Insert text command

### DIFF
--- a/addon/commands/insert-text-command.ts
+++ b/addon/commands/insert-text-command.ts
@@ -1,0 +1,24 @@
+import Command from "@lblod/ember-rdfa-editor/commands/command";
+import Model from "@lblod/ember-rdfa-editor/model/model";
+import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
+import {MisbehavedSelectionError} from "@lblod/ember-rdfa-editor/utils/errors";
+
+export default class InsertTextCommand extends Command {
+  name = "insert-text";
+
+  constructor(model: Model) {
+    super(model);
+  }
+
+  execute(text: string, range: ModelRange | null = this.model.selection.lastRange): void {
+    if (!range) {
+      throw new MisbehavedSelectionError();
+    }
+    this.model.change(mutator => {
+      const resultRange = mutator.insertText(range, text);
+      resultRange.collapse();
+      this.model.selectRange(resultRange);
+    });
+  }
+
+}

--- a/addon/commands/insert-text-command.ts
+++ b/addon/commands/insert-text-command.ts
@@ -16,8 +16,10 @@ export default class InsertTextCommand extends Command {
     }
     this.model.change(mutator => {
       const resultRange = mutator.insertText(range, text);
+      const commonAncestor = resultRange.getCommonAncestor();
       resultRange.collapse();
       this.model.selectRange(resultRange);
+      return commonAncestor;
     });
   }
 

--- a/addon/components/ce/content-editable.js
+++ b/addon/components/ce/content-editable.js
@@ -21,7 +21,7 @@ import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
 import { createElementsFromHTML } from "@lblod/ember-rdfa-editor/utils/dom-helpers";
 import { PropertyState } from "@lblod/ember-rdfa-editor/model/util/types";
-import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
+import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 /**
  * content-editable is the core of {{#crossLinkModule "rdfa-editor"}}rdfa-editor{{/crossLinkModule}}.
  * It provides handlers for input events, a component to display a contenteditable element and an api for interaction with the document and its internal document representation.
@@ -104,7 +104,7 @@ export default class ContentEditable extends Component {
    */
   init() {
     super.init(...arguments);
-    const rawEditor = PernetRawEditor.create({ });
+    const rawEditor = LegacyRawEditor.create({ });
     rawEditor.registerMovementObserver(new LumpNodeMovementObserver());
     this.set('rawEditor', rawEditor);
     const forceParagraph = this.features.isEnabled('editor-force-paragraph');

--- a/addon/components/ce/content-editable.js
+++ b/addon/components/ce/content-editable.js
@@ -19,9 +19,9 @@ import LumpNodeMovementObserver from '../../utils/ce/movement-observers/lump-nod
 import HTMLInputParser from '../../utils/html-input-parser';
 import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 import { createElementsFromHTML } from "@lblod/ember-rdfa-editor/utils/dom-helpers";
 import { PropertyState } from "@lblod/ember-rdfa-editor/model/util/types";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 /**
  * content-editable is the core of {{#crossLinkModule "rdfa-editor"}}rdfa-editor{{/crossLinkModule}}.
  * It provides handlers for input events, a component to display a contenteditable element and an api for interaction with the document and its internal document representation.
@@ -104,7 +104,7 @@ export default class ContentEditable extends Component {
    */
   init() {
     super.init(...arguments);
-    const rawEditor = LegacyRawEditor.create({ });
+    const rawEditor = PernetRawEditor.create({ });
     rawEditor.registerMovementObserver(new LumpNodeMovementObserver());
     this.set('rawEditor', rawEditor);
     const forceParagraph = this.features.isEnabled('editor-force-paragraph');

--- a/addon/components/rdfa/editor-toolbar.ts
+++ b/addon/components/rdfa/editor-toolbar.ts
@@ -1,12 +1,12 @@
 import Component from "@glimmer/component";
 import {action} from "@ember/object";
 import {tracked} from "@glimmer/tracking";
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 import ModelSelection from "@lblod/ember-rdfa-editor/model/model-selection";
 import {PropertyState} from "@lblod/ember-rdfa-editor/model/util/types";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
 interface Args {
-  editor: LegacyRawEditor;
+  editor: PernetRawEditor;
   showTextStyleButtons: boolean;
   showListButtons: boolean;
   showIndentButtons: boolean;

--- a/addon/editor/input-handlers/backspace-handler.ts
+++ b/addon/editor/input-handlers/backspace-handler.ts
@@ -9,7 +9,16 @@ import EmptyElementBackspacePlugin from '@lblod/ember-rdfa-editor/utils/plugins/
 import BrSkippingBackspacePlugin from '@lblod/ember-rdfa-editor/utils/plugins/br-skipping/backspace-plugin';
 import PlaceholderTextBackspacePlugin from '@lblod/ember-rdfa-editor/utils/plugins/placeholder-text/backspace-plugin';
 import TableBackspacePlugin from '@lblod/ember-rdfa-editor/utils/plugins/table/backspace-plugin';
-import {Manipulation, VoidElement} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
+import {
+  KeepCursorAtStartManipulation,
+  Manipulation, MoveCursorBeforeElementManipulation,
+  MoveCursorToEndOfElementManipulation,
+  RemoveCharacterManipulation, RemoveElementWithChildrenThatArentVisible,
+  RemoveEmptyElementManipulation,
+  RemoveEmptyTextNodeManipulation, RemoveOtherNodeManipulation,
+  RemoveVoidElementManipulation,
+  VoidElement
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
 import {HandlerResponse, InputHandler, InputPlugin} from './input-handler';
 import {
   editorDebug,
@@ -159,13 +168,13 @@ type UncommonNode = CDATASection | ProcessingInstruction | Comment | Document | 
  * @param errorMessage [string] The error message to be printed in
  * case this is not an UncommonNode.
  */
-function ensureUncommonNode( node: Node, errorMessage?: string ) : UncommonNode {
-  if( [ Node.CDATA_SECTION_NODE,
-        Node.PROCESSING_INSTRUCTION_NODE,
-        Node.COMMENT_NODE,
-        Node.DOCUMENT_NODE,
-        Node.DOCUMENT_TYPE_NODE,
-        Node.DOCUMENT_FRAGMENT_NODE ].includes( node.nodeType ) ) {
+function ensureUncommonNode(node: Node, errorMessage?: string): UncommonNode {
+  if ([Node.CDATA_SECTION_NODE,
+    Node.PROCESSING_INSTRUCTION_NODE,
+    Node.COMMENT_NODE,
+    Node.DOCUMENT_NODE,
+    Node.DOCUMENT_TYPE_NODE,
+    Node.DOCUMENT_FRAGMENT_NODE].includes(node.nodeType)) {
     return node as UncommonNode;
   } else {
     throw errorMessage || `Received node ${node.toString()} is not an UncommonNode.`;
@@ -183,17 +192,28 @@ interface EditorRootPosition extends BaseThingBeforeCursor {
   node: Element;
 }
 
+export type BackspaceHandlerManipulation =
+  RemoveCharacterManipulation
+  | RemoveEmptyTextNodeManipulation
+  | RemoveVoidElementManipulation
+  | MoveCursorToEndOfElementManipulation
+  | RemoveEmptyElementManipulation
+  | MoveCursorBeforeElementManipulation
+  | RemoveElementWithChildrenThatArentVisible
+  | RemoveOtherNodeManipulation
+  | KeepCursorAtStartManipulation;
+
 /**
  * Interface for specific plugins.
  */
-export interface BackspacePlugin extends InputPlugin{
+export interface BackspacePlugin extends InputPlugin {
   /**
    * Callback to let the plugin indicate whether or not it discovered
    * a change.
    *
    * Hint: return false if you don't detect location updates.
    */
-  detectChange: (manipulation: Manipulation, editor: RawEditor) => boolean;
+  detectChange: (manipulation: BackspaceHandlerManipulation, editor: RawEditor) => boolean;
 }
 
 /**
@@ -289,7 +309,7 @@ export default class BackspaceHandler extends InputHandler {
    * @public
    * @constructor
    */
-  constructor({ rawEditor }: { rawEditor: LegacyRawEditor }){
+  constructor({rawEditor}: { rawEditor: LegacyRawEditor }) {
     super(rawEditor);
     // Order is now the sole parameter for conflict resolution of plugins. Think before changing.
     this.plugins = [
@@ -312,7 +332,7 @@ export default class BackspaceHandler extends InputHandler {
    * @return boolean
    * @public
    */
-  isHandlerFor(event: Event ) {
+  isHandlerFor(event: Event) {
     const selection = window.getSelection();
     return ((event.type === "keydown" && (event as KeyboardEvent).key === 'Backspace')
       || (event.type == "beforeinput" && (event as InputEvent).inputType == "deleteContentsBackwards"))
@@ -325,20 +345,20 @@ export default class BackspaceHandler extends InputHandler {
    * @return {HandlerResponse}
    * @public
    */
-  handleEvent(event : Event) : HandlerResponse {
+  handleEvent(event: Event): HandlerResponse {
     // TODO: reason more about async behaviour of backspace.
     event.preventDefault(); // make sure event propagation is stopped, async behaviour of backspace could cause the browser to execute eventDefault before it is finished
 
-   //TODO: think harder about managability of the lock state, now a bit all over the place
-   if(this.isLocked){
+    //TODO: think harder about managability of the lock state, now a bit all over the place
+    if (this.isLocked) {
       editorDebug(`backspace-handler.handleEvent`, `Handler is busy removing, skipping`);
-      return { allowPropagation: false };
+      return {allowPropagation: false};
     }
 
-    void this.backspace().then( () => {
+    void this.backspace().then(() => {
       this.rawEditor.updateSelectionAfterComplexInput(); // make sure currentSelection of editor is up to date with actual cursor position
     });
-    return { allowPropagation: false };
+    return {allowPropagation: false};
   }
 
   /////////////////
@@ -351,15 +371,15 @@ export default class BackspaceHandler extends InputHandler {
    * @method backspace
    * @private
    */
-  async backspace( max_tries = 50 ) {
+  async backspace(max_tries = 50) {
 
-    if(this.isLocked){
+    if (this.isLocked) {
       editorDebug(`backspace-handler.backspace`, `Handler is busy removing, skipping`);
       return;
     }
 
-    if( max_tries == 0 ) {
-      warn("Too many backspace tries, giving up removing content", { id: "backspace-handler-too-many-tries"});
+    if (max_tries == 0) {
+      warn("Too many backspace tries, giving up removing content", {id: "backspace-handler-too-many-tries"});
       return;
     }
 
@@ -377,38 +397,37 @@ export default class BackspaceHandler extends InputHandler {
       const manipulation = this.getNextManipulation();
 
       // check if we can execute it
-      const { mayExecute, dispatchedExecutor } = this.checkManipulationByPlugins( manipulation );
+      const {mayExecute, dispatchedExecutor} = this.checkManipulationByPlugins(manipulation);
 
       // error if we're not allowed to
-      if ( ! mayExecute ) {
-        warn( "Not allowed to execute manipulation for backspace", { id: "backspace-handler-manipulation-not-allowed" } );
+      if (!mayExecute) {
+        warn("Not allowed to execute manipulation for backspace", {id: "backspace-handler-manipulation-not-allowed"});
         return;
       }
 
       // run the manipulation
-      if( dispatchedExecutor ) {
+      if (dispatchedExecutor) {
         // NOTE: we should pass some sort of editor interface here in the future.
-        dispatchedExecutor( manipulation, this.rawEditor );
+        dispatchedExecutor(manipulation, this.rawEditor);
       } else {
-        this.handleNativeManipulation( manipulation );
+        this.handleNativeManipulation(manipulation);
       }
 
       // ask plugins if something has changed
       await paintCycleHappened();
-      pluginSeesChange = this.runChangeDetectionByPlugins( manipulation );
-    }
-    finally {
+      pluginSeesChange = this.runChangeDetectionByPlugins(manipulation);
+    } finally {
       //make sure always unlocked
       this.isLocked = false;
     }
 
     // maybe iterate again
-    if( pluginSeesChange || this.checkVisibleChange( { previousVisualCursorCoordinates: visualCursorCoordinates } ) ) {
+    if (pluginSeesChange || this.checkVisibleChange({previousVisualCursorCoordinates: visualCursorCoordinates})) {
       // TODO: do we need to make sure cursor state in the editor corresponds with browser state here?
       return;
     } else {
       // debugger;
-      await this.backspace( max_tries -1 );
+      await this.backspace(max_tries - 1);
     }
   }
 
@@ -423,37 +442,35 @@ export default class BackspaceHandler extends InputHandler {
    * @param options.previousVisualCursorCoordinates {Array<DOMRectCoordinatesInEditor>}
    * Coordinates of the rectangles defining the selection.
    */
-  checkVisibleChange( options: {previousVisualCursorCoordinates: Array<DOMRectCoordinatesInEditor> }  ) : boolean {
+  checkVisibleChange(options: { previousVisualCursorCoordinates: Array<DOMRectCoordinatesInEditor> }): boolean {
 
-    const { previousVisualCursorCoordinates } = options;
+    const {previousVisualCursorCoordinates} = options;
 
-    if( ! previousVisualCursorCoordinates.length && ! this.selectionCoordinatesInEditor.length ){
+    if (!previousVisualCursorCoordinates.length && !this.selectionCoordinatesInEditor.length) {
       editorDebug(`backspace-handler.checkVisibleChange`,
-                  `Did not see a visual change when removing character, no visualCoordinates whatsoever`,
-                  { new: this.selectionCoordinatesInEditor, old: previousVisualCursorCoordinates });
+        `Did not see a visual change when removing character, no visualCoordinates whatsoever`,
+        {new: this.selectionCoordinatesInEditor, old: previousVisualCursorCoordinates});
       return false;
-    }
-    else if( ! previousVisualCursorCoordinates.length && this.selectionCoordinatesInEditor.length ){
+    } else if (!previousVisualCursorCoordinates.length && this.selectionCoordinatesInEditor.length) {
       editorDebug(`backspace-handler.checkVisibleChange`, `no previous coordinates`);
       return true;
-    }
-    else if( previousVisualCursorCoordinates.length && ! this.selectionCoordinatesInEditor.length ){
-      editorDebug(`backspace-handler.checkVisibleChange`,'no new coordinates');
+    } else if (previousVisualCursorCoordinates.length && !this.selectionCoordinatesInEditor.length) {
+      editorDebug(`backspace-handler.checkVisibleChange`, 'no new coordinates');
       return true;
     }
     //Previous and current have visual coordinates, we need to compare the contents
     else {
-      const { left: ol, top: ot } = previousVisualCursorCoordinates[0];
+      const {left: ol, top: ot} = previousVisualCursorCoordinates[0];
 
 
-      const { left: nl, top: nt } = this.selectionCoordinatesInEditor[0];
+      const {left: nl, top: nt} = this.selectionCoordinatesInEditor[0];
 
       const visibleChange = ol !== nl || ot !== nt;
 
-      if( !visibleChange ){
+      if (!visibleChange) {
         editorDebug(`backspace-handler.checkVisibleChange`,
-                    `Did not see a visual change when removing character`,
-                    { new: this.selectionCoordinatesInEditor, old: previousVisualCursorCoordinates });
+          `Did not see a visual change when removing character`,
+          {new: this.selectionCoordinatesInEditor, old: previousVisualCursorCoordinates});
       }
 
       return visibleChange;
@@ -474,7 +491,7 @@ export default class BackspaceHandler extends InputHandler {
    * @private
    *
    */
-  get selectionCoordinatesInEditor() : Array<DOMRectCoordinatesInEditor> {
+  get selectionCoordinatesInEditor(): Array<DOMRectCoordinatesInEditor> {
     const editorDomRect = this.rawEditor.rootNode.getBoundingClientRect();
     //Note: we select '0' because we only assume one selection. No multi-cursor
     if (window.getSelection() != null) {
@@ -482,8 +499,8 @@ export default class BackspaceHandler extends InputHandler {
       if (selection.rangeCount > 0) {
         const clientRects = selection.getRangeAt(0).getClientRects();
         const selectionCoordinates = new Array<DOMRectCoordinatesInEditor>();
-        for(const clientRect of Array.from(clientRects)){
-          const normalizedRect = { } as DOMRectCoordinatesInEditor;
+        for (const clientRect of Array.from(clientRects)) {
+          const normalizedRect = {} as DOMRectCoordinatesInEditor;
           normalizedRect.top = clientRect.top - editorDomRect.top;
           normalizedRect.bottom = clientRect.bottom - editorDomRect.bottom;
           normalizedRect.left = clientRect.left - editorDomRect.left;
@@ -507,8 +524,8 @@ export default class BackspaceHandler extends InputHandler {
    * @param {Manipulation} manipulation The manipulation which will be
    * executed on the DOM tree.
    */
-  handleNativeManipulation( manipulation: Manipulation ) {
-    switch( manipulation.type ) {
+  handleNativeManipulation(manipulation: BackspaceHandlerManipulation) {
+    switch (manipulation.type) {
       case "removeCharacter": {
         const {node, position} = manipulation;
         let nodeText = node.textContent || "";
@@ -600,7 +617,7 @@ export default class BackspaceHandler extends InputHandler {
         // do nothing
         break;
       default:
-        throw `Case ${manipulation.type} was not handled by handleNativeInputManipulation.`;
+        throw `Case ${(manipulation as Manipulation).type} was not handled by handleNativeInputManipulation.`;
     }
   }
 
@@ -616,12 +633,11 @@ export default class BackspaceHandler extends InputHandler {
    * @method getNextManipulation
    * @private
    */
-  getNextManipulation() : Manipulation
-  {
+  getNextManipulation(): BackspaceHandlerManipulation {
     // check where our cursor is and get the deepest "thing" before
     // the cursor (character or node)
     const thingBeforeCursor: ThingBeforeCursor = this.getThingBeforeCursor();
-    switch( thingBeforeCursor.type ) {
+    switch (thingBeforeCursor.type) {
 
       case "character": {
         // character: remove the character
@@ -635,7 +651,7 @@ export default class BackspaceHandler extends InputHandler {
 
       case "emptyTextNodeStart": {
         // empty text node: remove the text node
-        const textNodeBeforeCursor = thingBeforeCursor ;
+        const textNodeBeforeCursor = thingBeforeCursor;
         if (stringToVisibleText(textNodeBeforeCursor.node.textContent || "").length === 0) {
           return {
             type: "removeEmptyTextNode",
@@ -648,7 +664,7 @@ export default class BackspaceHandler extends InputHandler {
 
       case "emptyTextNodeEnd": {
         // empty text node: remove the text node
-        const textNodePositionBeforeCursor = thingBeforeCursor ;
+        const textNodePositionBeforeCursor = thingBeforeCursor;
         if (textNodePositionBeforeCursor.node.length === 0) {
           return {
             type: "removeEmptyTextNode",
@@ -660,7 +676,7 @@ export default class BackspaceHandler extends InputHandler {
       }
 
       case "voidElement": {
-        const voidElementBeforeCursor = thingBeforeCursor ;
+        const voidElementBeforeCursor = thingBeforeCursor;
         return {
           type: "removeVoidElement",
           node: voidElementBeforeCursor.node
@@ -668,7 +684,7 @@ export default class BackspaceHandler extends InputHandler {
       }
 
       case "elementEnd": {
-        const elementBeforeCursor = thingBeforeCursor ;
+        const elementBeforeCursor = thingBeforeCursor;
         return {
           type: "moveCursorToEndOfElement",
           node: elementBeforeCursor.node
@@ -676,7 +692,7 @@ export default class BackspaceHandler extends InputHandler {
       }
 
       case "elementStart": {
-        const parentBeforeCursor = thingBeforeCursor ;
+        const parentBeforeCursor = thingBeforeCursor;
         const element = parentBeforeCursor.node;
         if (element.childNodes.length == 0) {
           return {
@@ -699,7 +715,7 @@ export default class BackspaceHandler extends InputHandler {
         }
       }
       case "uncommonNodeEnd": {
-        const positionBeforeCursor = thingBeforeCursor ;
+        const positionBeforeCursor = thingBeforeCursor;
         const node = positionBeforeCursor.node;
         return {
           type: "removeOtherNode",
@@ -787,8 +803,7 @@ export default class BackspaceHandler extends InputHandler {
    * @method getThingBeforeCursor
    * @public
    */
-  getThingBeforeCursor() : ThingBeforeCursor
-  {
+  getThingBeforeCursor(): ThingBeforeCursor {
     // TODO: should we support actual selections here as well or will that be a different handler?
     // current implementation assumes a collapsed selection (e.g. a carret)
     const windowSelection = window.getSelection();
@@ -803,90 +818,75 @@ export default class BackspaceHandler extends InputHandler {
           if (position == 0) {
             if (element == this.rawEditor.rootNode) {
               // special case, we're at the start of the editor
-              return { type: "editorRootStart", node: element };
-            }
-            else {
+              return {type: "editorRootStart", node: element};
+            } else {
               // at the start of the element
-              return { type: "elementStart", node: element };
+              return {type: "elementStart", node: element};
             }
-          }
-          else {
+          } else {
             // position > 1 so there is a child node before our cursor
             // position is the number of child nodes between the start of the startNode and our cursor.
-            const child = element.childNodes[position-1] ;
+            const child = element.childNodes[position - 1];
             if (child.nodeType == Node.TEXT_NODE) {
               const text = child as Text;
-              return { type: "character", position: text.length, node: text};
-            }
-            else if( child.nodeType === Node.ELEMENT_NODE ){
+              return {type: "character", position: text.length, node: text};
+            } else if (child.nodeType === Node.ELEMENT_NODE) {
               const element = child as HTMLElement;
               if (isVoidElement(element)) {
-                return { type: "voidElement", node: element as VoidElement };
+                return {type: "voidElement", node: element as VoidElement};
+              } else {
+                return {type: "elementEnd", node: element};
               }
-              else {
-                return { type: "elementEnd", node: element };
-              }
-            }
-            else {
-              const uncommonNode = ensureUncommonNode( child, "Assumed all node cases exhausted and uncommon node found in backspace handler.  But node is not an uncommon node." );
-              return { type: "uncommonNodeEnd", node: uncommonNode };
+            } else {
+              const uncommonNode = ensureUncommonNode(child, "Assumed all node cases exhausted and uncommon node found in backspace handler.  But node is not an uncommon node.");
+              return {type: "uncommonNodeEnd", node: uncommonNode};
             }
           }
-        }
-        else if (node.nodeType == Node.TEXT_NODE) {
+        } else if (node.nodeType == Node.TEXT_NODE) {
           const text = node as Text;
           // cursor is in a text node
           if (position > 0) {
             // can delete a character
-            return { type: "character", position: position - 1, node: text};
-          }
-          else if (stringToVisibleText(text.textContent || "").length == 0){
+            return {type: "character", position: position - 1, node: text};
+          } else if (stringToVisibleText(text.textContent || "").length == 0) {
             // at the start an empty text node
-            return { type: "emptyTextNodeStart", node: text};
-          }
-          else {
+            return {type: "emptyTextNodeStart", node: text};
+          } else {
             // at the start of a non empty text node
             const previousSibling = text.previousSibling;
-            if( previousSibling ) {
-              if( previousSibling.nodeType === Node.TEXT_NODE ) {
+            if (previousSibling) {
+              if (previousSibling.nodeType === Node.TEXT_NODE) {
                 const sibling = previousSibling as Text;
-                if( sibling.length > 0 ) {
+                if (sibling.length > 0) {
                   // previous is text node with stuff
-                  return { type: "character", position: sibling.length - 1, node: sibling};
+                  return {type: "character", position: sibling.length - 1, node: sibling};
                 } else {
                   // previous is empty text node (only possible in non chrome based browsers)
-                  return { type: "emptyTextNodeEnd", node: sibling};
+                  return {type: "emptyTextNodeEnd", node: sibling};
                 }
-              }
-              else if( previousSibling.nodeType === Node.ELEMENT_NODE ){
+              } else if (previousSibling.nodeType === Node.ELEMENT_NODE) {
                 const sibling = previousSibling as HTMLElement;
                 if (isVoidElement(sibling)) {
-                  return { type: "voidElement", node: sibling as VoidElement };
+                  return {type: "voidElement", node: sibling as VoidElement};
+                } else {
+                  return {type: "elementEnd", node: sibling};
                 }
-                else {
-                  return { type: "elementEnd", node: sibling };
-                }
+              } else {
+                const uncommonNode = ensureUncommonNode(previousSibling, "Assumed all node cases exhausted and uncommon node found in backspace handler.  But node is not an uncommon node.");
+                return {type: "uncommonNodeEnd", node: uncommonNode};
               }
-              else {
-                const uncommonNode = ensureUncommonNode( previousSibling, "Assumed all node cases exhausted and uncommon node found in backspace handler.  But node is not an uncommon node." );
-                return { type: "uncommonNodeEnd", node: uncommonNode };
-              }
-            }
-            else if (text.parentElement) {
+            } else if (text.parentElement) {
               const parent = text.parentElement;
               if (parent != this.rawEditor.rootNode) {
-                return { type: "elementStart", node: parent };
+                return {type: "elementStart", node: parent};
+              } else {
+                return {type: "editorRootStart", node: parent};
               }
-              else {
-                return { type: "editorRootStart", node: parent };
-              }
-            }
-            else {
+            } else {
               throw "no previous sibling or parentnode found";
             }
           }
-        }
-        else {
+        } else {
           console.warn(`did not expect a startcontainer of type ${node.nodeType} from range`); // eslint-disable-line-console
           // there should not be an else per spec
         }
@@ -904,16 +904,21 @@ export default class BackspaceHandler extends InputHandler {
    * @private
    * @method runChangeDetectionByPlugins
    */
-  runChangeDetectionByPlugins( manipulation: Manipulation ): boolean {
+  runChangeDetectionByPlugins(manipulation: BackspaceHandlerManipulation): boolean {
     const reports =
       this
         .plugins
-        .map( (plugin) => { return { plugin, detectedChange: plugin.detectChange( manipulation, this.rawEditor ) }; } )
-        .filter( ({detectedChange}) => detectedChange );
+        .map((plugin) => {
+          return {plugin, detectedChange: plugin.detectChange(manipulation, this.rawEditor)};
+        })
+        .filter(({detectedChange}) => detectedChange);
 
     // debug reporting
-    for( const { plugin } of reports ) {
-      editorDebug(`backspace-handler.runChangeDetectionByPlugins`, `Change detected by plugin ${plugin.label}`, { manipulation, plugin });
+    for (const {plugin} of reports) {
+      editorDebug(`backspace-handler.runChangeDetectionByPlugins`, `Change detected by plugin ${plugin.label}`, {
+        manipulation,
+        plugin
+      });
     }
 
     return reports.length > 0;

--- a/addon/editor/input-handlers/backspace-handler.ts
+++ b/addon/editor/input-handlers/backspace-handler.ts
@@ -29,7 +29,7 @@ import {
   stringToVisibleText
 } from '@lblod/ember-rdfa-editor/editor/utils';
 import RawEditor from "@lblod/ember-rdfa-editor/utils/ce/raw-editor";
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
 /**
  * Represents the coordinates of a DOMRect relative to RootNode of the editor.
@@ -309,7 +309,7 @@ export default class BackspaceHandler extends InputHandler {
    * @public
    * @constructor
    */
-  constructor({rawEditor}: { rawEditor: LegacyRawEditor }) {
+  constructor({rawEditor}: { rawEditor: PernetRawEditor }) {
     super(rawEditor);
     // Order is now the sole parameter for conflict resolution of plugins. Think before changing.
     this.plugins = [

--- a/addon/editor/input-handlers/bold-italic-underline-handler.ts
+++ b/addon/editor/input-handlers/bold-italic-underline-handler.ts
@@ -1,7 +1,7 @@
-import { InputHandler } from './input-handler';
-import RawEditor from "@lblod/ember-rdfa-editor/utils/ce/raw-editor";
+import {InputHandler} from './input-handler';
 import ModelSelection from "@lblod/ember-rdfa-editor/model/model-selection";
 import {PropertyState} from "@lblod/ember-rdfa-editor/model/util/types";
+import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 
 
 /**
@@ -11,16 +11,15 @@ import {PropertyState} from "@lblod/ember-rdfa-editor/model/util/types";
  * @class BoldItalicUnderlineHandler
  * @constructor
  */
-export default class BoldItalicUnderlineHandler implements InputHandler {
+export default class BoldItalicUnderlineHandler extends InputHandler {
 
-  rawEditor: RawEditor;
   isBold = false;
   isItalic = false;
   isUnderline = false;
   isStrikethrough = false;
 
-  constructor({ rawEditor }: { rawEditor: RawEditor }) {
-    this.rawEditor = rawEditor;
+  constructor({ rawEditor }: { rawEditor: LegacyRawEditor }) {
+    super(rawEditor);
     document.addEventListener("richSelectionUpdated", this.updateProperties.bind(this));
   }
 

--- a/addon/editor/input-handlers/bold-italic-underline-handler.ts
+++ b/addon/editor/input-handlers/bold-italic-underline-handler.ts
@@ -1,7 +1,7 @@
 import {InputHandler} from './input-handler';
 import ModelSelection from "@lblod/ember-rdfa-editor/model/model-selection";
 import {PropertyState} from "@lblod/ember-rdfa-editor/model/util/types";
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
 
 /**
@@ -18,7 +18,7 @@ export default class BoldItalicUnderlineHandler extends InputHandler {
   isUnderline = false;
   isStrikethrough = false;
 
-  constructor({ rawEditor }: { rawEditor: LegacyRawEditor }) {
+  constructor({ rawEditor }: { rawEditor: PernetRawEditor }) {
     super(rawEditor);
     document.addEventListener("richSelectionUpdated", this.updateProperties.bind(this));
   }

--- a/addon/editor/input-handlers/delete-handler.ts
+++ b/addon/editor/input-handlers/delete-handler.ts
@@ -21,7 +21,7 @@ import {
   stringToVisibleText
 } from '@lblod/ember-rdfa-editor/editor/utils';
 import ListDeletePlugin from '@lblod/ember-rdfa-editor/utils/plugins/lists/delete-plugin';
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
 /**
  * We introduce an abstract reference point to check for visual changes.
@@ -33,7 +33,7 @@ interface VisualChangeReferencePoint {
   storeMeasurePoint(): void;
 
   hasChangedVisually: boolean;
-  editor: LegacyRawEditor;
+  editor: PernetRawEditor;
 
   cleanUp(): void;
 }
@@ -49,9 +49,9 @@ export class MagicSpan implements VisualChangeReferencePoint {
   firstMeasurePoint: Array<DOMRect>;
   secondMeasurePoint: Array<DOMRect>;
   span: Element;
-  editor: LegacyRawEditor;
+  editor: PernetRawEditor;
 
-  constructor(span: Element, editor: LegacyRawEditor) {
+  constructor(span: Element, editor: PernetRawEditor) {
     this.span = span;
     this.span.id = MagicSpan.ID;
     this.editor = editor;
@@ -83,9 +83,9 @@ export class MagicSpan implements VisualChangeReferencePoint {
 class Caret implements VisualChangeReferencePoint {
   firstMeasurePoint: Array<DOMRect>;
   secondMeasurePoint: Array<DOMRect>;
-  editor: LegacyRawEditor;
+  editor: PernetRawEditor;
 
-  constructor(editor: LegacyRawEditor) {
+  constructor(editor: PernetRawEditor) {
     this.editor = editor;
     this.firstMeasurePoint = [];
     this.secondMeasurePoint = [];
@@ -124,9 +124,9 @@ class VisibleTextLength implements VisualChangeReferencePoint {
   firstMeasurePoint: string;
   secondMeasurePoint: string;
   textNode: Text;
-  editor: LegacyRawEditor;
+  editor: PernetRawEditor;
 
-  constructor(textNode: Text, editor: LegacyRawEditor) {
+  constructor(textNode: Text, editor: PernetRawEditor) {
     this.editor = editor;
     this.firstMeasurePoint = '';
     this.secondMeasurePoint = '';
@@ -326,7 +326,7 @@ export type DeleteHandlerManipulation =
  * Interface for specific plugins.
  */
 export interface DeletePlugin extends InputPlugin {
-  guidanceForManipulation: (manipulation: DeleteHandlerManipulation, editor: LegacyRawEditor) => ManipulationGuidance | null;
+  guidanceForManipulation: (manipulation: DeleteHandlerManipulation, editor: PernetRawEditor) => ManipulationGuidance | null;
   /**
    * Callback to let the plugin indicate whether or not it discovered
    * a change.
@@ -368,7 +368,7 @@ export default class DeleteHandler extends InputHandler {
    * @public
    * @constructor
    */
-  constructor({rawEditor}: { rawEditor: LegacyRawEditor }) {
+  constructor({rawEditor}: { rawEditor: PernetRawEditor }) {
     super(rawEditor);
     // Order is now the sole parameter for conflict resolution of plugins. Think before changing.
     this.plugins = [

--- a/addon/editor/input-handlers/enter-handler.ts
+++ b/addon/editor/input-handlers/enter-handler.ts
@@ -1,5 +1,5 @@
 import {InputHandler} from './input-handler';
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
 
 /**
@@ -12,7 +12,7 @@ import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor
 export default class EnterHandler extends InputHandler {
 
 
-  constructor({ rawEditor }: { rawEditor: LegacyRawEditor }) {
+  constructor({ rawEditor }: { rawEditor: PernetRawEditor}) {
     super(rawEditor);
   }
 

--- a/addon/editor/input-handlers/enter-handler.ts
+++ b/addon/editor/input-handlers/enter-handler.ts
@@ -1,5 +1,5 @@
-import { InputHandler } from './input-handler';
-import RawEditor from "@lblod/ember-rdfa-editor/utils/ce/raw-editor";
+import {InputHandler} from './input-handler';
+import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 
 
 /**
@@ -9,12 +9,11 @@ import RawEditor from "@lblod/ember-rdfa-editor/utils/ce/raw-editor";
  * @class EnterHandler
  * @constructor
  */
-export default class EnterHandler implements InputHandler {
+export default class EnterHandler extends InputHandler {
 
-  rawEditor: RawEditor;
 
-  constructor({ rawEditor }: { rawEditor: RawEditor }) {
-    this.rawEditor = rawEditor;
+  constructor({ rawEditor }: { rawEditor: LegacyRawEditor }) {
+    super(rawEditor);
   }
 
   isHandlerFor(event: Event) {

--- a/addon/editor/input-handlers/escape-handler.ts
+++ b/addon/editor/input-handlers/escape-handler.ts
@@ -8,11 +8,10 @@ import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor
  * @class EscapeHandler
  * @constructor
  */
-export default class EscapeHandler implements InputHandler {
-  rawEditor: LegacyRawEditor;
+export default class EscapeHandler extends InputHandler {
 
   constructor( {rawEditor} : { rawEditor: LegacyRawEditor} ) {
-    this.rawEditor = rawEditor;
+    super(rawEditor);
   }
 
   isHandlerFor(event: Event) {

--- a/addon/editor/input-handlers/escape-handler.ts
+++ b/addon/editor/input-handlers/escape-handler.ts
@@ -1,5 +1,5 @@
 import { InputHandler } from './input-handler';
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
 /**
  * Escape Handler, an event handler to handle escape
@@ -10,7 +10,7 @@ import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor
  */
 export default class EscapeHandler extends InputHandler {
 
-  constructor( {rawEditor} : { rawEditor: LegacyRawEditor} ) {
+  constructor( {rawEditor} : { rawEditor: PernetRawEditor} ) {
     super(rawEditor);
   }
 

--- a/addon/editor/input-handlers/input-handler.ts
+++ b/addon/editor/input-handlers/input-handler.ts
@@ -1,3 +1,11 @@
+import {
+  Manipulation,
+  ManipulationExecutor,
+  ManipulationGuidance
+} from "@lblod/ember-rdfa-editor/editor/input-handlers/manipulation";
+import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
+import {editorDebug} from "@lblod/ember-rdfa-editor/editor/utils";
+
 export interface HandlerResponse {
   /**
    * specify if the event can also handled by another handler
@@ -9,8 +17,92 @@ export interface HandlerResponse {
   allowPropagation: boolean
 }
 
+export interface InputPlugin {
+  /**
+   * One-liner explaining what the plugin solves.
+   */
+  label: string;
 
-export interface InputHandler {
-  isHandlerFor: (event: Event) => boolean
-  handleEvent: (event: Event) => HandlerResponse
+  /**
+   * Callback executed to see if the plugin allows a certain
+   * manipulation and/or if it intends to handle the manipulation
+   * itself.
+   */
+  guidanceForManipulation: (manipulation: Manipulation, editor: LegacyRawEditor) => ManipulationGuidance | null;
+}
+
+export abstract class InputHandler {
+  plugins: InputPlugin[];
+  protected rawEditor: LegacyRawEditor;
+
+  constructor(rawEditor: LegacyRawEditor) {
+    this.rawEditor = rawEditor;
+    this.plugins = [];
+  }
+
+  abstract isHandlerFor(event: Event): boolean;
+
+  abstract handleEvent(event: Event): HandlerResponse;
+
+  /**
+   * Checks whether all plugins agree the manipulation is allowed.
+   *
+   * This method asks each plugin individually if the manipulation is
+   * allowed.  If it is not allowed by *any* plugin, it yields a
+   * negative response, otherwise it yields a positive response.
+   *
+   * We expect this method to be extended in the future with more rich
+   * responses from plugins.  Something like "skip" or "merge" to
+   * indicate this manipulation should be lumped together with a
+   * previous manipulation.  Plugins may also want to execute the
+   * changes themselves to ensure correct behaviour.
+   *
+   * @method checkManipulationByPlugins
+   * @private
+   *
+   * @param {Manipulation} manipulation DOM manipulation which will be
+   * checked by plugins.
+   **/
+  checkManipulationByPlugins(manipulation: Manipulation): { mayExecute: boolean, dispatchedExecutor: ManipulationExecutor | null } {
+    // calculate reports submitted by each plugin
+    const reports: Array<{ plugin: InputPlugin, allow: boolean, executor: ManipulationExecutor | undefined }> = [];
+    for (const plugin of this.plugins) {
+      const guidance = plugin.guidanceForManipulation(manipulation, this.rawEditor);
+      if (guidance) {
+        const allow = guidance.allow === undefined ? true : guidance.allow;
+        const executor = guidance.executor;
+        reports.push({plugin, allow, executor});
+      }
+    }
+
+    // filter reports based on our interests
+    const reportsNoExecute = reports.filter(({allow}) => !allow);
+    const reportsWithExecutor = reports.filter(({executor}) => executor);
+
+    // debug reporting
+    if (reports.length > 1) {
+      console.warn(`Multiple plugins want to alter this manipulation`, reports);
+    }
+    if (reportsNoExecute.length > 1 && reportsWithExecutor.length > 1) {
+      console.error(`Some plugins don't want execution, others want custom execution`, {
+        reportsNoExecute,
+        reportsWithExecutor
+      });
+    }
+    if (reportsWithExecutor.length > 1) {
+      console.warn(`Multiple plugins want to execute this plugin. First entry in the list wins: ${reportsWithExecutor[0].plugin.label}`);
+    }
+
+    for (const {plugin} of reportsNoExecute) {
+      editorDebug(`${this.constructor.name}.checkManipulationByPlugins`,
+        `Was not allowed to execute text manipulation by plugin ${plugin.label}`,
+        { manipulation, plugin });
+    }
+
+    // yield result
+    return {
+      mayExecute: reportsNoExecute.length === 0,
+      dispatchedExecutor: reportsWithExecutor.length ? reportsWithExecutor[0].executor as ManipulationExecutor : null
+    };
+  }
 }

--- a/addon/editor/input-handlers/input-handler.ts
+++ b/addon/editor/input-handlers/input-handler.ts
@@ -3,8 +3,8 @@ import {
   ManipulationExecutor,
   ManipulationGuidance
 } from "@lblod/ember-rdfa-editor/editor/input-handlers/manipulation";
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 import {editorDebug} from "@lblod/ember-rdfa-editor/editor/utils";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
 export interface HandlerResponse {
   /**
@@ -28,14 +28,14 @@ export interface InputPlugin {
    * manipulation and/or if it intends to handle the manipulation
    * itself.
    */
-  guidanceForManipulation: (manipulation: Manipulation, editor: LegacyRawEditor) => ManipulationGuidance | null;
+  guidanceForManipulation: (manipulation: Manipulation, editor: PernetRawEditor) => ManipulationGuidance | null;
 }
 
 export abstract class InputHandler {
   plugins: InputPlugin[];
-  protected rawEditor: LegacyRawEditor;
+  protected rawEditor: PernetRawEditor;
 
-  constructor(rawEditor: LegacyRawEditor) {
+  constructor(rawEditor: PernetRawEditor) {
     this.rawEditor = rawEditor;
     this.plugins = [];
   }
@@ -96,7 +96,7 @@ export abstract class InputHandler {
     for (const {plugin} of reportsNoExecute) {
       editorDebug(`${this.constructor.name}.checkManipulationByPlugins`,
         `Was not allowed to execute text manipulation by plugin ${plugin.label}`,
-        { manipulation, plugin });
+        {manipulation, plugin});
     }
 
     // yield result

--- a/addon/editor/input-handlers/manipulation.ts
+++ b/addon/editor/input-handlers/manipulation.ts
@@ -9,6 +9,8 @@
  * The HTMLWbrElement type is a custom type which we have added
  * ourselves.  We did not find a type.
  */
+import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
+
 export type VoidElement = HTMLAreaElement
   | HTMLBaseElement
   | HTMLBRElement
@@ -57,6 +59,7 @@ export type Manipulation =
   | ReplaceSelectionWithTextManipulation
   | RemoveBoundaryForwards
   | RemoveBoundaryBackwards
+  | InsertTextIntoRange
 ;
 
 /**
@@ -232,6 +235,12 @@ export interface RemoveBoundaryForwards extends BaseManipulation {
 export interface RemoveBoundaryBackwards extends BaseManipulation {
   type: "removeBoundaryBackwards";
   node: Node;
+}
+
+export interface InsertTextIntoRange extends BaseManipulation {
+  type: "insertTextIntoRange";
+  range: ModelRange;
+  text: string;
 }
 
 export interface ManipulationGuidance {

--- a/addon/editor/input-handlers/manipulation.ts
+++ b/addon/editor/input-handlers/manipulation.ts
@@ -36,33 +36,6 @@ interface HTMLWbrElement extends HTMLElement {
 }
 
 /**
- * Contains a set of all currently supported manipulations.
- */
-export type Manipulation =
-  RemoveEmptyTextNodeManipulation
-  | RemoveCharacterManipulation
-  | RemoveEmptyElementManipulation
-  | RemoveVoidElementManipulation
-  | RemoveOtherNodeManipulation
-  | RemoveElementWithOnlyInvisibleTextNodeChildrenManipulation
-  | RemoveElementWithChildrenThatArentVisible
-  | MoveCursorToEndOfElementManipulation
-  | MoveCursorAfterElementManipulation
-  | MoveCursorBeforeElementManipulation
-  | MoveCursorAfterEditorManipulation
-  | MoveCursorBeforeEditorManipulation
-  | MoveCursorToStartOfElementManipulation
-  | KeepCursorAtStartManipulation
-  | KeepCursorAtEndManipulation
-  | InsertTextIntoTextNodeManipulation
-  | InsertTextIntoElementManipulation
-  | ReplaceSelectionWithTextManipulation
-  | RemoveBoundaryForwards
-  | RemoveBoundaryBackwards
-  | InsertTextIntoRange
-;
-
-/**
  * Executor of a single Manipulation, as offered by plugins.
  *
  * The plugin receives a Manipulation and an Editor, and can use both
@@ -79,15 +52,14 @@ export interface Editor {
 /**
  * Base type for any manipulation, ensuring the type interface exists.
  */
-export interface BaseManipulation {
+export interface Manipulation {
   type: string;
-  node?: Node;
 }
 
 /**
  * Represents the removal of an empty text node.
  */
-export interface RemoveEmptyTextNodeManipulation extends BaseManipulation {
+export interface RemoveEmptyTextNodeManipulation extends Manipulation {
   type: "removeEmptyTextNode";
   node: Text;
 }
@@ -95,7 +67,7 @@ export interface RemoveEmptyTextNodeManipulation extends BaseManipulation {
 /**
  * Represents the removal of a single character from a text node.
  */
-export interface RemoveCharacterManipulation extends BaseManipulation {
+export interface RemoveCharacterManipulation extends Manipulation {
   type: "removeCharacter";
   node: Text;
   position: number;
@@ -104,7 +76,7 @@ export interface RemoveCharacterManipulation extends BaseManipulation {
 /**
  * Represents keeping the cursor at the start of the editor
  */
-export interface KeepCursorAtStartManipulation extends BaseManipulation {
+export interface KeepCursorAtStartManipulation extends Manipulation {
   type: "keepCursorAtStart";
   node: Element;
 }
@@ -112,7 +84,7 @@ export interface KeepCursorAtStartManipulation extends BaseManipulation {
 /**
  * Represents keeping the cursor at the End of the editor
  */
-export interface KeepCursorAtEndManipulation extends BaseManipulation {
+export interface KeepCursorAtEndManipulation extends Manipulation {
   type: "keepCursorAtEnd";
   node: Element;
 }
@@ -120,7 +92,7 @@ export interface KeepCursorAtEndManipulation extends BaseManipulation {
 /**
  * Represents the removal of an empty Element (so an Element without childNodes)
  */
-export interface RemoveEmptyElementManipulation extends BaseManipulation {
+export interface RemoveEmptyElementManipulation extends Manipulation {
   type: "removeEmptyElement";
   node: Element;
 }
@@ -128,7 +100,7 @@ export interface RemoveEmptyElementManipulation extends BaseManipulation {
 /**
  * Represents the removal of a void element
  */
-export interface RemoveVoidElementManipulation extends BaseManipulation {
+export interface RemoveVoidElementManipulation extends Manipulation {
   type: "removeVoidElement";
   node: VoidElement;
 }
@@ -136,13 +108,13 @@ export interface RemoveVoidElementManipulation extends BaseManipulation {
 /**
  * Represents moving the cursor after the last child of node
  */
-export interface MoveCursorToEndOfElementManipulation extends BaseManipulation {
+export interface MoveCursorToEndOfElementManipulation extends Manipulation {
   type: "moveCursorToEndOfElement";
   node: HTMLElement;
   selection?: Selection;
 }
 
-export interface MoveCursorToStartOfElementManipulation extends BaseManipulation {
+export interface MoveCursorToStartOfElementManipulation extends Manipulation {
   type: "moveCursorToStartOfElement";
   node: HTMLElement;
   selection?: Selection;
@@ -151,24 +123,24 @@ export interface MoveCursorToStartOfElementManipulation extends BaseManipulation
 /**
  * Represents moving the cursor before the element
  */
-export interface MoveCursorBeforeElementManipulation extends BaseManipulation {
+export interface MoveCursorBeforeElementManipulation extends Manipulation {
   type: "moveCursorBeforeElement";
   node: HTMLElement;
   selection?: Selection;
 }
 
-export interface MoveCursorAfterElementManipulation extends BaseManipulation {
+export interface MoveCursorAfterElementManipulation extends Manipulation {
   type: "moveCursorAfterElement";
   node: HTMLElement;
   selection?: Selection;
 }
 
-export interface MoveCursorAfterEditorManipulation extends BaseManipulation {
+export interface MoveCursorAfterEditorManipulation extends Manipulation {
   type: "moveCursorAfterEditor";
   node: HTMLElement; //will be rootNode of editor
 }
 
-export interface MoveCursorBeforeEditorManipulation extends BaseManipulation {
+export interface MoveCursorBeforeEditorManipulation extends Manipulation {
   type: "moveCursorBeforeEditor";
   node: HTMLElement; //will be rootNode of editor
 }
@@ -176,7 +148,7 @@ export interface MoveCursorBeforeEditorManipulation extends BaseManipulation {
 /**
  * Represents the removal of a node that is not of type Text of Element
  */
-export interface RemoveOtherNodeManipulation extends BaseManipulation {
+export interface RemoveOtherNodeManipulation extends Manipulation {
   type: "removeOtherNode";
   node: Node;
 }
@@ -185,7 +157,7 @@ export interface RemoveOtherNodeManipulation extends BaseManipulation {
  * Represents the removal of an element that has only invisible text nodes as children
  * TODO: currently replaced by removeElementWithChildrenThatArentVisible
  */
-export interface RemoveElementWithOnlyInvisibleTextNodeChildrenManipulation extends BaseManipulation {
+export interface RemoveElementWithOnlyInvisibleTextNodeChildrenManipulation extends Manipulation {
   type: "removeElementWithOnlyInvisibleTextNodeChildren";
   node: Element;
 }
@@ -193,7 +165,7 @@ export interface RemoveElementWithOnlyInvisibleTextNodeChildrenManipulation exte
 /**
  * Represents the removal of an element that only has invisible children
  */
-export interface RemoveElementWithChildrenThatArentVisible extends BaseManipulation {
+export interface RemoveElementWithChildrenThatArentVisible extends Manipulation {
   type: "removeElementWithChildrenThatArentVisible";
   node: Element;
 }
@@ -201,7 +173,7 @@ export interface RemoveElementWithChildrenThatArentVisible extends BaseManipulat
 /**
  * Represents adding text into a text node
  */
-export interface InsertTextIntoTextNodeManipulation extends BaseManipulation {
+export interface InsertTextIntoTextNodeManipulation extends Manipulation {
   type: "insertTextIntoTextNode";
   node: Text;
   position: number;
@@ -212,7 +184,7 @@ export interface InsertTextIntoTextNodeManipulation extends BaseManipulation {
  * Represents adding text into an element
  * position is the number of childNodes between the start of the element and the position where the text should be inserted
  */
-export interface InsertTextIntoElementManipulation extends BaseManipulation {
+export interface InsertTextIntoElementManipulation extends Manipulation {
   type: "insertTextIntoElement";
   node: HTMLElement;
   position: number;
@@ -222,22 +194,22 @@ export interface InsertTextIntoElementManipulation extends BaseManipulation {
 /**
  * Represents replacing a selection with text
  */
-export interface ReplaceSelectionWithTextManipulation extends BaseManipulation {
+export interface ReplaceSelectionWithTextManipulation extends Manipulation {
   type: "replaceSelectionWithText";
   node: Node; // the anchorNode
   selection: Selection
   text: string;
 }
-export interface RemoveBoundaryForwards extends BaseManipulation {
+export interface RemoveBoundaryForwards extends Manipulation {
   type: "removeBoundaryForwards";
   node: ChildNode;
 }
-export interface RemoveBoundaryBackwards extends BaseManipulation {
+export interface RemoveBoundaryBackwards extends Manipulation {
   type: "removeBoundaryBackwards";
   node: Node;
 }
 
-export interface InsertTextIntoRange extends BaseManipulation {
+export interface InsertTextIntoRange extends Manipulation {
   type: "insertTextIntoRange";
   range: ModelRange;
   text: string;

--- a/addon/editor/input-handlers/tab-handler.ts
+++ b/addon/editor/input-handlers/tab-handler.ts
@@ -14,8 +14,8 @@ import LumpNodeTabInputPlugin from '@lblod/ember-rdfa-editor/utils/plugins/lump-
 import ListTabInputPlugin from '@lblod/ember-rdfa-editor/utils/plugins/lists/tab-input-plugin';
 import TableTabInputPlugin from '@lblod/ember-rdfa-editor/utils/plugins/table/tab-input-plugin';
 import {ensureValidTextNodeForCaret} from '@lblod/ember-rdfa-editor/editor/utils';
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 import RawEditor from 'dummy/utils/ce/raw-editor';
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
 export type TabHandlerManipulation =
   MoveCursorBeforeElementManipulation
@@ -54,7 +54,7 @@ export interface TabInputPlugin extends InputPlugin {
 export default class TabInputHandler extends InputHandler {
   plugins: Array<TabInputPlugin>;
 
-  constructor({rawEditor}: { rawEditor: LegacyRawEditor }) {
+  constructor({rawEditor}: { rawEditor: PernetRawEditor}) {
     super(rawEditor);
     this.plugins = [
       new LumpNodeTabInputPlugin(),

--- a/addon/editor/input-handlers/text-input-handler.ts
+++ b/addon/editor/input-handlers/text-input-handler.ts
@@ -4,16 +4,17 @@ import {warn} from '@ember/debug';
 import RdfaTextInputPlugin from '@lblod/ember-rdfa-editor/utils/plugins/rdfa/text-input-plugin';
 import AnchorTagTextInputPlugin from '@lblod/ember-rdfa-editor/utils/plugins/anchor-tags/text-input-plugin';
 import PlaceHolderTextInputPlugin from '@lblod/ember-rdfa-editor/utils/plugins/placeholder-text/text-input-plugin';
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 import {MisbehavedSelectionError, UnsupportedManipulationError} from "@lblod/ember-rdfa-editor/utils/errors";
 import {NON_BREAKING_SPACE} from "@lblod/ember-rdfa-editor/model/util/constants";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
 
 export type TextHandlerManipulation = InsertTextIntoRange;
+
 /**
  * Interface for specific plugins.
  */
-export interface TextInputPlugin extends InputPlugin{
+export interface TextInputPlugin extends InputPlugin {
   /**
    * Callback executed to see if the plugin allows a certain
    * manipulation and/or if it intends to handle the manipulation
@@ -32,7 +33,7 @@ export interface TextInputPlugin extends InputPlugin{
 export default class TextInputHandler extends InputHandler {
   plugins: Array<TextInputPlugin>;
 
-  constructor({rawEditor}: { rawEditor: LegacyRawEditor }) {
+  constructor({rawEditor}: { rawEditor: PernetRawEditor }) {
     super(rawEditor);
     this.plugins = [
       new RdfaTextInputPlugin(),
@@ -99,7 +100,7 @@ export default class TextInputHandler extends InputHandler {
     if (!range) {
       throw new MisbehavedSelectionError();
     }
-    const text = event.key === " "? NON_BREAKING_SPACE : event.key;
+    const text = event.key === " " ? NON_BREAKING_SPACE : event.key;
     return {type: "insertTextIntoRange", range, text};
   }
 

--- a/addon/editor/input-handlers/text-input-handler.ts
+++ b/addon/editor/input-handlers/text-input-handler.ts
@@ -6,6 +6,7 @@ import AnchorTagTextInputPlugin from '@lblod/ember-rdfa-editor/utils/plugins/anc
 import PlaceHolderTextInputPlugin from '@lblod/ember-rdfa-editor/utils/plugins/placeholder-text/text-input-plugin';
 import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 import {MisbehavedSelectionError, UnsupportedManipulationError} from "@lblod/ember-rdfa-editor/utils/errors";
+import {NON_BREAKING_SPACE} from "@lblod/ember-rdfa-editor/model/util/constants";
 
 
 export type TextHandlerManipulation = InsertTextIntoRange;
@@ -84,7 +85,9 @@ export default class TextInputHandler extends InputHandler {
   }
 
   handleNativeManipulation(manipulation: TextHandlerManipulation) {
+    console.log("handling native manip");
     if (manipulation.type === "insertTextIntoRange") {
+      console.log(manipulation);
       this.rawEditor.executeCommand("insert-text", manipulation.text, manipulation.range);
     } else {
       throw new UnsupportedManipulationError(manipulation);
@@ -96,7 +99,8 @@ export default class TextInputHandler extends InputHandler {
     if (!range) {
       throw new MisbehavedSelectionError();
     }
-    return {type: "insertTextIntoRange", range, text: event.key};
+    const text = event.key === " "? NON_BREAKING_SPACE : event.key;
+    return {type: "insertTextIntoRange", range, text};
   }
 
 

--- a/addon/editor/input-handlers/text-input-handler.ts
+++ b/addon/editor/input-handlers/text-input-handler.ts
@@ -89,6 +89,8 @@ export default class TextInputHandler implements InputHandler {
 
   handleEvent(event: Event) {
     const keyboardEvent = event as KeyboardEvent;
+    this.rawEditor.executeCommand("insert-text", keyboardEvent.key);
+    return {allowPropagation: false};
     const manipulation = this.getNextManipulation(keyboardEvent);
     // check if we can execute it
     const { mayExecute, dispatchedExecutor } = this.checkManipulationByPlugins( manipulation );

--- a/addon/editor/input-handlers/text-input-handler.ts
+++ b/addon/editor/input-handlers/text-input-handler.ts
@@ -1,5 +1,5 @@
-import {InputHandler} from './input-handler';
-import {Editor, Manipulation, ManipulationGuidance} from './manipulation';
+import {InputHandler, InputPlugin} from './input-handler';
+import {Editor, InsertTextIntoRange, ManipulationGuidance} from './manipulation';
 import {warn} from '@ember/debug';
 import RdfaTextInputPlugin from '@lblod/ember-rdfa-editor/utils/plugins/rdfa/text-input-plugin';
 import AnchorTagTextInputPlugin from '@lblod/ember-rdfa-editor/utils/plugins/anchor-tags/text-input-plugin';
@@ -8,21 +8,17 @@ import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor
 import {MisbehavedSelectionError, UnsupportedManipulationError} from "@lblod/ember-rdfa-editor/utils/errors";
 
 
+export type TextHandlerManipulation = InsertTextIntoRange;
 /**
  * Interface for specific plugins.
  */
-export interface TextInputPlugin {
-  /**
-   * One-liner explaining what the plugin solves.
-   */
-  label: string;
-
+export interface TextInputPlugin extends InputPlugin{
   /**
    * Callback executed to see if the plugin allows a certain
    * manipulation and/or if it intends to handle the manipulation
    * itself.
    */
-  guidanceForManipulation: (manipulation: Manipulation) => ManipulationGuidance | null;
+  guidanceForManipulation: (manipulation: TextHandlerManipulation) => ManipulationGuidance | null;
 }
 
 /**
@@ -87,7 +83,7 @@ export default class TextInputHandler extends InputHandler {
     return {allowPropagation: false};
   }
 
-  handleNativeManipulation(manipulation: Manipulation) {
+  handleNativeManipulation(manipulation: TextHandlerManipulation) {
     if (manipulation.type === "insertTextIntoRange") {
       this.rawEditor.executeCommand("insert-text", manipulation.text, manipulation.range);
     } else {
@@ -95,7 +91,7 @@ export default class TextInputHandler extends InputHandler {
     }
   }
 
-  getNextManipulation(event: KeyboardEvent): Manipulation {
+  getNextManipulation(event: KeyboardEvent): TextHandlerManipulation {
     const range = this.rawEditor.model.selection.lastRange;
     if (!range) {
       throw new MisbehavedSelectionError();

--- a/addon/model/model-element.ts
+++ b/addon/model/model-element.ts
@@ -365,4 +365,13 @@ export default class ModelElement extends ModelNode implements Cloneable<ModelEl
 
     return true;
   }
+  isMergeable(other: ModelNode): boolean {
+    if(!ModelNode.isModelElement(other)) {
+      return false;
+    }
+    if(other.type !== this.type) {
+      return false;
+    }
+    return ModelNodeUtils.areAttributeMapsSame(this.attributeMap, other.attributeMap);
+  }
 }

--- a/addon/model/model-node.ts
+++ b/addon/model/model-node.ts
@@ -204,6 +204,16 @@ export default abstract class ModelNode {
   }
 
   /**
+   * Removes an attribute on this node.
+   * Returns true if a removal took place,
+   * false if the key wasn't in the map to start with.
+   * @param key
+   */
+  removeAttribute(key: string): boolean {
+    return this._attributeMap.delete(key);
+  }
+
+  /**
    * Generic no-op default for setting a text attribute. Should be overridden by subclasses
    * that care about textAttributes. Intentionally a no-op and not an abstract method.
    * @param _key

--- a/addon/model/model-node.ts
+++ b/addon/model/model-node.ts
@@ -298,6 +298,14 @@ export default abstract class ModelNode {
    * @param strict
    */
   abstract sameAs(other: ModelNode, strict?: boolean): boolean;
+
+  /**
+   * True if node can be merged with other
+   * This means we are ok with this node being replaced by a shallowclone of either this or other,
+   * with the children of this and other appended to the clone.
+   * @param other
+   */
+  abstract isMergeable(other: ModelNode): boolean;
 }
 
 

--- a/addon/model/model-position.ts
+++ b/addon/model/model-position.ts
@@ -155,6 +155,17 @@ export default class ModelPosition {
   }
 
   /**
+   * Resets the parent cache
+   * Call this when the parent tree of the position has possibly changed
+   * TODO: this is a hack, redesign this
+   * can be resolved relatively elegantly by a robust event system by having every position listen to
+   * operation events and invalidating their caches greedily
+   */
+  invalidateParentCache(): void {
+    this.parentCache = null;
+  }
+
+  /**
    * Check if two modelpositions describe the same position
    * @param other
    */

--- a/addon/model/model-selection.ts
+++ b/addon/model/model-selection.ts
@@ -8,7 +8,6 @@ import ModelNodeFinder from "@lblod/ember-rdfa-editor/model/util/model-node-find
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
 import {Direction, FilterAndPredicate, PropertyState,} from "@lblod/ember-rdfa-editor/model/util/types";
-import ModelTreeWalker, {FilterResult} from "@lblod/ember-rdfa-editor/model/util/model-tree-walker";
 import {nodeIsElementOfType} from "@lblod/ember-rdfa-editor/model/util/predicate-utils";
 
 /**
@@ -279,16 +278,9 @@ export default class ModelSelection {
 
     if (ModelSelection.isWellBehaved(this)) {
       const range = this.lastRange;
-
-      const treeWalker = new ModelTreeWalker({
-        range,
-        filter: (node) => ModelNode.isModelText(node) && node.getTextAttribute(property) ? FilterResult.FILTER_ACCEPT : FilterResult.FILTER_SKIP
-      });
-      const result = Array.from(treeWalker);
-      return result.length ? PropertyState.enabled : PropertyState.disabled;
-    } else {
-      return PropertyState.unknown;
+      return range.getTextAttributes().get(property) || PropertyState.unknown;
     }
+    return PropertyState.unknown;
   }
 
 

--- a/addon/model/model-text.ts
+++ b/addon/model/model-text.ts
@@ -122,4 +122,10 @@ export default class ModelText extends ModelNode {
       return ModelNodeUtils.areAttributeMapsSame(this.attributeMap, other.attributeMap);
     }
   }
+  isMergeable(other: ModelNode): boolean {
+    if(!ModelNode.isModelText(other)) {
+      return false;
+    }
+    return ModelNodeUtils.areAttributeMapsSame(this.attributeMap, other.attributeMap);
+  }
 }

--- a/addon/model/mutators/immediate-model-mutator.ts
+++ b/addon/model/mutators/immediate-model-mutator.ts
@@ -3,11 +3,13 @@ import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import AttributeOperation from "@lblod/ember-rdfa-editor/model/operations/attribute-operation";
 import InsertOperation from "@lblod/ember-rdfa-editor/model/operations/insert-operation";
 import MoveOperation from "@lblod/ember-rdfa-editor/model/operations/move-operation";
-import {TextAttribute} from "@lblod/ember-rdfa-editor/model/model-text";
+import ModelText, {TextAttribute} from "@lblod/ember-rdfa-editor/model/model-text";
 import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
 import SplitOperation from "@lblod/ember-rdfa-editor/model/operations/split-operation";
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
+import {PropertyState} from "@lblod/ember-rdfa-editor/model/util/types";
+import ModelTreeWalker from "@lblod/ember-rdfa-editor/model/util/model-tree-walker";
 
 /**
  * {@link ModelMutator} implementation where all operations immediately
@@ -30,6 +32,73 @@ export default class ImmediateModelMutator extends ModelMutator<ModelRange> {
 
   insertAtPosition(position: ModelPosition, ...nodes: ModelNode[]): ModelRange {
     return this.insertNodes(new ModelRange(position, position), ...nodes);
+  }
+
+  insertText(range: ModelRange, text: string): ModelRange {
+    const textNode = new ModelText(text);
+    for (const [attr, val] of range.getTextAttributes().entries()) {
+      if(val === PropertyState.enabled) {
+        textNode.setTextAttribute(attr, true);
+      }
+    }
+    const op = new InsertOperation(range, textNode);
+
+    const resultRange = op.execute();
+    const start = ModelPosition.fromBeforeNode(textNode.previousSibling || textNode);
+    const end = ModelPosition.fromAfterNode(textNode.nextSibling || textNode);
+    const mergeRange = new ModelRange(start, end);
+    this.mergeTextNodesInRange(mergeRange);
+
+    return resultRange;
+  }
+
+  private mergeTextNodesInRange(range: ModelRange) {
+    if (!range.isConfined()) {
+      return;
+    }
+    if(range.collapsed) {
+      return;
+    }
+    const walker = new ModelTreeWalker({range, descend: false});
+
+    const nodes: ModelNode[] = [];
+    for (const node of walker) {
+      const last = nodes[nodes.length - 1];
+      if(ModelNode.isModelText(last) && ModelNode.isModelText(node) && last.isMergeable(node)) {
+        last.content += node.content;
+      } else {
+        nodes.push(node.clone());
+      }
+    }
+
+    const op = new InsertOperation(range, ...nodes);
+    op.execute();
+  }
+
+  /**
+   * Merge two text nodes. Both nodes will be replaced by a new node with content
+   * equal to left.content + right.content
+   * If nodes are not siblings, do nothing
+   * @param left
+   * @param right
+   * @return resultPosition a position at the end of the left node, which will be at the boundary of the original
+   * if the merge was successful
+   */
+  mergeSiblingTextNodes(left: ModelText, right: ModelText): ModelPosition {
+    const resultPosition = ModelPosition.fromAfterNode(left);
+    if (left.nextSibling !== right) {
+      return resultPosition;
+    }
+    const newNode = left.clone();
+    newNode.content += right.content;
+    const start = ModelPosition.fromBeforeNode(left);
+    const end = ModelPosition.fromAfterNode(right);
+    const replaceRange = new ModelRange(start, end);
+    const op = new InsertOperation(replaceRange, newNode);
+    op.execute();
+    resultPosition.invalidateParentCache();
+    return resultPosition;
+
   }
 
   /**

--- a/addon/model/mutators/immediate-model-mutator.ts
+++ b/addon/model/mutators/immediate-model-mutator.ts
@@ -76,32 +76,6 @@ export default class ImmediateModelMutator extends ModelMutator<ModelRange> {
   }
 
   /**
-   * Merge two text nodes. Both nodes will be replaced by a new node with content
-   * equal to left.content + right.content
-   * If nodes are not siblings, do nothing
-   * @param left
-   * @param right
-   * @return resultPosition a position at the end of the left node, which will be at the boundary of the original
-   * if the merge was successful
-   */
-  mergeSiblingTextNodes(left: ModelText, right: ModelText): ModelPosition {
-    const resultPosition = ModelPosition.fromAfterNode(left);
-    if (left.nextSibling !== right) {
-      return resultPosition;
-    }
-    const newNode = left.clone();
-    newNode.content += right.content;
-    const start = ModelPosition.fromBeforeNode(left);
-    const end = ModelPosition.fromAfterNode(right);
-    const replaceRange = new ModelRange(start, end);
-    const op = new InsertOperation(replaceRange, newNode);
-    op.execute();
-    resultPosition.invalidateParentCache();
-    return resultPosition;
-
-  }
-
-  /**
    * @inheritDoc
    * @param rangeToMove
    * @param targetPosition

--- a/addon/model/util/string-utils.ts
+++ b/addon/model/util/string-utils.ts
@@ -1,0 +1,6 @@
+export default class StringUtils {
+
+  static isAllWhiteSpace(text: string): boolean {
+    return !(/[^\t\n\r \u00A0]/.test(text));
+  }
+}

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -34,6 +34,7 @@ import RichNode from "@lblod/marawa/rich-node";
 import classic from 'ember-classic-decorator';
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import InsertXmlCommand from "@lblod/ember-rdfa-editor/commands/insert-xml-command";
+import InsertTextCommand from "@lblod/ember-rdfa-editor/commands/insert-text-command";
 
 /**
  * Raw contenteditable editor. This acts as both the internal and external API to the DOM.
@@ -110,6 +111,7 @@ class RawEditor extends EmberObject {
     this.registerCommand(new RemoveTableCommand(this.model));
     this.registerCommand(new InsertHtmlCommand(this.model));
     this.registerCommand(new InsertXmlCommand(this.model));
+    this.registerCommand(new InsertTextCommand(this.model));
   }
 
   /**

--- a/addon/utils/errors.ts
+++ b/addon/utils/errors.ts
@@ -1,3 +1,5 @@
+import {Manipulation} from "@lblod/ember-rdfa-editor/editor/input-handlers/manipulation";
+
 abstract class CustomError extends Error {
   constructor(message?: string) {
     super(message);
@@ -104,6 +106,11 @@ export class ParseError extends CustomError {}
  */
 export class IllegalArgumentError extends CustomError {}
 
+export class UnsupportedManipulationError extends CustomError {
+  constructor(manipulation: Manipulation) {
+    super(`Manipulation with type ${manipulation.type} not supported here.`);
+  }
+}
 
 /**
  * Thrown when an object or map does not have the expected key

--- a/addon/utils/plugins/anchor-tags/text-input-plugin.ts
+++ b/addon/utils/plugins/anchor-tags/text-input-plugin.ts
@@ -15,24 +15,32 @@ export default class AnchorTagTextInputPlugin implements TextInputPlugin {
       const clonedRange = range.clone();
       const collapsed = clonedRange.collapsed;
       const {start, end, start: {parent: startParent}, end: {parent: endParent}} = clonedRange;
+      let anyAnchors = false;
 
       if (startParent.type === "a" && start.parentOffset === 0) {
+        anyAnchors = true;
         clonedRange.start = ModelPosition.fromBeforeNode(startParent);
         if (collapsed) {
           clonedRange.collapse(true);
         }
       }
       if (endParent.type === "a" && end.parentOffset === endParent.getMaxOffset()) {
+        anyAnchors = true;
         clonedRange.end = ModelPosition.fromAfterNode(endParent);
         if (collapsed) {
           clonedRange.collapse();
         }
       }
-      return {
-        allow: true, executor: (_, rawEditor: PernetRawEditor) => {
-          rawEditor.executeCommand("insert-text", text, clonedRange);
-        }
-      };
+      if(anyAnchors) {
+        return {
+          allow: true, executor: (_, rawEditor: PernetRawEditor) => {
+            rawEditor.executeCommand("insert-text", text, clonedRange);
+          }
+        };
+
+      } else {
+        return null;
+      }
     }
     return null;
   }

--- a/addon/utils/plugins/br-skipping/backspace-plugin.ts
+++ b/addon/utils/plugins/br-skipping/backspace-plugin.ts
@@ -1,6 +1,8 @@
-import {BackspacePlugin} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
 import {
-  Manipulation,
+  BackspaceHandlerManipulation,
+  BackspacePlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
+import {
   ManipulationGuidance,
   MoveCursorToEndOfElementManipulation
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
@@ -18,7 +20,7 @@ function isBr(node: Node): boolean {
 export default class BrSkippingBackspacePlugin implements BackspacePlugin {
   label = "This plugin jumps over brs where necessary";
 
-  guidanceForManipulation(manipulation: Manipulation): ManipulationGuidance | null {
+  guidanceForManipulation(manipulation: BackspaceHandlerManipulation): ManipulationGuidance | null {
     if (manipulation.type == "moveCursorToEndOfElement") {
       const element = manipulation.node ;
       if (window.getComputedStyle(element).display == "block") {

--- a/addon/utils/plugins/contenteditable-false/backspace-plugin.ts
+++ b/addon/utils/plugins/contenteditable-false/backspace-plugin.ts
@@ -1,6 +1,8 @@
-import {BackspacePlugin} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
 import {
-  Manipulation,
+  BackspaceHandlerManipulation,
+  BackspacePlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
+import {
   ManipulationGuidance,
   MoveCursorToEndOfElementManipulation
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
@@ -12,7 +14,7 @@ import {editorDebug, moveCaretBefore} from '@lblod/ember-rdfa-editor/editor/util
 export default class ContentEditableFalseBackspacePlugin implements BackspacePlugin {
   label = "backspace plugin to remove empty elements instead of jumping in";
 
-  guidanceForManipulation(manipulation: Manipulation) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation: BackspaceHandlerManipulation) : ManipulationGuidance | null {
     if (manipulation.type == "moveCursorToEndOfElement") {
       editorDebug(`plugins.contenteditable-false.guidanceForManipulation`, 'possible jump before element', manipulation.node);
       const element = manipulation.node ;

--- a/addon/utils/plugins/empty-element/backspace-plugin.ts
+++ b/addon/utils/plugins/empty-element/backspace-plugin.ts
@@ -1,4 +1,7 @@
-import { BackspacePlugin } from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
+import {
+  BackspaceHandlerManipulation,
+  BackspacePlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
 import { Editor,
          Manipulation,
          ManipulationGuidance,
@@ -11,7 +14,7 @@ import { moveCaretBefore } from '@lblod/ember-rdfa-editor/editor/utils';
 export default class EmptyElementBackspacePlugin implements BackspacePlugin {
   label = "backspace plugin to remove empty elements instead of jumping in";
 
-  guidanceForManipulation(manipulation: Manipulation) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation: BackspaceHandlerManipulation) : ManipulationGuidance | null {
     if (manipulation.type == "moveCursorToEndOfElement") {
       const element = manipulation.node ;
       if (element.innerText.length == 0) {

--- a/addon/utils/plugins/empty-text-node/backspace-plugin.ts
+++ b/addon/utils/plugins/empty-text-node/backspace-plugin.ts
@@ -2,7 +2,10 @@ import { Editor,
          Manipulation,
          ManipulationGuidance,
          RemoveCharacterManipulation } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
-import { BackspacePlugin }  from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
+import {
+  BackspaceHandlerManipulation,
+  BackspacePlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
 import { invisibleSpace } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 import { moveCaretBefore, moveCaret, stringToVisibleText } from '@lblod/ember-rdfa-editor/editor/utils';
 /**
@@ -14,7 +17,7 @@ import { moveCaretBefore, moveCaret, stringToVisibleText } from '@lblod/ember-rd
 export default class EmptyTextNodeBackspacePlugin implements BackspacePlugin {
   label = "backspace plugin for properly handling empty text nodes";
 
-  guidanceForManipulation(manipulation : Manipulation) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation : BackspaceHandlerManipulation) : ManipulationGuidance | null {
     if (manipulation.type == "removeCharacter") {
       if (manipulation.position == 0 && manipulation.node.textContent?.length == 1) {
         return {

--- a/addon/utils/plugins/lists/backspace-plugin.ts
+++ b/addon/utils/plugins/lists/backspace-plugin.ts
@@ -1,12 +1,14 @@
 import {
   MoveCursorToEndOfElementManipulation,
   ManipulationGuidance,
-  Manipulation,
   Editor,
   RemoveEmptyElementManipulation,
   RemoveElementWithChildrenThatArentVisible,
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
-import { BackspacePlugin } from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
+import {
+  BackspaceHandlerManipulation,
+  BackspacePlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
 import { runInDebug } from '@ember/debug';
 import { findLastLi, tagName } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 
@@ -27,7 +29,7 @@ type ElementRemovalManipulation = RemoveEmptyElementManipulation | RemoveElement
 export default class ListBackspacePlugin implements BackspacePlugin {
   label = 'backspace plugin for handling lists';
 
-  guidanceForManipulation(manipulation: Manipulation): ManipulationGuidance | null {
+  guidanceForManipulation(manipulation: BackspaceHandlerManipulation): ManipulationGuidance | null {
     if (manipulation.type == "removeEmptyElement" || manipulation.type == "removeElementWithChildrenThatArentVisible") {
       /*
        * removing an (empty-ish) list item
@@ -141,7 +143,7 @@ export default class ListBackspacePlugin implements BackspacePlugin {
    * The executor will remove both list and list item, but keep the contents of the list item. the cursor will be positioned before the first child node of the list item.
    * @method removeListItemAndListButKeepContent
    */
-  removeListItemAndListButKeepContent = (manipulation: Manipulation, editor: Editor) => {
+  removeListItemAndListButKeepContent = (manipulation: BackspaceHandlerManipulation, editor: Editor) => {
     let element;
 
     if(manipulation.type == 'moveCursorBeforeElement'){
@@ -169,7 +171,7 @@ export default class ListBackspacePlugin implements BackspacePlugin {
    * The executor will move the contents of the first list item before the list and remove the list item. the cursor will be positioned before the first child node of the list item.
    * @method removeListItemAndMoveContentBeforeList
    */
-  removeListItemAndMoveContentBeforeList = (manipulation: Manipulation, editor: Editor) => {
+  removeListItemAndMoveContentBeforeList = (manipulation: BackspaceHandlerManipulation, editor: Editor) => {
     let element;
 
     if(manipulation.type == 'moveCursorBeforeElement'){
@@ -197,7 +199,7 @@ export default class ListBackspacePlugin implements BackspacePlugin {
    * The executor will move the content of the list item to its previous sibling and position the cursor before the first child node of the list item (at the end of the original content of the previous sibling). the list item is removed.
    * @method mergeWithPreviousLi
    */
-  mergeWithPreviousLi = (manipulation: Manipulation, editor: Editor): void => {
+  mergeWithPreviousLi = (manipulation: BackspaceHandlerManipulation, editor: Editor): void => {
     let element;
 
     if(manipulation.type == 'moveCursorBeforeElement'){
@@ -293,7 +295,7 @@ export default class ListBackspacePlugin implements BackspacePlugin {
    * currently signals a change when an li has been removed during a "moveCursorBeforeElement" , "removeEmptyElement" or "removeElementWithChildrenThatArentVisible" manipulation.
    * @method detectChange
    */
-  detectChange(manipulation: Manipulation): boolean {
+  detectChange(manipulation: BackspaceHandlerManipulation): boolean {
     if (["removeEmptyElement", "moveCursorBeforeElement", "removeElementWithChildrenThatArentVisible"].includes(manipulation.type)) {
       const element = manipulation.node as Element;
       if (tagName(element) == "li") {

--- a/addon/utils/plugins/lists/delete-plugin.ts
+++ b/addon/utils/plugins/lists/delete-plugin.ts
@@ -28,7 +28,7 @@ import {
   moveCaretToEndOfNode,
 } from "@lblod/ember-rdfa-editor/editor/utils";
 import { isInList } from "../../ce/list-helpers";
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function debug(message: string, object: unknown = null): void {
@@ -73,7 +73,7 @@ export default class ListDeletePlugin implements DeletePlugin {
     if (this.isAnyListNode(manipulation.node)) {
       const dispatch = (
         manipulation: RemoveBoundaryBackwards,
-        editor: LegacyRawEditor
+        editor: PernetRawEditor
       ) => {
         this.mergeBackwards(manipulation.node, editor);
       };
@@ -87,7 +87,7 @@ export default class ListDeletePlugin implements DeletePlugin {
     if (this.isAnyListNode(manipulation.node)) {
       const dispatch = (
         manipulation: RemoveBoundaryForwards,
-        editor: LegacyRawEditor
+        editor: PernetRawEditor
       ) => {
         this.mergeForwards(manipulation.node, editor);
       };
@@ -107,7 +107,7 @@ export default class ListDeletePlugin implements DeletePlugin {
     if (this.isAnyListNode(manipulation.node)) {
       const dispatcher = (
         manipulation: RemoveEmptyElementManipulation,
-        editor: LegacyRawEditor
+        editor: PernetRawEditor
       ) => {
         this.mergeForwards(manipulation.node, editor);
       };
@@ -121,7 +121,7 @@ export default class ListDeletePlugin implements DeletePlugin {
    * @param node the node which will be merged into the previous one
    * @param editor The editor instance
    */
-  private mergeBackwards(node: Node, editor: LegacyRawEditor) {
+  private mergeBackwards(node: Node, editor: PernetRawEditor) {
     const baseNode = this.findNodeBefore(node, editor.rootNode);
     const nodeToMerge = this.getDeepestFirstDescendant(node);
 
@@ -148,7 +148,7 @@ export default class ListDeletePlugin implements DeletePlugin {
    * @param node The node to merge into
    * @param editor The editor instance
    */
-  private mergeForwards(node: Node, editor: LegacyRawEditor) {
+  private mergeForwards(node: Node, editor: PernetRawEditor) {
 
     const mergeNode = this.getDeepestLastDescendant(node);
     let cursorPosition = 0;

--- a/addon/utils/plugins/lists/delete-plugin.ts
+++ b/addon/utils/plugins/lists/delete-plugin.ts
@@ -1,9 +1,9 @@
 import {
+  DeleteHandlerManipulation,
   DeletePlugin,
   MagicSpan,
 } from "@lblod/ember-rdfa-editor/editor/input-handlers/delete-handler";
 import {
-  Manipulation,
   ManipulationGuidance,
   RemoveEmptyElementManipulation,
   RemoveElementWithChildrenThatArentVisible,
@@ -47,7 +47,7 @@ export default class ListDeletePlugin implements DeletePlugin {
   hasChanged = false;
 
   guidanceForManipulation(
-    manipulation: Manipulation
+    manipulation: DeleteHandlerManipulation
   ): ManipulationGuidance | null {
     this.hasChanged = false;
     if (manipulation.type === "removeBoundaryBackwards") {

--- a/addon/utils/plugins/lists/tab-input-plugin.ts
+++ b/addon/utils/plugins/lists/tab-input-plugin.ts
@@ -1,4 +1,4 @@
-import { TabInputPlugin } from '@lblod/ember-rdfa-editor/editor/input-handlers/tab-handler';
+import {TabHandlerManipulation, TabInputPlugin} from '@lblod/ember-rdfa-editor/editor/input-handlers/tab-handler';
 import { Editor, Manipulation, ManipulationGuidance } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
 import { isList,
          isLI,
@@ -24,7 +24,7 @@ import { ensureValidTextNodeForCaret } from '@lblod/ember-rdfa-editor/editor/uti
 export default class ListTabInputPlugin implements TabInputPlugin {
   label = 'Tap input plugin for handling List interaction';
 
-  guidanceForManipulation(manipulation : Manipulation) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation : TabHandlerManipulation) : ManipulationGuidance | null {
     if( manipulation.type == 'moveCursorToStartOfElement' ){
       if(isList(manipulation.node)){
         return { allow: true, executor: this.jumpIntoFirstLi };
@@ -90,7 +90,7 @@ export default class ListTabInputPlugin implements TabInputPlugin {
   /**
    * Sets the cursor in the first <li></li>. If list is empty, creates an <li></li>
    */
-  jumpIntoFirstLi = (manipulation: Manipulation, editor: Editor): void => {
+  jumpIntoFirstLi = (manipulation: TabHandlerManipulation, editor: Editor): void => {
     const list = manipulation.node as HTMLUListElement | HTMLOListElement;
     let firstLi;
 
@@ -108,7 +108,7 @@ export default class ListTabInputPlugin implements TabInputPlugin {
   /**
    * Sets the cursor in the last <li></li>. If list is empty, creates an <li></li>
    */
-  jumpIntoLastLi = (manipulation: Manipulation, editor: Editor): void => {
+  jumpIntoLastLi = (manipulation: TabHandlerManipulation, editor: Editor): void => {
     const list = manipulation.node as HTMLUListElement | HTMLOListElement;
     let lastLi;
 
@@ -128,7 +128,7 @@ export default class ListTabInputPlugin implements TabInputPlugin {
    * Note: depends on list helpers from a long time ago.
    * TODO: Indent means the same as nested list, perhaps rename the action
    */
-  indentLiContent = (_: Manipulation, editor: Editor): void => {
+  indentLiContent = (_: TabHandlerManipulation, editor: Editor): void => {
     indentAction(editor); //TODO: this is legacy, this should be revisited.
   };
 
@@ -137,14 +137,14 @@ export default class ListTabInputPlugin implements TabInputPlugin {
    * Note: depends on list helpers from a long time ago.
    * TODO: Indent means the same as merge nested list, perhaps rename the action
    */
-  unindentLiContent = (_: Manipulation, editor: Editor): void => {
+  unindentLiContent = (_: TabHandlerManipulation, editor: Editor): void => {
     unindentAction(editor); //TODO: this is legacy, this should be revisited.
   };
 
   /*
    * Jumps to next List item. Assumes there is one and current LI is not the last
    */
-  jumpToNextLi = (manipulation: Manipulation, editor: Editor): void => {
+  jumpToNextLi = (manipulation: TabHandlerManipulation, editor: Editor): void => {
     //Assumes the LI is not the last one
     const listItem = manipulation.node as HTMLLIElement;
     const listItems = siblingLis(listItem);
@@ -155,7 +155,7 @@ export default class ListTabInputPlugin implements TabInputPlugin {
   /*
    * Jumps to next List item. Assumes there is one and current LI is not the first
    */
-  jumpToPreviousLi = (manipulation: Manipulation, editor: Editor): void => {
+  jumpToPreviousLi = (manipulation: TabHandlerManipulation, editor: Editor): void => {
     //Assumes the LI is not the last one
     const listItem = manipulation.node as HTMLLIElement;
     const listItems = siblingLis(listItem);
@@ -166,7 +166,7 @@ export default class ListTabInputPlugin implements TabInputPlugin {
   /*
    * Jumps outside of list.
    */
-  jumpOutOfList = (manipulation: Manipulation, editor: Editor): void => {
+  jumpOutOfList = (manipulation: TabHandlerManipulation, editor: Editor): void => {
     const element = manipulation.node.parentElement; //this is the list
     if(!element) throw 'Tab-input-handler expected list to be attached to DOM';
 
@@ -187,7 +187,7 @@ export default class ListTabInputPlugin implements TabInputPlugin {
   /*
    * Jumps outside of at the start
    */
-  jumpOutOfListToStart = (manipulation: Manipulation, editor: Editor): void => {
+  jumpOutOfListToStart = (manipulation: TabHandlerManipulation, editor: Editor): void => {
     const element = manipulation.node.parentElement; //this is the list
     if(!element) throw 'Tab-input-handler expected list to be attached to DOM';
 

--- a/addon/utils/plugins/lump-node/backspace-plugin.ts
+++ b/addon/utils/plugins/lump-node/backspace-plugin.ts
@@ -1,4 +1,7 @@
-import { BackspacePlugin } from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
+import {
+  BackspaceHandlerManipulation,
+  BackspacePlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
 import { Editor, Manipulation, ManipulationGuidance } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
 import { isInLumpNode, getParentLumpNode } from '@lblod/ember-rdfa-editor/utils/ce/lump-node-utils';
 
@@ -24,7 +27,7 @@ const SUPPORTED_MANIPULATIONS = [
 export default class LumpNodeBackspacePlugin implements BackspacePlugin {
   label = 'backspace plugin for handling LumpNodes';
 
-  guidanceForManipulation(manipulation : Manipulation) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation : BackspaceHandlerManipulation) : ManipulationGuidance | null {
     //TODO: fix case.manipulation.node == lumpnode
     const node = manipulation.node;
     const rootNode = node.getRootNode(); //Assuming here that node is attached.
@@ -61,7 +64,7 @@ export default class LumpNodeBackspacePlugin implements BackspacePlugin {
    * It assumes manipulation.node is located in a LumpNode
    * @method removeLumpNode
    */
-  removeLumpNode = ( manipulation: Manipulation, editor: Editor ): void => {
+  removeLumpNode = ( manipulation: BackspaceHandlerManipulation, editor: Editor ): void => {
     const node = manipulation.node;
     const rootNode = node.getRootNode();
     const lumpNode = getParentLumpNode(node, rootNode) as ChildNode;
@@ -79,7 +82,7 @@ export default class LumpNodeBackspacePlugin implements BackspacePlugin {
    * Other cases, we rely on the detectVisualChange from backspace handler
    * @method detectChange
    */
-  detectChange( manipulation: Manipulation ) : boolean {
+  detectChange( manipulation: BackspaceHandlerManipulation ) : boolean {
     const node = manipulation.node;
     const rootNode = node.getRootNode();
 
@@ -117,7 +120,7 @@ export default class LumpNodeBackspacePlugin implements BackspacePlugin {
    * Flags the LumpNode for removal.
    * @method flagForRemoval
    */
-  flagForRemoval = ( manipulation: Manipulation): void => {
+  flagForRemoval = ( manipulation: BackspaceHandlerManipulation): void => {
     const node = manipulation.node;
     const rootNode = node.getRootNode();
     const lumpNode = getParentLumpNode(node, rootNode) as Element;

--- a/addon/utils/plugins/lump-node/tab-input-plugin.ts
+++ b/addon/utils/plugins/lump-node/tab-input-plugin.ts
@@ -1,4 +1,4 @@
-import { TabInputPlugin } from '@lblod/ember-rdfa-editor/editor/input-handlers/tab-handler';
+import {TabHandlerManipulation, TabInputPlugin} from '@lblod/ember-rdfa-editor/editor/input-handlers/tab-handler';
 import { Editor, Manipulation, ManipulationGuidance } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
 import { isInLumpNode, getParentLumpNode } from '@lblod/ember-rdfa-editor/utils/ce/lump-node-utils';
 import { ensureValidTextNodeForCaret } from '@lblod/ember-rdfa-editor/editor/utils';
@@ -16,12 +16,12 @@ export default class LumpNodeTabInputPlugin implements TabInputPlugin {
       || manipulation.type  === 'moveCursorToEndOfElement';
   }
 
-  guidanceForManipulation(manipulation : Manipulation) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation : TabHandlerManipulation) : ManipulationGuidance | null {
     if( !this.isSupportedManipulation(manipulation) ){
       return null;
     }
 
-    const element = manipulation.node as HTMLElement;
+    const element = manipulation.node;
     const rootNode = element.getRootNode(); //Assuming here that node is attached.
     const isElementInLumpNode = isInLumpNode(element, rootNode);
 
@@ -41,7 +41,7 @@ export default class LumpNodeTabInputPlugin implements TabInputPlugin {
     return null;
   }
 
-  jumpOverLumpNode = (manipulation: Manipulation, editor: Editor): void => {
+  jumpOverLumpNode = (manipulation: TabHandlerManipulation, editor: Editor): void => {
     const element = getParentLumpNode(manipulation.node, manipulation.node.getRootNode()) as HTMLElement; //we can safely assume this
     let textNode;
     if(element.nextSibling && element.nextSibling.nodeType == Node.TEXT_NODE){
@@ -56,7 +56,7 @@ export default class LumpNodeTabInputPlugin implements TabInputPlugin {
     editor.setCaret(textNode, 0);
   };
 
-  jumpOverLumpNodeBackwards = (manipulation: Manipulation, editor: Editor ): void => {
+  jumpOverLumpNodeBackwards = (manipulation: TabHandlerManipulation, editor: Editor ): void => {
     const element = getParentLumpNode(manipulation.node, manipulation.node.getRootNode()) as HTMLElement; //we can safely assume this
     let textNode;
     if(element.previousSibling && element.previousSibling.nodeType == Node.TEXT_NODE){

--- a/addon/utils/plugins/placeholder-text/backspace-plugin.ts
+++ b/addon/utils/plugins/placeholder-text/backspace-plugin.ts
@@ -1,5 +1,8 @@
-import { BackspacePlugin } from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
-import { Editor, Manipulation, ManipulationGuidance } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
+import {
+  BackspaceHandlerManipulation,
+  BackspacePlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
+import { Editor, ManipulationGuidance } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
 import { invisibleSpace } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 
 /**
@@ -10,7 +13,7 @@ import { invisibleSpace } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 export default class PlaceholderTextBackspacePlugin implements BackspacePlugin {
   label = 'backspace plugin for handling placeholder nodes';
 
-  guidanceForManipulation(manipulation : Manipulation) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation : BackspaceHandlerManipulation) : ManipulationGuidance | null {
     const node = manipulation.node;
     const parentNode = node.parentElement;
     if(parentNode && parentNode.classList.contains('mark-highlight-manual')) {
@@ -26,7 +29,7 @@ export default class PlaceholderTextBackspacePlugin implements BackspacePlugin {
    * This executor removes the placeholder node containing manipulation.node competly.
    * @method removePlaceholder
    */
-  removePlaceholder = (manipulation: Manipulation, editor: Editor): void => {
+  removePlaceholder = (manipulation: BackspaceHandlerManipulation, editor: Editor): void => {
     const node = manipulation.node;
     const parentNode = node.parentElement;
     if(parentNode) {
@@ -42,7 +45,7 @@ export default class PlaceholderTextBackspacePlugin implements BackspacePlugin {
    * Returns true explicitly when it detects the manipulation.node is inside a placeholder node.
    * @method detectChange
    */
-  detectChange( manipulation: Manipulation ) : boolean {
+  detectChange( manipulation: BackspaceHandlerManipulation ) : boolean {
     const node = manipulation.node;
     const parentNode = node.parentElement;
     if(parentNode && parentNode.classList.contains('mark-highlight-manual')) {

--- a/addon/utils/plugins/placeholder-text/text-input-plugin.ts
+++ b/addon/utils/plugins/placeholder-text/text-input-plugin.ts
@@ -1,12 +1,13 @@
-import { TextInputPlugin } from '@lblod/ember-rdfa-editor/editor/input-handlers/text-input-handler';
-import { Editor,
-         Manipulation,
-         ManipulationGuidance,
-         InsertTextIntoTextNodeManipulation,
-         InsertTextIntoElementManipulation
-       } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
+import {
+  TextHandlerManipulation,
+  TextInputPlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/text-input-handler';
+import {ManipulationGuidance} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
+import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
+import ModelPosition from '@lblod/ember-rdfa-editor/model/model-position';
 
-const NON_BREAKING_SPACE = '\u00A0';
+const PLACEHOLDER_CLASS = "mark-highlight-manual";
 /**
  * @class PlaceholderTextInputPlugin
  * @module plugins/placeholder-text
@@ -14,32 +15,32 @@ const NON_BREAKING_SPACE = '\u00A0';
 export default class PlaceholderTextInputPlugin implements TextInputPlugin {
   label = 'text input plugin for handling RDFA specific logic';
 
-  guidanceForManipulation(manipulation : Manipulation) : ManipulationGuidance | null {
-    return null;
-    const node = manipulation.node;
-    const parentNode = node.parentElement;
-    if(parentNode && parentNode.classList.contains('mark-highlight-manual')) {
-      return {
-        allow: true,
-        executor: this.replacePlaceHolder
-      };
-    }
-    return null;
-  }
 
-  /**
-   * This executor replaces the placeholder node with a text node containing the provided input
-   * @method removePlaceholder
-   */
-  replacePlaceHolder = (manipulation: (InsertTextIntoTextNodeManipulation | InsertTextIntoElementManipulation), editor: Editor): void => {
-    const node = manipulation.node;
-    if (node.parentElement) {
-      const parent = node.parentElement;
-      const text = manipulation.text == " " ? NON_BREAKING_SPACE : manipulation.text;
-      const textNode = document.createTextNode(text);
-      parent.replaceWith(textNode);
-      editor.updateRichNode();
-      editor.setCaret(textNode, textNode.length);
+  guidanceForManipulation(manipulation: TextHandlerManipulation): ManipulationGuidance | null {
+    const {range: originalRange, text} = manipulation;
+    const range = originalRange.clone();
+
+    let anyPlaceholder = false;
+    if (isPlaceHolder(range.start.parent)) {
+      range.start = ModelPosition.fromBeforeNode(range.start.parent);
+      anyPlaceholder = true;
     }
-  };
+    if (isPlaceHolder(range.end.parent)) {
+      range.end = ModelPosition.fromAfterNode(range.end.parent);
+      anyPlaceholder = true;
+    }
+    if (anyPlaceholder) {
+      return {
+        allow: true, executor: (_, rawEditor: PernetRawEditor) => {
+          rawEditor.executeCommand("insert-text", text, range);
+        }
+      };
+    } else {
+      return null;
+    }
+  }
+}
+
+function isPlaceHolder(element: ModelElement): boolean {
+  return !!element.getAttribute("class")?.includes(PLACEHOLDER_CLASS);
 }

--- a/addon/utils/plugins/placeholder-text/text-input-plugin.ts
+++ b/addon/utils/plugins/placeholder-text/text-input-plugin.ts
@@ -15,6 +15,7 @@ export default class PlaceholderTextInputPlugin implements TextInputPlugin {
   label = 'text input plugin for handling RDFA specific logic';
 
   guidanceForManipulation(manipulation : Manipulation) : ManipulationGuidance | null {
+    return null;
     const node = manipulation.node;
     const parentNode = node.parentElement;
     if(parentNode && parentNode.classList.contains('mark-highlight-manual')) {

--- a/addon/utils/plugins/rdfa/backspace-plugin.ts
+++ b/addon/utils/plugins/rdfa/backspace-plugin.ts
@@ -1,6 +1,8 @@
-import { BackspacePlugin } from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
+import {
+  BackspaceHandlerManipulation,
+  BackspacePlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
 import { Editor,
-         Manipulation,
          ManipulationGuidance
        } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
 import NodeWalker from '@lblod/marawa/node-walker';
@@ -59,7 +61,7 @@ export default class RdfaBackspacePlugin implements BackspacePlugin {
   label = 'backspace plugin for handling RDFA specific logic';
 
 
-  guidanceForManipulation(manipulation : Manipulation) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation : BackspaceHandlerManipulation) : ManipulationGuidance | null {
     if(this.needsRemoveStep(manipulation)){
       return {
         allow: true,
@@ -88,7 +90,7 @@ export default class RdfaBackspacePlugin implements BackspacePlugin {
    * This will require from the user to press backspace once more to remove the element.
    * @method detectChange
    */
-  detectChange( manipulation: Manipulation ) : boolean {
+  detectChange( manipulation: BackspaceHandlerManipulation ) : boolean {
     if(this.isManipulationSupportedFor(SUPPORTED_TEXT_NODE_MANIPULATIONS, manipulation)){
 
       const node = manipulation.node;
@@ -116,7 +118,7 @@ export default class RdfaBackspacePlugin implements BackspacePlugin {
    * Note: this is only done on TextNode operations for now.
    * It feels like such flow for emptyElements would feel cumbersome. (And add complexity)
    */
-  needsAlmostCompleteStep(manipulation: Manipulation) : boolean {
+  needsAlmostCompleteStep(manipulation: BackspaceHandlerManipulation) : boolean {
     const node = manipulation.node;
     const parent = node.parentElement;
 
@@ -134,7 +136,7 @@ export default class RdfaBackspacePlugin implements BackspacePlugin {
   /**
    * Tests whether the 'last call' flag may be added
    */
-  needsCompleteStep(manipulation: Manipulation) : boolean {
+  needsCompleteStep(manipulation: BackspaceHandlerManipulation) : boolean {
     if(this.isManipulationSupportedFor(SUPPORTED_TEXT_NODE_MANIPULATIONS, manipulation)){
       const node = manipulation.node;
       const parent = node.parentElement;
@@ -159,7 +161,7 @@ export default class RdfaBackspacePlugin implements BackspacePlugin {
   /**
    * Tests whether the element should be removed, after having given all the warnings.
    */
-  needsRemoveStep(manipulation: Manipulation) : boolean {
+  needsRemoveStep(manipulation: BackspaceHandlerManipulation) : boolean {
     if(this.isManipulationSupportedFor(SUPPORTED_TEXT_NODE_MANIPULATIONS, manipulation)){
       const node = manipulation.node;
       const parent = node.parentElement;
@@ -186,7 +188,7 @@ export default class RdfaBackspacePlugin implements BackspacePlugin {
    * Note: this is only done on TextNode operations for now.
    * (again) It feels like such flow for emptyElements would feel cumbersome. (And add complexity)
    */
-  executeAlmostCompleteStep = (manipulation: Manipulation): void => {
+  executeAlmostCompleteStep = (manipulation: BackspaceHandlerManipulation): void => {
     const node = manipulation.node;
     const parent = node.parentElement;
 
@@ -199,7 +201,7 @@ export default class RdfaBackspacePlugin implements BackspacePlugin {
    * For textNode manipulations, removes the last visible text node and adds `data-flagged-remove=complete` to the parent.
    * For empty element manipulation, just adds `data-flagged-remove=complete`
    */
-  executeCompleteStep = (manipulation: Manipulation, editor: Editor ): void => {
+  executeCompleteStep = (manipulation: BackspaceHandlerManipulation, editor: Editor ): void => {
     const node = manipulation.node;
     const parent = node.parentElement;
 
@@ -219,7 +221,7 @@ export default class RdfaBackspacePlugin implements BackspacePlugin {
   /*
    * Last step. The rdfa element is removed.
    */
-  executeRemoveStep = (manipulation: Manipulation, editor: Editor ): void => {
+  executeRemoveStep = (manipulation: BackspaceHandlerManipulation, editor: Editor ): void => {
     let removedElement;
     let updatedSelection;
 
@@ -338,7 +340,7 @@ export default class RdfaBackspacePlugin implements BackspacePlugin {
     }
   }
 
-  isManipulationSupportedFor(manipulationTypes: Array<string>, manipulation : Manipulation) : boolean {
+  isManipulationSupportedFor(manipulationTypes: Array<string>, manipulation : BackspaceHandlerManipulation) : boolean {
     return manipulationTypes.some(manipulationType => manipulationType === manipulation.type );
   }
 

--- a/addon/utils/plugins/rdfa/text-input-plugin.ts
+++ b/addon/utils/plugins/rdfa/text-input-plugin.ts
@@ -2,17 +2,15 @@ import {
   TextHandlerManipulation,
   TextInputPlugin
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/text-input-handler';
-import {
-  ManipulationGuidance,
-} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
+import {ManipulationGuidance,} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
 import {stringToVisibleText} from '@lblod/ember-rdfa-editor/editor/utils';
-import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 import ModelTreeWalker, {toFilterSkipFalse} from "@lblod/ember-rdfa-editor/model/util/model-tree-walker";
 import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
 
-function updateDataFlaggedRemove(manipulation: TextHandlerManipulation, editor: LegacyRawEditor) {
+function updateDataFlaggedRemove(manipulation: TextHandlerManipulation, editor: PernetRawEditor) {
   const {range} = manipulation;
   const parent = range.start.parent;
   const textNodeWalker = new ModelTreeWalker<ModelText>({

--- a/addon/utils/plugins/rdfa/text-input-plugin.ts
+++ b/addon/utils/plugins/rdfa/text-input-plugin.ts
@@ -1,20 +1,22 @@
-import { TextInputPlugin, insertTextIntoTextNode } from '@lblod/ember-rdfa-editor/editor/input-handlers/text-input-handler';
-import { Editor,
-         Manipulation,
+import {
+  TextHandlerManipulation,
+  TextInputPlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/text-input-handler';
+import {
+  Editor,
+  Manipulation,
   ManipulationGuidance,
-  InsertTextIntoTextNodeManipulation
-       } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
-import { stringToVisibleText } from '@lblod/ember-rdfa-editor/editor/utils';
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
+import {stringToVisibleText} from '@lblod/ember-rdfa-editor/editor/utils';
 
-function updateDataFlaggedRemove(manipulation: InsertTextIntoTextNodeManipulation, editor: Editor) {
+function updateDataFlaggedRemove(manipulation: TextHandlerManipulation, editor: Editor) {
   const textNode = manipulation.node;
   const parent = textNode.parentElement;
   if (parent) {
-    const length =  stringToVisibleText(parent.innerText || "").length;
+    const length = stringToVisibleText(parent.innerText || "").length;
     if (length <= 2) {
       parent.setAttribute('data-flagged-remove', 'almost-complete');
-    }
-    else if (length > 2){
+    } else if (length > 2) {
       parent.removeAttribute('data-flagged-remove');
     }
   }
@@ -26,8 +28,8 @@ function updateDataFlaggedRemove(manipulation: InsertTextIntoTextNodeManipulatio
 export default class RdfaTextInputPlugin implements TextInputPlugin {
   label = 'text input plugin for handling RDFA specific logic';
 
-  guidanceForManipulation(manipulation: Manipulation) : ManipulationGuidance | null {
-    const { type, node } = manipulation;
+  guidanceForManipulation(manipulation: Manipulation): ManipulationGuidance | null {
+    const {type, node} = manipulation;
     if (type == "insertTextIntoTextNode" && node.parentElement?.getAttribute('data-flagged-remove')) {
       return {
         allow: true,

--- a/addon/utils/plugins/table/backspace-plugin.ts
+++ b/addon/utils/plugins/table/backspace-plugin.ts
@@ -1,5 +1,8 @@
-import {BackspacePlugin} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
-import {Manipulation, ManipulationGuidance} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
+import {
+  BackspaceHandlerManipulation,
+  BackspacePlugin
+} from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
+import {ManipulationGuidance} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
 import RawEditor from 'dummy/utils/ce/raw-editor';
 import {PropertyState} from "@lblod/ember-rdfa-editor/model/util/types";
 
@@ -11,7 +14,7 @@ import {PropertyState} from "@lblod/ember-rdfa-editor/model/util/types";
 export default class TableBackspacePlugin implements BackspacePlugin {
   label = 'backspace plugin for handling table nodes';
 
-  guidanceForManipulation(manipulation: Manipulation, editor: RawEditor) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation: BackspaceHandlerManipulation, editor: RawEditor) : ManipulationGuidance | null {
     const voidExecutor = {
       allow: false,
       executor: undefined
@@ -37,7 +40,7 @@ export default class TableBackspacePlugin implements BackspacePlugin {
    * If the handler has been executed we had done nothing so we should return true if not we return false.
    * @method detectChange
    */
-  detectChange(manipulation: Manipulation, editor: RawEditor) : boolean {
+  detectChange(manipulation: BackspaceHandlerManipulation, editor: RawEditor) : boolean {
     const selection = editor.selection;
     if(selection.inTableState === PropertyState.enabled) {
       if(manipulation.type === 'moveCursorBeforeElement' || manipulation.type === 'removeEmptyElement') {

--- a/addon/utils/plugins/table/tab-input-plugin.ts
+++ b/addon/utils/plugins/table/tab-input-plugin.ts
@@ -1,6 +1,5 @@
-import { TabInputPlugin } from '@lblod/ember-rdfa-editor/editor/input-handlers/tab-handler';
+import {TabHandlerManipulation, TabInputPlugin} from '@lblod/ember-rdfa-editor/editor/input-handlers/tab-handler';
 import {
-  Manipulation,
   ManipulationGuidance
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
 import RawEditor from 'dummy/utils/ce/raw-editor';
@@ -20,7 +19,7 @@ import PernetRawEditor from '../../ce/pernet-raw-editor';
 export default class TableTabInputPlugin implements TabInputPlugin {
   label = 'backspace plugin for handling table nodes';
 
-  guidanceForManipulation(manipulation: Manipulation, editor: RawEditor) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation: TabHandlerManipulation, editor: RawEditor) : ManipulationGuidance | null {
     const selection = editor.selection;
     if(selection.inTableState === PropertyState.enabled) {
       return {
@@ -51,7 +50,7 @@ export default class TableTabInputPlugin implements TabInputPlugin {
     return tagName(element) === 'table';
   }
 
-  static selectFirstCell(manipulation : Manipulation, editor: PernetRawEditor) {
+  static selectFirstCell(manipulation : TabHandlerManipulation, editor: PernetRawEditor) {
     const table = editor.model.getModelNodeFor(manipulation.node) as ModelTable;
     const firstCell = table.getCell(0,0);
     if(firstCell) {
@@ -60,7 +59,7 @@ export default class TableTabInputPlugin implements TabInputPlugin {
     }
   }
 
-  static selectLastCell(manipulation : Manipulation, editor: PernetRawEditor) {
+  static selectLastCell(manipulation : TabHandlerManipulation, editor: PernetRawEditor) {
     const table = editor.model.getModelNodeFor(manipulation.node) as ModelTable;
     const {x, y} = table.getDimensions();
     const lastCell = table.getCell(x-1,y-1);
@@ -70,7 +69,7 @@ export default class TableTabInputPlugin implements TabInputPlugin {
     }
   }
 
-  static tabHandler(manipulation : Manipulation, editor: PernetRawEditor) {
+  static tabHandler(manipulation : TabHandlerManipulation, editor: PernetRawEditor) {
     let table;
     const selection = editor.selection;
     let selectedCell = ModelTable.getCellFromSelection(selection);

--- a/tests/unit/model/mutators/immediate-model-mutator-test.ts
+++ b/tests/unit/model/mutators/immediate-model-mutator-test.ts
@@ -449,4 +449,71 @@ module("Unit | model | mutators | immediate-model-mutator-test", hooks => {
       assert.true(resultRange.sameAs(ModelRange.fromPaths(initial as ModelElement, [1], [2])));
     });
   });
+  module("Unit | model | mutators | immediate-model-mutator-test | insertText", () => {
+    test("insert text into root", assert => {
+      // language=XML
+      const {root: initial} = vdom`
+        <modelRoot/>
+      `;
+
+      // language=XML
+      const {root: expected} = vdom`
+        <modelRoot>
+          <text>abc</text>
+        </modelRoot>
+      `;
+
+      const mut = new ImmediateModelMutator();
+      const range = ModelRange.fromInElement(initial as ModelElement, 0, 0);
+      const resultRange = mut.insertText(range, "abc");
+      assert.true(initial.sameAs(expected));
+      assert.true(resultRange.sameAs(ModelRange.fromInElement(initial as ModelElement, 3, 3)));
+
+    });
+
+    test("insert empty text into root", assert => {
+      // language=XML
+      const {root: initial} = vdom`
+        <modelRoot/>
+      `;
+
+      // language=XML
+      const {root: expected} = vdom`
+        <modelRoot>
+          <text/>
+        </modelRoot>
+      `;
+
+      const mut = new ImmediateModelMutator();
+      const range = ModelRange.fromInElement(initial as ModelElement, 0, 0);
+      const resultRange = mut.insertText(range, "");
+      assert.true(initial.sameAs(expected));
+      assert.true(resultRange.sameAs(ModelRange.fromInElement(initial as ModelElement, 0, 0)));
+
+    });
+
+    test("insert text into text node merges", assert => {
+      // language=XML
+      const {root: initial} = vdom`
+        <modelRoot>
+          <text>abef</text>
+        </modelRoot>
+      `;
+
+      // language=XML
+      const {root: expected} = vdom`
+        <modelRoot>
+          <text>abcdef</text>
+        </modelRoot>
+      `;
+
+      const mut = new ImmediateModelMutator();
+      const range = ModelRange.fromInElement(initial as ModelElement, 2, 2);
+      const resultRange = mut.insertText(range, "cd");
+      console.log(initial.toXml());
+      assert.true(initial.sameAs(expected));
+      assert.true(resultRange.sameAs(ModelRange.fromInElement(initial as ModelElement, 4, 4)));
+    });
+
+  });
 });


### PR DESCRIPTION
# Changes
## New features
- implement insertText mutator method, since I suspect we'll want this for multiple commands
- implement insert text command using that method
- rewrite the text-input handler to use the new command
- rewrite the existing handler pugins to use the command 
## Code cleanup
- Replace references to legacy raw editor with pernet
- rework typing structure of Manipulations to allow for easier extension and better type information (see #101 for a better overview)
- make the InputHandler basetype an abstract class instead of an interface, since the `checkManipulationsByPlugins` method was identical on all implementations of it.

# Comments

I'm still planning on doing the TODO comments, it just might take a while and I didn't want to block this PR cause it's fine for now (we cant depend on operation-only modifications yet anyway)