### PR TITLE
Fix broken rendering of br

### DIFF
--- a/addon/commands/insert-newLine-command.ts
+++ b/addon/commands/insert-newLine-command.ts
@@ -1,7 +1,7 @@
 import Command from "./command";
 import Model from "@lblod/ember-rdfa-editor/model/model";
 import ModelElement from "../model/model-element";
-import {ImpossibleModelStateError, MisbehavedSelectionError, ModelError} from "@lblod/ember-rdfa-editor/utils/errors";
+import {ImpossibleModelStateError, MisbehavedSelectionError} from "@lblod/ember-rdfa-editor/utils/errors";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 import ModelText from "@lblod/ember-rdfa-editor/model/model-text";

--- a/addon/commands/insert-newLine-command.ts
+++ b/addon/commands/insert-newLine-command.ts
@@ -1,11 +1,19 @@
 import Command from "./command";
 import Model from "@lblod/ember-rdfa-editor/model/model";
 import ModelElement from "../model/model-element";
-import {MisbehavedSelectionError} from "@lblod/ember-rdfa-editor/utils/errors";
+import {ImpossibleModelStateError, MisbehavedSelectionError, ModelError} from "@lblod/ember-rdfa-editor/utils/errors";
 import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
+import ModelText from "@lblod/ember-rdfa-editor/model/model-text";
+import {INVISIBLE_SPACE} from "@lblod/ember-rdfa-editor/model/util/constants";
+import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
 
 
+/**
+ * Insert a newline at the cursor position. Is responsible for making sure
+ * that newline renders correctly. Newlines are currently done using <br> elements, but
+ * that is technically an implementation detail.
+ */
 export default class InsertNewLineCommand extends Command {
   name = "insert-newLine";
 
@@ -23,9 +31,28 @@ export default class InsertNewLineCommand extends Command {
     }
     const br = new ModelElement("br");
     this.model.change(mutator => {
+
+      const nodeBefore = range.start.nodeBefore();
+      // if we have a textnode with a singe invis space before us, extend the range
+      // so it will be overwritten (this is mainly to clean up after ourselves)
+      if (ModelNode.isModelText(nodeBefore) && nodeBefore.content === INVISIBLE_SPACE) {
+        range.start = ModelPosition.fromBeforeNode(nodeBefore);
+      }
+
       mutator.insertNodes(range, br);
+
       const cursorPos = ModelPosition.fromAfterNode(br);
-      const newRange = new ModelRange(cursorPos, cursorPos);
+      let newRange = new ModelRange(cursorPos, cursorPos);
+
+      if(!br.parent ) {
+        throw new ImpossibleModelStateError();
+      }
+      // if the br is the last child of a block element, it won't render properly
+      // thanks to the magic of the dom spec, so we insert a good old invisible space
+      if(br.parent.isBlock && br === br.parent.lastChild) {
+        const dummyText = new ModelText(INVISIBLE_SPACE);
+        newRange = mutator.insertNodes(newRange, dummyText);
+      }
       this.model.selectRange(newRange);
     });
   }

--- a/addon/editor/input-handlers/text-input-handler.ts
+++ b/addon/editor/input-handlers/text-input-handler.ts
@@ -86,7 +86,6 @@ export default class TextInputHandler extends InputHandler {
 
   handleNativeManipulation(manipulation: TextHandlerManipulation) {
     if (manipulation.type === "insertTextIntoRange") {
-      console.log(manipulation);
       this.rawEditor.executeCommand("insert-text", manipulation.text, manipulation.range);
     } else {
       throw new UnsupportedManipulationError(manipulation);

--- a/addon/utils/errors.ts
+++ b/addon/utils/errors.ts
@@ -89,6 +89,12 @@ export class OffsetOutOfRangeError extends CustomError {
 export class ModelRangeError extends SelectionError {
 }
 
+export class ImpossibleModelStateError extends ModelError {
+  constructor() {
+    super("Something went horribly wrong and a strong assumption was broken");
+  }
+}
+
 export class UnconfinedRangeError extends ModelRangeError {
   constructor() {
     super("Range is not confined to a single parent");


### PR DESCRIPTION
When a br is the last element of a block, it doesn't render like it should, so we detect that scenario and insert an invisible space when necessary.