### PR TITLE
bump marawa

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@ember/optional-features": "^1.3.0",
     "@ember/render-modifiers": "^1.0.2",
     "@glimmer/tracking": "^1.0.0",
-    "@lblod/marawa": "^0.6.0",
+    "@lblod/marawa": "^0.8.0-beta.2",
     "@types/diff-match-patch": "^1.0.32",
     "common-tags": "^1.8.0",
     "diff-match-patch": "^1.0.5",


### PR DESCRIPTION
bumps marawa, so possible sideeffects are in our richnode structure and the rdfa-blocks for plugins. Seems to be backwards compatible, but probably needs some testing