### PR TITLE
Use inserthtml for pasting

### DIFF
--- a/addon/components/ce/content-editable.js
+++ b/addon/components/ce/content-editable.js
@@ -291,7 +291,6 @@ export default class ContentEditable extends Component {
     }
     this.rawEditor.selection.lastRange.collapse();
     this.rawEditor.model.writeSelection();
-    this.rawEditor.updateRichNode();
     this.rawEditor.updateSelectionAfterComplexInput();
     this.rawEditor.generateDiffEvents.perform();
     return false;

--- a/addon/components/ce/content-editable.js
+++ b/addon/components/ce/content-editable.js
@@ -19,7 +19,6 @@ import LumpNodeMovementObserver from '../../utils/ce/movement-observers/lump-nod
 import HTMLInputParser from '../../utils/html-input-parser';
 import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
-import { createElementsFromHTML } from "@lblod/ember-rdfa-editor/utils/dom-helpers";
 import { PropertyState } from "@lblod/ember-rdfa-editor/model/util/types";
 import LegacyRawEditor from "@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor";
 import ModelRangeUtils from "@lblod/ember-rdfa-editor/model/util/model-range-utils";

--- a/addon/editor/input-handlers/backspace-handler.ts
+++ b/addon/editor/input-handlers/backspace-handler.ts
@@ -1,5 +1,5 @@
 import {warn} from '@ember/debug';
-import {getWindowSelection, isElement, isVoidElement, tagName} from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+import {isVoidElement} from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 import ListBackspacePlugin from '@lblod/ember-rdfa-editor/utils/plugins/lists/backspace-plugin';
 import LumpNodeBackspacePlugin from '@lblod/ember-rdfa-editor/utils/plugins/lump-node/backspace-plugin';
 import EmptyTextNodePlugin from '@lblod/ember-rdfa-editor/utils/plugins/empty-text-node/backspace-plugin';
@@ -11,11 +11,14 @@ import PlaceholderTextBackspacePlugin from '@lblod/ember-rdfa-editor/utils/plugi
 import TableBackspacePlugin from '@lblod/ember-rdfa-editor/utils/plugins/table/backspace-plugin';
 import {
   KeepCursorAtStartManipulation,
-  Manipulation, MoveCursorBeforeElementManipulation,
+  Manipulation,
+  MoveCursorBeforeElementManipulation,
   MoveCursorToEndOfElementManipulation,
-  RemoveCharacterManipulation, RemoveElementWithChildrenThatArentVisible,
+  RemoveCharacterManipulation,
+  RemoveElementWithChildrenThatArentVisible,
   RemoveEmptyElementManipulation,
-  RemoveEmptyTextNodeManipulation, RemoveOtherNodeManipulation,
+  RemoveEmptyTextNodeManipulation,
+  RemoveOtherNodeManipulation,
   RemoveVoidElementManipulation,
   VoidElement
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
@@ -30,7 +33,6 @@ import {
 } from '@lblod/ember-rdfa-editor/editor/utils';
 import RawEditor from "@lblod/ember-rdfa-editor/utils/ce/raw-editor";
 import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
-import {isInLumpNode} from "@lblod/ember-rdfa-editor/utils/ce/lump-node-utils";
 
 /**
  * Represents the coordinates of a DOMRect relative to RootNode of the editor.

--- a/addon/editor/input-handlers/backspace-handler.ts
+++ b/addon/editor/input-handlers/backspace-handler.ts
@@ -1,5 +1,5 @@
 import {warn} from '@ember/debug';
-import {isVoidElement} from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+import {getWindowSelection, isElement, isVoidElement, tagName} from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 import ListBackspacePlugin from '@lblod/ember-rdfa-editor/utils/plugins/lists/backspace-plugin';
 import LumpNodeBackspacePlugin from '@lblod/ember-rdfa-editor/utils/plugins/lump-node/backspace-plugin';
 import EmptyTextNodePlugin from '@lblod/ember-rdfa-editor/utils/plugins/empty-text-node/backspace-plugin';
@@ -30,6 +30,7 @@ import {
 } from '@lblod/ember-rdfa-editor/editor/utils';
 import RawEditor from "@lblod/ember-rdfa-editor/utils/ce/raw-editor";
 import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
+import {isInLumpNode} from "@lblod/ember-rdfa-editor/utils/ce/lump-node-utils";
 
 /**
  * Represents the coordinates of a DOMRect relative to RootNode of the editor.

--- a/addon/model/util/constants.ts
+++ b/addon/model/util/constants.ts
@@ -7,3 +7,4 @@ export const NON_BREAKING_SPACE = '\u00A0';
 export const SPACE = " ";
 export const INVISIBLE_SPACE='\u200B';
 export const HIGHLIGHT_ATTRIBUTE='data-editor-highlight';
+export const PLACEHOLDER_CLASS = "mark-highlight-manual";

--- a/addon/model/util/model-node-utils.ts
+++ b/addon/model/util/model-node-utils.ts
@@ -1,7 +1,7 @@
 import MapUtils from "@lblod/ember-rdfa-editor/model/util/map-utils";
 import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
-import {LIST_CONTAINERS} from "@lblod/ember-rdfa-editor/model/util/constants";
+import {LIST_CONTAINERS, PLACEHOLDER_CLASS} from "@lblod/ember-rdfa-editor/model/util/constants";
 
 export default class ModelNodeUtils {
   static DEFAULT_IGNORED_ATTRS: Set<string> = new Set(["__dummy_test_attr", "__id", "data-editor-position-level", "data-editor-rdfa-position-level"]);
@@ -26,5 +26,9 @@ export default class ModelNodeUtils {
 
   static isListContainer(node: ModelNode): node is ModelElement {
     return ModelNode.isModelElement(node) && LIST_CONTAINERS.has(node.type);
+  }
+
+  static isPlaceHolder(node: ModelNode): node is ModelElement {
+    return ModelNode.isModelElement(node) && !!node.getAttribute("class")?.includes(PLACEHOLDER_CLASS);
   }
 }

--- a/addon/model/util/model-range-utils.ts
+++ b/addon/model/util/model-range-utils.ts
@@ -1,0 +1,19 @@
+import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
+import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
+import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
+import ModelNodeUtils from "@lblod/ember-rdfa-editor/model/util/model-node-utils";
+
+export default class ModelRangeUtils {
+  static getExtendedToPlaceholder(range: ModelRange): ModelRange {
+
+    const copyRange = range.clone();
+
+    if (ModelNodeUtils.isPlaceHolder(copyRange.start.parent)) {
+      copyRange.start = ModelPosition.fromBeforeNode(copyRange.start.parent);
+    }
+    if (ModelNodeUtils.isPlaceHolder(copyRange.end.parent)) {
+      copyRange.end = ModelPosition.fromAfterNode(copyRange.end.parent);
+    }
+    return copyRange;
+  }
+}

--- a/addon/model/util/model-range-utils.ts
+++ b/addon/model/util/model-range-utils.ts
@@ -1,6 +1,5 @@
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
-import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
 import ModelNodeUtils from "@lblod/ember-rdfa-editor/model/util/model-node-utils";
 
 export default class ModelRangeUtils {

--- a/addon/utils/ce/lump-node-utils.js
+++ b/addon/utils/ce/lump-node-utils.js
@@ -35,7 +35,7 @@ function isInLumpNode(node, rootNode){
  *
  * @param {Node} node
  * @param {Node} rootNode
- * @return {null | Node}
+ * @return {null | Element}
  */
 function getParentLumpNode(node, rootNode){
   if(hasLumpNodeProperty(node)){

--- a/addon/utils/ce/lump-node-utils.js
+++ b/addon/utils/ce/lump-node-utils.js
@@ -29,6 +29,14 @@ function isInLumpNode(node, rootNode){
   return false;
 }
 
+/**
+ * Return node if it is a lumpnode, walk up the tree to find one
+ * otherwise, until you hit rootNode. Return null if no node found.
+ *
+ * @param {Node} node
+ * @param {Node} rootNode
+ * @return {null | Node}
+ */
 function getParentLumpNode(node, rootNode){
   if(hasLumpNodeProperty(node)){
     return node;

--- a/addon/utils/plugins/contenteditable-false/backspace-plugin.ts
+++ b/addon/utils/plugins/contenteditable-false/backspace-plugin.ts
@@ -7,6 +7,7 @@ import {
   MoveCursorToEndOfElementManipulation
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
 import {editorDebug, moveCaretBefore} from '@lblod/ember-rdfa-editor/editor/utils';
+import {isInLumpNode} from "@lblod/ember-rdfa-editor/utils/ce/lump-node-utils";
 
 /**
  * This plugin jumps before uneditable elements
@@ -18,7 +19,7 @@ export default class ContentEditableFalseBackspacePlugin implements BackspacePlu
     if (manipulation.type == "moveCursorToEndOfElement") {
       editorDebug(`plugins.contenteditable-false.guidanceForManipulation`, 'possible jump before element', manipulation.node);
       const element = manipulation.node ;
-      if (! element.isContentEditable) {
+      if (! element.isContentEditable && ! isInLumpNode(element)) {
         // element is not editable
         editorDebug(`plugins.contenteditable-false.guidanceForManipulation`,'will jump');
         return {

--- a/addon/utils/plugins/lump-node/backspace-plugin.ts
+++ b/addon/utils/plugins/lump-node/backspace-plugin.ts
@@ -32,12 +32,12 @@ export default class LumpNodeBackspacePlugin implements BackspacePlugin {
     const node = manipulation.node;
     const rootNode = node.getRootNode(); //Assuming here that node is attached.
 
-    let parentLump = getParentLumpNode(node, rootNode);
+    let parentLump: Element | null = getParentLumpNode(node, rootNode);
 
     if (manipulation.type === "removeEmptyTextNode" && !parentLump) {
       const prevSibling = manipulation.node.previousSibling;
       if (prevSibling) {
-        parentLump = getParentLumpNode(prevSibling, rootNode) as Element;
+        parentLump = getParentLumpNode(prevSibling, rootNode);
       }
     }
     const isManipulationSupported = this.isSupportedManipulation(manipulation);
@@ -49,14 +49,14 @@ export default class LumpNodeBackspacePlugin implements BackspacePlugin {
         return {
           allow: true,
           executor: (_, editor: Editor) => {
-            this.removeLumpNode(parentLump, editor);
+            this.removeLumpNode(parentLump!, editor);
           }
         };
       } else {
         return {
           allow: true,
           executor: () => {
-            this.flagForRemoval(parentLump);
+            this.flagForRemoval(parentLump!);
           }
         };
       }

--- a/addon/utils/plugins/lump-node/backspace-plugin.ts
+++ b/addon/utils/plugins/lump-node/backspace-plugin.ts
@@ -2,8 +2,9 @@ import {
   BackspaceHandlerManipulation,
   BackspacePlugin
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
-import { Editor, Manipulation, ManipulationGuidance } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
-import { isInLumpNode, getParentLumpNode } from '@lblod/ember-rdfa-editor/utils/ce/lump-node-utils';
+import {Editor, Manipulation, ManipulationGuidance} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
+import {getParentLumpNode, isInLumpNode} from '@lblod/ember-rdfa-editor/utils/ce/lump-node-utils';
+import {getWindowSelection, tagName} from "@lblod/ember-rdfa-editor/utils/dom-helpers";
 
 //We favour to be defensive in the stuff we accept.
 const SUPPORTED_MANIPULATIONS = [
@@ -27,36 +28,43 @@ const SUPPORTED_MANIPULATIONS = [
 export default class LumpNodeBackspacePlugin implements BackspacePlugin {
   label = 'backspace plugin for handling LumpNodes';
 
-  guidanceForManipulation(manipulation : BackspaceHandlerManipulation) : ManipulationGuidance | null {
+  guidanceForManipulation(manipulation: BackspaceHandlerManipulation): ManipulationGuidance | null {
     //TODO: fix case.manipulation.node == lumpnode
     const node = manipulation.node;
     const rootNode = node.getRootNode(); //Assuming here that node is attached.
-    const isElementInLumpNode = isInLumpNode(node, rootNode);
-    const isManipulationSupported = this.isSupportedManipulation(manipulation);
 
-    if(isElementInLumpNode && !isManipulationSupported){
+    let parentLump = getParentLumpNode(node, rootNode);
+
+    if (manipulation.type === "removeEmptyTextNode" && !parentLump) {
+      const prevSibling = manipulation.node.previousSibling;
+      if (prevSibling) {
+        parentLump = getParentLumpNode(prevSibling, rootNode) as Element;
+      }
+    }
+    const isManipulationSupported = this.isSupportedManipulation(manipulation);
+    if (parentLump && !isManipulationSupported) {
       console.warn(`plugins/lump-node/backspace-plugin: manipulation ${manipulation.type} not supported for lumpNode`);
       return null;
-    }
-
-    else if(isElementInLumpNode){
-      const parentLumpNode = getParentLumpNode(node, rootNode) as Element; //we can safely assume this
-
-      if(this.isElementFlaggedForRemoval(parentLumpNode)){
+    } else if (parentLump) {
+      if (this.isElementFlaggedForRemoval(parentLump)) {
         return {
           allow: true,
-          executor: this.removeLumpNode
+          executor: (_, editor: Editor) => {
+            this.removeLumpNode(parentLump, editor);
+          }
         };
-      }
-      else {
+      } else {
         return {
           allow: true,
-          executor: this.flagForRemoval
+          executor: () => {
+            this.flagForRemoval(parentLump);
+          }
         };
       }
-    }
 
-    return null;
+    } else {
+      return null;
+    }
   }
 
   /**
@@ -64,10 +72,7 @@ export default class LumpNodeBackspacePlugin implements BackspacePlugin {
    * It assumes manipulation.node is located in a LumpNode
    * @method removeLumpNode
    */
-  removeLumpNode = ( manipulation: BackspaceHandlerManipulation, editor: Editor ): void => {
-    const node = manipulation.node;
-    const rootNode = node.getRootNode();
-    const lumpNode = getParentLumpNode(node, rootNode) as ChildNode;
+  removeLumpNode = (lumpNode: Element, editor: Editor): void => {
     const parentOfLumpNode = lumpNode.parentNode!;
     const offset = Array.from(parentOfLumpNode.childNodes).indexOf(lumpNode);
     lumpNode.remove();
@@ -82,37 +87,29 @@ export default class LumpNodeBackspacePlugin implements BackspacePlugin {
    * Other cases, we rely on the detectVisualChange from backspace handler
    * @method detectChange
    */
-  detectChange( manipulation: BackspaceHandlerManipulation ) : boolean {
+  detectChange(manipulation: BackspaceHandlerManipulation): boolean {
     const node = manipulation.node;
-    const rootNode = node.getRootNode();
-
-    if(!node.isConnected){
+    if (!node.isConnected) {
       return false;
     }
-
-    const isElementInLumpNode = isInLumpNode(node, rootNode);
-    const isManipulationSupported = this.isSupportedManipulation(manipulation);
-
-    if(isElementInLumpNode && isManipulationSupported){
-      return true;
-    }
-
-    return false;
+    // we always do a visual change in this plugin, so we need the exact same logic
+    // this could be solved more efficiently with state but that is not recommended for handler plugins
+    return !!this.guidanceForManipulation(manipulation);
   }
 
   /**
    * checks whether manipulation is supported
    * @method isSupportedManipulation
    */
-  isSupportedManipulation( manipulation: Manipulation ) : boolean {
-    return SUPPORTED_MANIPULATIONS.some( m => m === manipulation.type );
+  isSupportedManipulation(manipulation: Manipulation): boolean {
+    return SUPPORTED_MANIPULATIONS.some(m => m === manipulation.type);
   }
 
   /**
    * checks whether element is flagged for removal
    * @method isElementFlaggedForRemoval
    */
-  isElementFlaggedForRemoval( element: Element ) : boolean {
+  isElementFlaggedForRemoval(element: Element): boolean {
     return element.getAttribute('data-flagged-remove') === "complete";
   }
 
@@ -120,10 +117,7 @@ export default class LumpNodeBackspacePlugin implements BackspacePlugin {
    * Flags the LumpNode for removal.
    * @method flagForRemoval
    */
-  flagForRemoval = ( manipulation: BackspaceHandlerManipulation): void => {
-    const node = manipulation.node;
-    const rootNode = node.getRootNode();
-    const lumpNode = getParentLumpNode(node, rootNode) as Element;
+  flagForRemoval = (lumpNode: Element): void => {
     lumpNode.setAttribute('data-flagged-remove', 'complete');
   };
 

--- a/addon/utils/plugins/lump-node/backspace-plugin.ts
+++ b/addon/utils/plugins/lump-node/backspace-plugin.ts
@@ -3,8 +3,7 @@ import {
   BackspacePlugin
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
 import {Editor, Manipulation, ManipulationGuidance} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
-import {getParentLumpNode, isInLumpNode} from '@lblod/ember-rdfa-editor/utils/ce/lump-node-utils';
-import {getWindowSelection, tagName} from "@lblod/ember-rdfa-editor/utils/dom-helpers";
+import {getParentLumpNode} from '@lblod/ember-rdfa-editor/utils/ce/lump-node-utils';
 
 //We favour to be defensive in the stuff we accept.
 const SUPPORTED_MANIPULATIONS = [


### PR DESCRIPTION
- move placeholder extension logic into a util class so we use the same code in the text input plugin as in the paste handler
- replace slightly dodgy custom html insertion logic with inserthtml command
- made sure selection is collapsed to end after insertion

seems to be working nicely

fixes: https://binnenland.atlassian.net/browse/GN-2564