### PR TITLE
faster and cleaner builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "diary": "^0.1.6",
     "diff-match-patch": "^1.0.5",
     "dompurify": "^2.0.12",
-    "ember-auto-import": "^1.6.0",
+    "ember-auto-import": "^2.2.0",
     "ember-classic-decorator": "^1.0.3",
     "ember-cli-babel": "^7.21.0",
     "ember-cli-htmlbars": "^5.2.0",
@@ -127,6 +127,7 @@
     "sass": "^1.26.3",
     "svg-symbols": "^1.0.5",
     "typescript": "^4.3.4",
+    "webpack": "^5.55.1",
     "yuidoc-ember-theme": "^2.0.1"
   },
   "engines": {


### PR DESCRIPTION
Bumps ember auto import for faster (hey ed Faulkner promised!) and cleaner builds. Does require the host app to follow the upgrade guide as well, as such it's a breaking change: https://github.com/ef4/ember-auto-import/blob/main/docs/upgrade-guide-2.0.md