### PR TITLE
add spacing between 2 tables, remove focus style from table cell

### DIFF
--- a/app/styles/ember-rdfa-editor/_c-table.scss
+++ b/app/styles/ember-rdfa-editor/_c-table.scss
@@ -8,6 +8,10 @@
   border: .1rem solid $say-gray-300;
   white-space: normal;
 
+  & + & {
+    margin-top: $say-unit;
+  }
+
   thead {
     border-bottom: .2rem solid $say-gray-300;
   }
@@ -36,5 +40,10 @@
   th,
   td {
     max-width: 55ch;
+  }
+
+  th:focus,
+  td:focus {
+    outline: none;
   }
 }


### PR DESCRIPTION
- added margin between 2 or more tables
- removed the focus style on a table cell, not necessary when the cursor is already inside the cell