### PR TITLE
Fix insert XML

### DIFF
--- a/addon/commands/insert-xml-command.ts
+++ b/addon/commands/insert-xml-command.ts
@@ -1,6 +1,6 @@
 import Command from "@lblod/ember-rdfa-editor/commands/command";
 import {MisbehavedSelectionError} from "@lblod/ember-rdfa-editor/utils/errors";
-import {parseXml} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
+import {parseXmlSiblings} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
 import Model from "@lblod/ember-rdfa-editor/model/model";
 import {logExecute} from "@lblod/ember-rdfa-editor/utils/logging-utils";
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
@@ -21,9 +21,9 @@ export default class InsertXmlCommand extends Command {
       throw new MisbehavedSelectionError();
     }
 
-    const parsed = parseXml(xml);
+    const parsedModelNodes = parseXmlSiblings(xml);
     this.model.change(mutator => {
-      const newRange = mutator.insertNodes(range, parsed.root);
+      const newRange = mutator.insertNodes(range, ...parsedModelNodes);
       this.model.selectRange(newRange);
     });
   }

--- a/addon/model/readers/xml-reader.ts
+++ b/addon/model/readers/xml-reader.ts
@@ -18,6 +18,5 @@ export default class XmlReader implements Reader<Node, XmlReaderResult, void> {
     }
     return {root, elements: elementRegistry, textNodes: textRegistry};
   }
-
 }
 

--- a/addon/model/util/xml-utils.ts
+++ b/addon/model/util/xml-utils.ts
@@ -11,6 +11,24 @@ export function parseXml(xml: string): XmlReaderResult {
   return reader.read(doc.firstElementChild!);
 }
 
+export function parseXmlSiblings(xml: string): ModelNode[] {
+  const parser = new DOMParser();
+  const xmlToParse = `<div>${xml}</div>`;
+  const doc = parser.parseFromString(xmlToParse, "application/xml");
+
+  const reader = new XmlReader();
+  if (!doc.firstElementChild) {
+    throw new Error("Resulting document has no nodes in it");
+  }
+
+  const topContainer = reader.read(doc.firstElementChild).root;
+  if (!ModelNode.isModelElement(topContainer)) {
+    throw new Error("Container is not an element");
+  }
+
+  return topContainer.children;
+}
+
 export function parseHtml(html: string): HTMLDocument {
   const parser = new DOMParser();
   return parser.parseFromString(html, "text/html");

--- a/addon/utils/rdfa/rdfa-document.ts
+++ b/addon/utils/rdfa/rdfa-document.ts
@@ -44,16 +44,17 @@ export default class RdfaDocument {
     const root = this._editor.model.toXml() as Element;
     let result = '';
     for (const child of root.childNodes) {
-
       let formatted;
+
       try {
         formatted = xmlFormat((child as Element).outerHTML);
       } catch (e) {
         formatted = (child as Element).outerHTML;
       }
-      result += formatted;
 
+      result += formatted;
     }
+
     return result;
   }
 

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -109,7 +109,6 @@ export default class IndexController extends Controller {
 
   @action openContentDebugger(type: "xml" | "html") {
     if (this.rdfaEditor) {
-
       if (type === "xml") {
         this.debuggerContent = this.rdfaEditor.xmlContentPrettified;
         this.xmlDebuggerOpen = true;


### PR DESCRIPTION
The insert XML didn't work when inserting multiple top level XML nodes. I wrote a new method that can handle this and used this one in the `insert-xml` command.