### PR TITLE
on init explicitly set the selection to be collapsed in the rootNode

### DIFF
--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -131,7 +131,8 @@ class RawEditor extends EmberObject {
   set rootNode(rootNode: HTMLElement) {
     if (rootNode) {
       this.initialize(rootNode);
-      this.model.read();
+      this.model.read(false);
+      this.model.selection.collapseIn(this.model.rootModelNode);
       this.model.write();
       this.updateRichNode();
     }


### PR DESCRIPTION
this is inline with behaviour of the old editor code in that the cursor position
is forced to be at the start of the contenteditable node.

I *think* this fixes most of the init issues we have at the moment, unsure of
unwanted side effects