### PR TITLE
Feature/better command logging

### DIFF
--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -175,7 +175,7 @@ export default class ModelRange {
   }
 
   collapse(toLeft = false): void {
-    if(toLeft) {
+    if (toLeft) {
       this.end = this.start;
     } else {
       this.start = this.end;
@@ -279,7 +279,7 @@ export default class ModelRange {
   }
 
   toString(): string {
-    return `{[${this.start.path.toString()}] - [${this.end.path.toString()}]}`;
+    return `ModelRange<[${this.start.path.toString()}] - [${this.end.path.toString()}]>`;
 
   }
 }

--- a/addon/utils/logging-utils.ts
+++ b/addon/utils/logging-utils.ts
@@ -1,6 +1,7 @@
 import config from 'ember-get-config';
 import {defaultReporter, Diary, diary, LogEvent, LogLevels, Reporter} from 'diary';
 import {compare} from 'diary/utils';
+import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
 
 // this array is sorted from lowest to highest "level"
 // aka setting loglevel to "info" will include info and everything to the right of it
@@ -138,4 +139,20 @@ export function logMethod(message: string | MethodMessageFunc = defaultLogMethod
   };
 }
 
-export const logExecute = logMethod(undefined, {scopePrefix: "command"});
+export const logExecute = logMethod(
+  (_methodName: string, ...args) => {
+    const mappedArgs = args.map(arg => {
+        if (arg instanceof ModelRange) {
+          return arg.toString();
+        }
+        if (typeof arg === "string") {
+          return `string<"${arg}", ${arg.length}>`;
+        } else {
+          return arg;
+        }
+      }
+    );
+    return ["Executing with args:", ...mappedArgs];
+
+  }, {scopePrefix: "command"});
+


### PR DESCRIPTION
Trying out smaller prs inspired by [Chris Manson's writeup](https://simplabs.com/blog/2021/05/26/keeping-a-clean-git-history/).

Improves logging of commands with some custom printing for strings and ModelRanges. Since we often deal with whitespace or even invisible whitespace I wanted to make a clear string representation. I landed on `string<"${mystring}", ${mystring.length}>`