### PR TITLE
Replace remnant usage of the globalTextOffsetToPath util

### DIFF
--- a/addon/components/rdfa/rdfa-context-debugger.js
+++ b/addon/components/rdfa/rdfa-context-debugger.js
@@ -4,7 +4,7 @@ import { analyse } from '@lblod/marawa/rdfa-context-scanner';
 import { debug } from '@ember/debug';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import globalTextOffsetToPath from '@lblod/ember-rdfa-editor/utils/global-text-offset-to-path';
+import globalTextRegionToModelRange from '@lblod/ember-rdfa-editor/utils/global-text-region-to-model-range';
 
 /**
  * Debugger component for the RDFa context of DOM nodes
@@ -77,10 +77,10 @@ export default class RdfaContextDebugger extends Component {
    */
   @action
   highlight([start, end]){
-    const startPos = globalTextOffsetToPath(this.editor.rootModelNode, start);
-    const endPos = globalTextOffsetToPath(this.editor.rootModelNode, end);
+    const range = globalTextRegionToModelRange(this.editor.rootModelNode, start, end);
     const selection = this.editor.createSelection();
-    selection.selectRange(this.editor.createRangeFromPaths(startPos, endPos));    this.editor.executeCommand("make-highlight", selection);
+    selection.selectRange(range);
+    this.editor.executeCommand("make-highlight", selection);
   }
 
   @action


### PR DESCRIPTION
This utility doesn't exist anymore and was replaced by the `globalTextRegionToModelRange` utility.

The module was removed in [this commit](https://github.com/lblod/ember-rdfa-editor/commit/184152d857b9ff675c085ca74ed8a1190af5f06a).