### PR TITLE
Backspace handler

### DIFF
--- a/addon/commands/delete-selection-command.ts
+++ b/addon/commands/delete-selection-command.ts
@@ -18,6 +18,7 @@ export default class DeleteSelectionCommand extends Command<unknown[], ModelNode
 
   execute(selection: ModelSelection = this.model.selection): ModelNode[] {
     if (!ModelSelection.isWellBehaved(selection)) {
+      console.log("here");
       throw new MisbehavedSelectionError();
     }
 

--- a/addon/commands/unwrap-command.ts
+++ b/addon/commands/unwrap-command.ts
@@ -1,0 +1,17 @@
+import Command from "@lblod/ember-rdfa-editor/commands/command";
+import Model from "@lblod/ember-rdfa-editor/model/model";
+import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
+
+export default class UnwrapCommand extends Command {
+  name = "unwrap";
+
+  constructor(model: Model) {
+    super(model);
+  }
+
+  execute(element: ModelElement): void {
+    this.model.change(mutator => {
+      mutator.unwrap(element);
+    });
+  }
+}

--- a/addon/components/ce/content-editable.ts
+++ b/addon/components/ce/content-editable.ts
@@ -2,7 +2,7 @@ import { action } from "@ember/object";
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import BackspaceHandler from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler';
+import BackspaceHandler from '@lblod/ember-rdfa-editor/editor/input-handlers/backspace-handler-new';
 import BoldItalicUnderlineHandler from '@lblod/ember-rdfa-editor/editor/input-handlers/bold-italic-underline-handler';
 import CutHandler from "@lblod/ember-rdfa-editor/editor/input-handlers/cut-handler";
 import EnterHandler from '@lblod/ember-rdfa-editor/editor/input-handlers/enter-handler';

--- a/addon/editor/input-handlers/backspace-handler-new.ts
+++ b/addon/editor/input-handlers/backspace-handler-new.ts
@@ -1,0 +1,148 @@
+import {InputHandler} from "@lblod/ember-rdfa-editor/editor/input-handlers/input-handler";
+import {isKeyDownEvent} from "@lblod/ember-rdfa-editor/editor/input-handlers/event-helpers";
+import PernetRawEditor from "@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor";
+import {HandlerResponse} from "@lblod/ember-rdfa-editor/editor/input-handlers/handler-response";
+import {MisbehavedSelectionError} from "@lblod/ember-rdfa-editor/utils/errors";
+import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
+import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
+import ModelNodeUtils from "@lblod/ember-rdfa-editor/model/util/model-node-utils";
+import ModelTreeWalker, {toFilterSkipFalse} from "@lblod/ember-rdfa-editor/model/util/model-tree-walker";
+import ModelPosition from "@lblod/ember-rdfa-editor/model/model-position";
+import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
+import ModelSelection from "@lblod/ember-rdfa-editor/model/model-selection";
+
+export default class BackspaceHandler extends InputHandler {
+  constructor({rawEditor}: {rawEditor: PernetRawEditor}) {
+    super(rawEditor);
+  }
+
+  isHandlerFor(event: Event): boolean {
+    return isKeyDownEvent(event)
+      && event.key === "Backspace"
+      && !!this.rawEditor.model.selection.lastRange;
+  }
+
+  handleEvent(_: KeyboardEvent): HandlerResponse {
+    const range = this.rawEditor.model.selection.lastRange;
+    if (!range) {
+      throw new MisbehavedSelectionError();
+    }
+
+    if (range.collapsed) {
+      // The cursor is located at the start of an element, which means right behind the opening tag.
+      // There are 3 cases here:
+      //   - The element is an "li". We replace the element by its children, we split the list into two lists
+      //     and if there remain lists without any "li" element in them, we also remove these lists.
+      //   - The element is a table cell ("th" or "td"). In this case, do nothing (see Google Documents).
+      //   - In all other cases, we remove the last character of the first text node we find before
+      //     the cursor.
+      if (range.start.parentOffset === 0) {
+        if (ModelNodeUtils.isListElement(range.start.parent)) {
+          // TODO: In list element.
+        } else if (!ModelNodeUtils.isTableCell(range.start.parent)) {
+          this.backspaceLastTextRelatedNode(range.start);
+        } else {
+          // DO NOTHING IN CASE OF TABLE
+        }
+      } else {
+        const nodeBefore = range.start.nodeBefore();
+        // The cursor is located right behind a text node. In this case, we can safely select the last
+        // character of this text node and remove it.
+        if (ModelNodeUtils.isTextRelated(nodeBefore)) {
+          this.backspaceTextRelatedNode(nodeBefore);
+        // The cursor is located right behind an element, which means right behind its closing tag.
+        // There are 3 cases here:
+        //   - The element is a list container ("ul" or "ol"). In this case, we place the cursor right behind
+        //     the first text node in this list.
+        //   - The element is a "table". In this case, do nothing (see Google Documents).
+        //   - In all other cases, we remove the last character of the first text node we find before
+        //     the cursor.
+        } else if (ModelNode.isModelElement(nodeBefore)) {
+          if (ModelNodeUtils.isListContainer(range.start.parent)) {
+            console.log("list container");
+            const lastLi = BackspaceHandler.findLastListElement(nodeBefore);
+            if (!lastLi) {
+              throw new Error("List without any list elements");
+            }
+
+            const newPosition = ModelPosition.fromInElement(lastLi, lastLi.getMaxOffset());
+            this.rawEditor.model.selectRange(new ModelRange(newPosition));
+          } else if (!ModelNodeUtils.isTableCell(range.start.parent)) {
+            this.backspaceLastTextRelatedNode(range.start);
+          } else {
+            // DO NOTHING IN CASE OF TABLE
+          }
+        } else {
+          throw new Error("Unsupported node type");
+        }
+      }
+    } else {
+      // If the selection is not collapsed, backspace just has to delete every node in the selection.
+      this.rawEditor.executeCommand("delete-selection");
+    }
+
+    return {allowPropagation: false, allowBrowserDefault: false};
+  }
+
+  private backspaceTextRelatedNode(node: ModelNode | null): void {
+    if (!node) {
+      return;
+    }
+
+    let deleteRange: ModelRange;
+    if (ModelNode.isModelText(node)) {
+      // Create a new range that selects the last character of the found text node.
+      deleteRange = new ModelRange(
+        ModelPosition.fromInTextNode(node, node.length - 1),
+        ModelPosition.fromInTextNode(node, node.length)
+      );
+    } else if (ModelNodeUtils.isBr(node)) {
+      // Create a new range around the "br" element.
+      deleteRange = ModelRange.fromAroundNode(node);
+    } else {
+      throw new Error("Found node is not text related");
+    }
+
+    const modelSelection = new ModelSelection(this.rawEditor.model);
+    modelSelection.addRange(deleteRange);
+
+    this.rawEditor.executeCommand("delete-selection", modelSelection);
+  }
+
+  private backspaceLastTextRelatedNode(cursorPosition: ModelPosition): void {
+    const start = ModelPosition.fromInElement(this.rawEditor.model.rootModelNode, 0);
+    const range = new ModelRange(start, cursorPosition);
+    const textRelatedNode = BackspaceHandler.findLastTextRelatedNode(range);
+
+    this.backspaceTextRelatedNode(textRelatedNode);
+  }
+
+  private static findLastNode(range: ModelRange, predicate: (node: ModelNode) => boolean): ModelNode | null {
+    const treeWalker = new ModelTreeWalker({
+      filter: toFilterSkipFalse(predicate),
+      range: range
+    });
+
+    const nodes = [...treeWalker];
+    return nodes.length > 0 ? nodes[nodes.length - 1] : null;
+  }
+
+  private static findLastTextRelatedNode(range: ModelRange): ModelNode | null {
+    return this.findLastNode(range, ModelNodeUtils.isTextRelated);
+  }
+
+  private static findLastListElement(list: ModelElement): ModelElement | null {
+    const range = ModelRange.fromAroundNode(list);
+    const lastLi = this.findLastNode(range, ModelNodeUtils.isListElement);
+
+    if (!lastLi) {
+      return null;
+    }
+
+    if (!ModelNodeUtils.isListElement(lastLi)) {
+      throw new Error("Found node is not a list element");
+    }
+
+    return lastLi;
+  }
+}

--- a/addon/editor/input-handlers/event-helpers.ts
+++ b/addon/editor/input-handlers/event-helpers.ts
@@ -1,0 +1,3 @@
+export function isKeyDownEvent(event: Event): event is KeyboardEvent {
+  return event.type === "keydown";
+}

--- a/addon/model/model-position.ts
+++ b/addon/model/model-position.ts
@@ -299,7 +299,7 @@ export default class ModelPosition {
   }
 
   /**
-   * If position is "inside" a textnode, this will return that node.
+   * If position is "inside" a text node, this will return that node.
    * Otherwise, return the node immediately before the cursor
    */
   nodeBefore(): ModelNode | null {
@@ -372,16 +372,11 @@ export default class ModelPosition {
     return ModelPosition.fromInElement(this.parent, newOffset);
   }
 
-  //this returns true if the position is inside a text node (not right before not right after)
+  // This returns true if the position is inside a text node (not right before not right after).
   isInsideText(): boolean {
-    if (
-      (this.nodeAfter() == this.nodeBefore()) &&
-      (ModelNode.isModelText(this.nodeAfter()) && ModelNode.isModelText(this.nodeBefore()))
-    ) {
-      return true;
-    } else {
-      return false;
-    }
+    return this.nodeAfter() === this.nodeBefore()
+      && ModelNode.isModelText(this.nodeAfter())
+      && ModelNode.isModelText(this.nodeBefore());
   }
 
   clone(): ModelPosition {
@@ -389,20 +384,21 @@ export default class ModelPosition {
   }
 
   findAncestors(predicate: (elem: ModelElement) => boolean = () => true): ModelElement[] {
-    let cur = this.parent;
-    const rslt = [];
+    let current = this.parent;
+    const result = [];
 
-    while (cur !== this.root) {
-      if (predicate(cur)) {
-        rslt.push(cur);
+    while (current !== this.root) {
+      if (predicate(current)) {
+        result.push(current);
       }
-      cur = cur.parent!;
 
+      current = current.parent!;
     }
-    if (predicate(cur)) {
-      rslt.push(cur);
+
+    if (predicate(current)) {
+      result.push(current);
     }
-    return rslt;
+
+    return result;
   }
-
 }

--- a/addon/model/util/constants.ts
+++ b/addon/model/util/constants.ts
@@ -2,6 +2,7 @@ export const nonBlockNodes = new Set(['b', 'strong', 'i', 'em', 'span', 'a']);
 export const listTypes = new Set(['li', 'ul', 'ol']);
 export const LIST_CONTAINERS = new Set(['ul', 'ol']);
 export const tableTypes = new Set(['table', 'th', 'tr', 'td', 'thead', 'tbody']);
+export const TABLE_CELLS = new Set(['th', 'td']);
 export const TEXT_PROPERTY_NODES = new Set(['b', 'strong', 'i', 'emph', 'u', 'del', 'span']);
 export const NON_BREAKING_SPACE = '\u00A0';
 export const SPACE = " ";

--- a/addon/model/util/model-node-utils.ts
+++ b/addon/model/util/model-node-utils.ts
@@ -1,7 +1,7 @@
 import MapUtils from "@lblod/ember-rdfa-editor/model/util/map-utils";
 import ModelNode from "@lblod/ember-rdfa-editor/model/model-node";
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
-import {LIST_CONTAINERS, PLACEHOLDER_CLASS} from "@lblod/ember-rdfa-editor/model/util/constants";
+import {LIST_CONTAINERS, PLACEHOLDER_CLASS, TABLE_CELLS} from "@lblod/ember-rdfa-editor/model/util/constants";
 
 export default class ModelNodeUtils {
   static DEFAULT_IGNORED_ATTRS: Set<string> = new Set(["__dummy_test_attr", "__id", "data-editor-position-level", "data-editor-rdfa-position-level"]);
@@ -26,6 +26,22 @@ export default class ModelNodeUtils {
 
   static isListContainer(node: ModelNode): node is ModelElement {
     return ModelNode.isModelElement(node) && LIST_CONTAINERS.has(node.type);
+  }
+
+  static isListElement(node: ModelNode | null): node is ModelElement {
+    return ModelNode.isModelElement(node) && node.type === "li";
+  }
+
+  static isTableCell(node: ModelNode): node is ModelElement {
+    return ModelNode.isModelElement(node) && TABLE_CELLS.has(node.type);
+  }
+
+  static isBr(node: ModelNode | null): node is ModelElement {
+    return ModelNode.isModelElement(node) && node.type === "br";
+  }
+
+  static isTextRelated(node: ModelNode | null): boolean {
+    return ModelNode.isModelText(node) || ModelNodeUtils.isBr(node);
   }
 
   static isPlaceHolder(node: ModelNode): node is ModelElement {

--- a/addon/model/util/model-tree-walker.ts
+++ b/addon/model/util/model-tree-walker.ts
@@ -77,7 +77,6 @@ export default class ModelTreeWalker<T extends ModelNode = ModelNode> implements
     this.visitParentUpwards = visitParentUpwards;
 
     if (from.path.length > 0) {
-
       const startNode = this.getStartNodeFromPosition(from);
       this.nodeAfterEnd = this.getNodeAfterEndFromPosition(to, startNode);
       this._currentNode = startNode;


### PR DESCRIPTION
This PR aims at reimplementing the backspace handler by means of commands.
Currently, this is still a draft, but I already opened this PR, so I can leave some notes and thoughts here.

If the cursor is behind a list, `nodeBefore` does only return this list if there is also text behind the cursor. Otherwise it returns a text node with an empty string as content. This is quite problematic for the implementation of the handler, but currently I don't see how this is possible. 