### PR TITLE
Collapse the selection upon initializing the editor

### DIFF
--- a/addon/utils/rdfa/rdfa-document.ts
+++ b/addon/utils/rdfa/rdfa-document.ts
@@ -28,6 +28,8 @@ export default class RdfaDocument {
     const root = this._editor.model.rootModelNode;
     const range = ModelRange.fromPaths(root, [0], [root.getMaxOffset()]);
     this._editor.executeCommand("insert-html", html, range);
+    this._editor.selection.lastRange?.collapse(true);
+    this._editor.model.writeSelection();
   }
 
   get xmlContent() {


### PR DESCRIPTION
Having the whole content selected is consistent and was intended
behavior, but it's not great ux

fixes https://binnenland.atlassian.net/browse/GN-2878