### PR TITLE
Make it possible to click outside of a table

### DIFF
--- a/addon/components/rdfa/toolbar-dropdown.hbs
+++ b/addon/components/rdfa/toolbar-dropdown.hbs
@@ -15,7 +15,7 @@
             shouldSelfFocus=true
             focusTrapOptions=(hash
                     onDeactivate=this.deactivateDropdown
-                    setReturnFocus=this.rootNode
+                    returnFocusOnDeactivate=false
                     clickOutsideDeactivates=true)
     }}
           {{on "click" this.deactivateFocusTrap}}

--- a/addon/components/rdfa/toolbar-dropdown.js
+++ b/addon/components/rdfa/toolbar-dropdown.js
@@ -11,11 +11,6 @@ export default class AuDropdown extends Component {
   @tracked dropdownOpen = false;
   @tracked focusTrapActive = false;
 
-
-  get rootNode() {
-    return this.args.editor.rootNode;
-  }
-
   activateFocusTrap() {
     this.focusTrapActive = true;
   }
@@ -28,6 +23,7 @@ export default class AuDropdown extends Component {
   @action
   deactivateDropdown() {
     this.dropdownOpen = false;
+    this.args.editor.model.writeSelection();
   }
 
   // toggle dropdown

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -83,10 +83,7 @@ class RawEditor extends EmberObject {
     this.registeredCommands = new Map<string, Command>();
     this._model = new Model(rootNode);
     this.modelSelectionTracker = new ModelSelectionTracker(this._model);
-    this.modelSelectionTracker.startTracking();   
-    this.rootNode.addEventListener("focus", () => {
-      this.model.writeSelection();
-    });
+    this.modelSelectionTracker.startTracking();
     window.__VDOM = this.model;
     window.__executeCommand = (commandName: string, ...args: unknown[]) => {
       this.executeCommand(commandName, ...args);


### PR DESCRIPTION
Listening for rootnode focus was not a good way to solve the focus issues with the dropdown

On the dummy editor, this solution also gives focus back correctly when using the table dropdown, but on GN it does not.
This is not a regression however since this is already the case on the dev env