### PR TITLE
it's recommended to use may-import-regenerator over babel polyfills

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,9 +15,6 @@ module.exports = function(defaults) {
       cascade: true,
       sourcemap: true
     },
-    'ember-cli-babel': {
-      includePolyfill: true
-    }
   });
 
   /*

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ember-feature-flags": "^6.0.0",
     "ember-focus-trap": "^0.7.0",
     "ember-intl": "^5.6.2",
+    "ember-maybe-import-regenerator": "^1.0.0",
     "ember-truth-helpers": "^2.0.0",
     "mdn-polyfills": "^5.16.0",
     "xml-formatter": "^2.4.0"


### PR DESCRIPTION
specifically so for addons, see https://github.com/machty/ember-maybe-import-regenerator for more info