### PR TITLE
Changes to getFromSelection methods in ModelTable

### DIFF
--- a/addon/model/model-node.ts
+++ b/addon/model/model-node.ts
@@ -2,6 +2,7 @@ import ModelText, {TextAttribute} from "@lblod/ember-rdfa-editor/model/model-tex
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import {ModelError, NoParentError, OutsideRootError} from "@lblod/ember-rdfa-editor/utils/errors";
 import XmlWriter from "@lblod/ember-rdfa-editor/model/writers/xml-writer";
+import ModelTable from "@lblod/ember-rdfa-editor/model/model-table";
 
 export type ModelNodeType = "TEXT" | "ELEMENT" | "FRAGMENT";
 
@@ -44,6 +45,14 @@ export default abstract class ModelNode {
    */
   static isModelText(node?: ModelNode | null): node is ModelText {
     return !!node && node.modelNodeType === "TEXT";
+  }
+
+  /**
+   * Typechecking utility to verify whether the node is {@link ModelTable}
+   * @param node
+   */
+  static isModelTable(node?: ModelNode | null): node is ModelTable {
+    return this.isModelElement(node) && node instanceof ModelTable;
   }
 
   get attributeMap(): Map<string, string> {

--- a/addon/model/model-node.ts
+++ b/addon/model/model-node.ts
@@ -2,7 +2,6 @@ import ModelText, {TextAttribute} from "@lblod/ember-rdfa-editor/model/model-tex
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import {ModelError, NoParentError, OutsideRootError} from "@lblod/ember-rdfa-editor/utils/errors";
 import XmlWriter from "@lblod/ember-rdfa-editor/model/writers/xml-writer";
-import ModelTable from "@lblod/ember-rdfa-editor/model/model-table";
 
 export type ModelNodeType = "TEXT" | "ELEMENT" | "FRAGMENT";
 
@@ -45,14 +44,6 @@ export default abstract class ModelNode {
    */
   static isModelText(node?: ModelNode | null): node is ModelText {
     return !!node && node.modelNodeType === "TEXT";
-  }
-
-  /**
-   * Typechecking utility to verify whether the node is {@link ModelTable}
-   * @param node
-   */
-  static isModelTable(node?: ModelNode | null): node is ModelTable {
-    return this.isModelElement(node) && node instanceof ModelTable;
   }
 
   get attributeMap(): Map<string, string> {

--- a/addon/model/model-table.ts
+++ b/addon/model/model-table.ts
@@ -94,31 +94,18 @@ export default class ModelTable extends ModelElement {
   }
 
   static getCellFromSelection(selection: ModelSelection) {
-    const commonAncestor = selection.getCommonAncestor();
-    if(!commonAncestor) return null;
-    const cell = commonAncestor.parentElement.findAncestor((node) => {
-      if(node.modelNodeType === 'ELEMENT') {
-        const element = node as ModelElement;
-        if(element.type === 'td') return true;
-      }
-      return false;
-    }) as ModelElement;
-    return cell;
+    const generator = selection.lastRange?.findCommonAncestorsWhere((node) => {
+      return this.isModelElement(node) && node.type === "td";
+    });
+
+    return generator?.next().value;
   }
 
   static getTableFromSelection(selection: ModelSelection) {
-    const commonAncestor = selection.getCommonAncestor();
-    if(!commonAncestor) return null;
-    const table = commonAncestor.parentElement.findAncestor((node) => {
-      if(node.modelNodeType === 'ELEMENT') {
-        const element = node as ModelElement;
-        if(element.type === 'table') {
-          return true;
-        }
-      }
-      return false;
-    }) as ModelTable;
-    return table;
-  }
+    const generator = selection.lastRange?.findCommonAncestorsWhere((node) => {
+      return node instanceof ModelTable;
+    });
 
+    return generator?.next().value;
+  }
 }

--- a/addon/model/model-table.ts
+++ b/addon/model/model-table.ts
@@ -106,6 +106,6 @@ export default class ModelTable extends ModelElement {
       return node instanceof ModelTable;
     });
 
-    return generator?.next().value;
+    return generator?.next().value as ModelTable;
   }
 }


### PR DESCRIPTION
Change `getCellFromSelection` and `getTableFromSelection` in the `ModelTable` class to no longer make use of deprecated methods. Also improved the predicate used in `getTableFromSelection`.