### PR TITLE
Remove all app/utils reexports

### DIFF
--- a/addon/utils/plugins/table/backspace-plugin.ts
+++ b/addon/utils/plugins/table/backspace-plugin.ts
@@ -3,7 +3,7 @@ import {
   BackspacePlugin
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
 import {ManipulationGuidance} from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
-import RawEditor from 'dummy/utils/ce/raw-editor';
+import RawEditor from '@lblod/ember-rdfa-editor/utils/ce/raw-editor';
 import {PropertyState} from "@lblod/ember-rdfa-editor/model/util/types";
 
 /**

--- a/addon/utils/plugins/table/tab-input-plugin.ts
+++ b/addon/utils/plugins/table/tab-input-plugin.ts
@@ -2,7 +2,7 @@ import {TabHandlerManipulation, TabInputPlugin} from '@lblod/ember-rdfa-editor/e
 import {
   ManipulationGuidance
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/manipulation';
-import RawEditor from 'dummy/utils/ce/raw-editor';
+import RawEditor from '@lblod/ember-rdfa-editor/utils/ce/raw-editor';
 import ModelTable from '@lblod/ember-rdfa-editor/model/model-table';
 import { PropertyState } from '@lblod/ember-rdfa-editor/model/util/types';
 import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';

--- a/app/utils/array-equals.js
+++ b/app/utils/array-equals.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/array-equals';

--- a/app/utils/ce/capped-history.js
+++ b/app/utils/ce/capped-history.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/capped-history';

--- a/app/utils/ce/editor.js
+++ b/app/utils/ce/editor.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/editor';

--- a/app/utils/ce/editor/operation.js
+++ b/app/utils/ce/editor/operation.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/editor/operation';

--- a/app/utils/ce/editor/select.js
+++ b/app/utils/ce/editor/select.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/editor/select';

--- a/app/utils/ce/editor/selection-utils.js
+++ b/app/utils/ce/editor/selection-utils.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/editor/selection-utils';

--- a/app/utils/ce/editor/triplestore.js
+++ b/app/utils/ce/editor/triplestore.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/editor/triplestore';

--- a/app/utils/ce/editor/update.js
+++ b/app/utils/ce/editor/update.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/editor/update';

--- a/app/utils/ce/flat-map.js
+++ b/app/utils/ce/flat-map.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/flat-map';

--- a/app/utils/ce/forgiving-action.js
+++ b/app/utils/ce/forgiving-action.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/forgiving-action';

--- a/app/utils/ce/get-rich-node-matching-dom-node.js
+++ b/app/utils/ce/get-rich-node-matching-dom-node.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/get-rich-node-matching-dom-node';

--- a/app/utils/ce/handlers/arrow-handler.js
+++ b/app/utils/ce/handlers/arrow-handler.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/handlers/arrow-handler';

--- a/app/utils/ce/handlers/delete-handler.js
+++ b/app/utils/ce/handlers/delete-handler.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/handlers/delete-handler';

--- a/app/utils/ce/handlers/emphasis-markdown-handler.js
+++ b/app/utils/ce/handlers/emphasis-markdown-handler.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/handlers/emphasis-markdown-handler';

--- a/app/utils/ce/handlers/fallback-input-handler.js
+++ b/app/utils/ce/handlers/fallback-input-handler.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/handlers/fallback-input-handler';

--- a/app/utils/ce/handlers/handler-response.js
+++ b/app/utils/ce/handlers/handler-response.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/handlers/handler-response';

--- a/app/utils/ce/handlers/header-markdown-handler.js
+++ b/app/utils/ce/handlers/header-markdown-handler.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/handlers/header-markdown-handler';

--- a/app/utils/ce/handlers/ignore-modifiers-handler.js
+++ b/app/utils/ce/handlers/ignore-modifiers-handler.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/handlers/ignore-modifiers-handler';

--- a/app/utils/ce/handlers/list-insertion-markdown-handler.js
+++ b/app/utils/ce/handlers/list-insertion-markdown-handler.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/handlers/list-insertion-markdown-handler';

--- a/app/utils/ce/handlers/tab-handler.js
+++ b/app/utils/ce/handlers/tab-handler.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/handlers/tab-handler';

--- a/app/utils/ce/handlers/undo-hander.js
+++ b/app/utils/ce/handlers/undo-hander.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/handlers/undo-hander';

--- a/app/utils/ce/legacy-raw-editor.js
+++ b/app/utils/ce/legacy-raw-editor.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/legacy-raw-editor';

--- a/app/utils/ce/list-helpers.js
+++ b/app/utils/ce/list-helpers.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/list-helpers';

--- a/app/utils/ce/lump-node-utils.js
+++ b/app/utils/ce/lump-node-utils.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/lump-node-utils';

--- a/app/utils/ce/model-selection-tracker.js
+++ b/app/utils/ce/model-selection-tracker.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/model-selection-tracker';

--- a/app/utils/ce/movement-observers/lump-node-movement-observer.js
+++ b/app/utils/ce/movement-observers/lump-node-movement-observer.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/movement-observers/lump-node-movement-observer';

--- a/app/utils/ce/movement-observers/movement-observer.js
+++ b/app/utils/ce/movement-observers/movement-observer.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/movement-observers/movement-observer';

--- a/app/utils/ce/next-text-node.js
+++ b/app/utils/ce/next-text-node.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/next-text-node';

--- a/app/utils/ce/node-walker.js
+++ b/app/utils/ce/node-walker.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/node-walker';

--- a/app/utils/ce/pernet-raw-editor.js
+++ b/app/utils/ce/pernet-raw-editor.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor';

--- a/app/utils/ce/previous-text-node.js
+++ b/app/utils/ce/previous-text-node.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/previous-text-node';

--- a/app/utils/ce/raw-editor.js
+++ b/app/utils/ce/raw-editor.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/raw-editor';

--- a/app/utils/ce/rich-node-tree-modification.js
+++ b/app/utils/ce/rich-node-tree-modification.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/rich-node-tree-modification';

--- a/app/utils/ce/text-node-walker.js
+++ b/app/utils/ce/text-node-walker.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/ce/text-node-walker';

--- a/app/utils/dom-helpers.js
+++ b/app/utils/dom-helpers.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/dom-helpers';

--- a/app/utils/errors.js
+++ b/app/utils/errors.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/errors';

--- a/app/utils/global-text-region-to-model-range.js
+++ b/app/utils/global-text-region-to-model-range.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/global-text-region-to-model-range';

--- a/app/utils/html-input-parser.js
+++ b/app/utils/html-input-parser.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/html-input-parser';

--- a/app/utils/is-empty.js
+++ b/app/utils/is-empty.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/is-empty';

--- a/app/utils/make-native-or-classic-instance.js
+++ b/app/utils/make-native-or-classic-instance.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/make-native-or-classic-instance';

--- a/app/utils/normalize-location.js
+++ b/app/utils/normalize-location.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/normalize-location';

--- a/app/utils/plugin-editor-api.js
+++ b/app/utils/plugin-editor-api.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugin-editor-api';

--- a/app/utils/plugin-hints-registry-api.js
+++ b/app/utils/plugin-hints-registry-api.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugin-hints-registry-api';

--- a/app/utils/plugins/anchor-tags/text-input-plugin.js
+++ b/app/utils/plugins/anchor-tags/text-input-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/anchor-tags/text-input-plugin';

--- a/app/utils/plugins/br-skipping/backspace-plugin.js
+++ b/app/utils/plugins/br-skipping/backspace-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/br-skipping/backspace-plugin';

--- a/app/utils/plugins/contenteditable-false/backspace-plugin.js
+++ b/app/utils/plugins/contenteditable-false/backspace-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/contenteditable-false/backspace-plugin';

--- a/app/utils/plugins/empty-element/backspace-plugin.js
+++ b/app/utils/plugins/empty-element/backspace-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/empty-element/backspace-plugin';

--- a/app/utils/plugins/empty-text-node/backspace-plugin.js
+++ b/app/utils/plugins/empty-text-node/backspace-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/empty-text-node/backspace-plugin';

--- a/app/utils/plugins/lists/backspace-plugin.js
+++ b/app/utils/plugins/lists/backspace-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/lists/backspace-plugin';

--- a/app/utils/plugins/lists/delete-plugin.js
+++ b/app/utils/plugins/lists/delete-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/lists/delete-plugin';

--- a/app/utils/plugins/lists/tab-input-plugin.js
+++ b/app/utils/plugins/lists/tab-input-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/lists/tab-input-plugin';

--- a/app/utils/plugins/lump-node/backspace-plugin.js
+++ b/app/utils/plugins/lump-node/backspace-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/lump-node/backspace-plugin';

--- a/app/utils/plugins/lump-node/tab-input-plugin.js
+++ b/app/utils/plugins/lump-node/tab-input-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/lump-node/tab-input-plugin';

--- a/app/utils/plugins/placeholder-text/backspace-plugin.js
+++ b/app/utils/plugins/placeholder-text/backspace-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/placeholder-text/backspace-plugin';

--- a/app/utils/plugins/placeholder-text/text-input-plugin.js
+++ b/app/utils/plugins/placeholder-text/text-input-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/placeholder-text/text-input-plugin';

--- a/app/utils/plugins/rdfa/backspace-plugin.js
+++ b/app/utils/plugins/rdfa/backspace-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/rdfa/backspace-plugin';

--- a/app/utils/plugins/rdfa/text-input-plugin.js
+++ b/app/utils/plugins/rdfa/text-input-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/rdfa/text-input-plugin';

--- a/app/utils/plugins/table/backspace-plugin.js
+++ b/app/utils/plugins/table/backspace-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/table/backspace-plugin';

--- a/app/utils/plugins/table/tab-input-plugin.js
+++ b/app/utils/plugins/table/tab-input-plugin.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/plugins/table/tab-input-plugin';

--- a/app/utils/rdfa/event-processor.js
+++ b/app/utils/rdfa/event-processor.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/rdfa/event-processor';

--- a/app/utils/rdfa/forgiving-action.js
+++ b/app/utils/rdfa/forgiving-action.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/rdfa/forgiving-action';

--- a/app/utils/rdfa/hints-registry.js
+++ b/app/utils/rdfa/hints-registry.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/rdfa/hints-registry';

--- a/app/utils/rdfa/rdfa-block-helpers.js
+++ b/app/utils/rdfa/rdfa-block-helpers.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/rdfa/rdfa-block-helpers';

--- a/app/utils/rdfa/rdfa-context-scanner.js
+++ b/app/utils/rdfa/rdfa-context-scanner.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/rdfa/rdfa-context-scanner';

--- a/app/utils/rdfa/rdfa-document.js
+++ b/app/utils/rdfa/rdfa-document.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/rdfa/rdfa-document';

--- a/app/utils/rdfa/rdfa-rich-node-helpers.js
+++ b/app/utils/rdfa/rdfa-rich-node-helpers.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/rdfa/rdfa-rich-node-helpers';

--- a/app/utils/rdfa/scoped-method.js
+++ b/app/utils/rdfa/scoped-method.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/rdfa/scoped-method';

--- a/app/utils/triples-in-selection.js
+++ b/app/utils/triples-in-selection.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/utils/triples-in-selection';

--- a/tests/dummy/app/utils/ce/next-text-node.js
+++ b/tests/dummy/app/utils/ce/next-text-node.js
@@ -1,1 +1,0 @@
-export { default } from "@lblod/ember-rdfa-editor/utils/ce/next-text-node";

--- a/tests/unit/utils/ce/next-text-node-test.ts
+++ b/tests/unit/utils/ce/next-text-node-test.ts
@@ -1,4 +1,4 @@
-import ceNextTextNode from "dummy/utils/ce/next-text-node";
+import ceNextTextNode from "@lblod/ember-rdfa-editor/utils/ce/next-text-node";
 import { module, test, skip } from "qunit";
 
 const invisibleSpace = "\u200B";


### PR DESCRIPTION
The preferred import path for utils is `@lblod/ember-rdfa-editor/utils/util-name`.