### PR TITLE
Document core classes

### DIFF
--- a/addon/archive/utils/event-bus.ts
+++ b/addon/archive/utils/event-bus.ts
@@ -67,6 +67,10 @@ export type EventEmitter<E extends EditorEventName> = (event: EDITOR_EVENT_MAP[E
 
 export type DebouncedEmitter<E extends EditorEventName> = (delayMs: number, event: EDITOR_EVENT_MAP[E]) => void;
 
+/**
+ * The event bus is a simple event system for internal and external use.
+ * It's purpose is to decouple editor events from the browser for more control and easier testability.
+ */
 export default class EventBus {
 
   private listeners: Map<EditorEventName, Array<EditorEventListener<EditorEventName>>> = new Map<EditorEventName, Array<EditorEventListener<EditorEventName>>>();

--- a/addon/components/ce/content-editable.ts
+++ b/addon/components/ce/content-editable.ts
@@ -15,22 +15,12 @@ interface ContentEditableArgs {
 const CE_OWNER = "content-editable";
 
 /**
- * content-editable is the core of {{#crossLinkModule "rdfa-editor"}}rdfa-editor{{/crossLinkModule}}.
- * It provides handlers for input events, a component to display a content editable element and an API for interaction
- * with the document and its internal document representation.
- *
- * rdfa-editor embeds the {{#crossLink "ContentEditable"}}{{/crossLink}} and interacts with the document
- * through the {{#crossLink "RawEditor"}}{{/crossLink}} interface.
- *
- * Input is handled by input handlers such as the {{#crossLink "TextInputHandler"}}{{/crossLink}},
- * {{#crossLink "BackspaceHandler"}}{{/crossLink}}, {{#crossLink "ArrowHandler"}}{{/crossLink}} and
- * {{#crossLink "EnterHandler"}}{{/crossLink}}.
- * @module contenteditable-editor
- * @main contenteditable-editor
- */
-
-/**
  * Content editable editor component.
+ * Ember component which wraps the actual contenteditable div.
+ * Responsible for setting up event listeners
+ * (which simply refire EditorEvents to allow custom event structures)
+ * and initializing the editor instance
+ *
  * @module contenteditable-editor
  * @class ContentEditableComponent
  * @extends Component

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -49,20 +49,11 @@ interface SuggestedHint {
 }
 
 /**
- * RDFa editor
- *
- * This module contains all classes and components provided by the @lblod/ember-rdfa-editor addon.
- * The main entrypoint is the {{#crossLink "RdfaEditorComponent"}}{{/crossLink}}.
- * @module rdfa-editor
- * @main rdfa-editor
- */
-
-/**
  * RDFa editor component
  *
- * This component wraps around a {{#crossLink "ContentEditableComponent"}}{{/crossLink}}
+ * This component wraps around a {@link ContentEditable} component
  * and provides an architecture to interact with the document through plugins.
- * {{#crossLinkModule "rdfa-editor"}}rdfa-editor{{/crossLinkModule}}.
+ *
  * @module rdfa-editor
  * @class RdfaEditorComponent
  * @extends Component

--- a/addon/core/command.ts
+++ b/addon/core/command.ts
@@ -1,11 +1,20 @@
 import {MutableModel} from "@lblod/ember-rdfa-editor/core/editor-model";
 
 /**
- * Commands are the only things that are allowed to modify the model.
- * TODO: Currently this restriction is not enforced yet.
- * They need to be registered with {@link RawEditor.registerCommand()} before they
- * can be executed with {@link RawEditor.executeCommand()}.
- */
+ * A command is an abstraction of a modification to the VDOM state.
+ * It is the mutating half of the
+ * {@link https://en.wikipedia.org/wiki/Command%E2%80%93query_separation Command-Query-Separation pattern}.
+ * Commands are the only way in which plugins can modify the editor state.
+ *
+ * Throughout the lifetime of the {@link Editor}
+ * (which is identical to the lifetime of its ember component in the host app)
+ * a single instance of each registered command will be made.
+ * It is discouraged to rely on this and keep state between command executions.
+ * (The reason for it being a class rather than a function
+ * is that we may need to keep things like disabled/enabled state in the future.
+ * Arguments can be made here both ways, but this is what we have at the moment.)
+ *
+ * Commands are defined by {@link Plugin plugins} */
 export default abstract class Command<A extends unknown[], R> {
   abstract name: string;
   protected model: MutableModel;
@@ -14,9 +23,28 @@ export default abstract class Command<A extends unknown[], R> {
     this.model = model;
   }
 
+  /**
+   * This method is used to signal if a command "makes sense" in a certain context.
+   * It is a bit of an oddity, at the moment only few commands actually implement it.
+   * It is as of yet unclear if this is a good place for this kind of logic to live.
+   * @param _args
+   */
   canExecute(..._args: A): boolean {
     return true;
   }
 
+  /**
+   * This is where the magic happens. Commands are allowed to freely choose what arguments they require.
+   * Typically commands take in some sort of {@link ModelRange} or other context
+   * (TODO: first-class support for using rdfa-context as a specifier, it's already possible but still a bit cumbersome)
+   * on which they operate.
+   * Modifications to the VDOM are made through the {@link MutableModel} interface,
+   * of which commands receive an instance in their constructors (see below).
+   * This interface provides not much more than a single {@link MutableModel.change change} method.
+   * Commands use the {@link Inspector} to query for VDOM state, and the {@link Mutator} to change it.
+   * This single entrypoint allows the editor to precisely manage its own state, enabling async editing in the future.
+   * @param source The origin of this particular command execution. Usually the name of a {@link EditorPlugin}
+   * @param args
+   */
   abstract execute(source: string, ...args: A): R;
 }

--- a/addon/core/editor-controller.ts
+++ b/addon/core/editor-controller.ts
@@ -6,6 +6,15 @@ import {InternalWidgetSpec, WidgetSpec} from "@lblod/ember-rdfa-editor/archive/u
 import {ModelRangeFactory, RangeFactory} from "@lblod/ember-rdfa-editor/core/model/model-range";
 import ModelSelection from "@lblod/ember-rdfa-editor/core/model/model-selection";
 
+/**
+ * Consumers (aka plugins or the host app) receive a controller instance as their interface to the editor.
+ * Every consumer gets its own unique instance.
+ * It has its own unique name, so any modification and event can be traced back to its originating controller.
+ * This is crucial and the main reason for the existence of controllers.
+ * This way, {@link EditorPlugin plugins} can safely listen to contentChange-type events
+ * and modify the vdom in their handlers, cause they can easily filter out
+ * change events that originate from their own changes, preventing infinite loops.
+ */
 export default interface EditorController {
   registerCommand<A extends unknown[], R>(command: new (model: EditorModel) => Command<A, R>): void;
 
@@ -23,6 +32,11 @@ export default interface EditorController {
 
 }
 
+/**
+ * Default implementation of {@link EditorController}.
+ * Simply delegates most of its methods to an {@link Editor} instance, injecting
+ * its own name where necessary.
+ */
 export class EditorControllerImpl implements EditorController {
   private editor: Editor;
   private name: string;

--- a/addon/core/editor-plugin.ts
+++ b/addon/core/editor-plugin.ts
@@ -1,6 +1,46 @@
 import EditorController from "@lblod/ember-rdfa-editor/core/editor-controller";
 
+/**
+ * In rdfa-editor, we make a distinction the "core" and plugins.
+ * The core takes care of managing the VDOM state and 2-way sync between DOM and VDOM.
+ * It defines a set of primitive operations with which the document state can be queried and changed.
+ *
+ * Plugins use these primitives to actually implement the desired user-facing behavior and UI.
+ * Some plugins are developed right in the rdfa-editor repo and can be considered "internal" plugins.
+ * There is however no real distinction between them and "external" plugins,
+ * they use the exact same interface to do their thing.
+ */
 export interface EditorPlugin {
+
+  /**
+   * Name of the plugin. Should be unique.
+   * Convention is to use kebab-case for plugin names and to not repeat the word "plugin".
+   *
+   * example:
+   * if your EditorPlugin class is called StandardTemplatesPlugin, this method should return
+   * "standard-templates".
+   */
   get name(): string;
+
+  /**
+   * This is the entrypoint for a plugin.
+   *
+   * In this method, plugins should:
+   * - register any {@link Command commands} and {@link Query queries} they themselves define
+   * - register any widgets
+   * - setup any event listeners
+   *
+   * The method is awaited on, so plugins are able to depend on async operations
+   * before they are expected to be "ready".
+   *
+   * In this method, plugins should not:
+   * - execute {@link Command commands} (this will most likely simply fail, and will probably be completely impossible in the future)
+   *
+   * Plugins can expect other plugins that come before them in the plugin-config array
+   * (aka editor-profile, to be refined) to be fully initialized.
+   *
+   * However, it is not advised to depend on this fact.
+   * @param controller Each plugin receives a unique controller instance. It is their only interface to the editor.
+   */
   initialize(controller: EditorController): Promise<void>;
 }

--- a/addon/core/editor.ts
+++ b/addon/core/editor.ts
@@ -9,6 +9,9 @@ import {InternalWidgetSpec, WidgetLocation, WidgetSpec} from "@lblod/ember-rdfa-
 import ModelElement from "@lblod/ember-rdfa-editor/core/model/model-element";
 import ModelSelection from "@lblod/ember-rdfa-editor/core/model/model-selection";
 
+/**
+ * Container interface holding a {@link EditorModel} and exposing core editing API.
+ */
 export default interface Editor {
   executeCommand<A extends unknown[], R>(source: string, commandName: string, ...args: A): R | void;
 
@@ -33,6 +36,10 @@ export default interface Editor {
   get selection(): ModelSelection;
 }
 
+/**
+ * Default implementation of {@link Editor} interface. A single instance of this
+ * class is made per {@link RdfaEditor} component lifetime.
+ */
 export class EditorImpl implements Editor {
   private model: EditorModel;
   private registeredCommands: Map<string, Command<unknown[], unknown>> = new Map<string, Command<unknown[], unknown>>();

--- a/addon/core/inspector.ts
+++ b/addon/core/inspector.ts
@@ -1,3 +1,7 @@
+/**
+ * Immutable counterpart to a {@link Mutator}.
+ * TODO
+ */
 export default interface Inspector{}
 
 export class ModelInspector implements Inspector {}

--- a/addon/core/mutator.ts
+++ b/addon/core/mutator.ts
@@ -4,13 +4,24 @@ import ModelNode from "@lblod/ember-rdfa-editor/core/model/model-node";
 import {TextAttribute} from "@lblod/ember-rdfa-editor/core/model/model-text";
 import ModelElement from "@lblod/ember-rdfa-editor/core/model/model-element";
 
+/**
+ * The methods provided in this interface are the low-level primitives with which the
+ * {@link EditorModel} can be mutated. Any methods implemented here should make use of
+ * {@link Operation operations} exclusively. While hard-enforcing this restriction is planned,
+ * it is not a top-priority since {@link EditorPlugin plugins} cannot provide extensions here.
+ *
+ * While there is no hard requirement for the interface to these methods, most of them
+ * take a {@link ModelRange} as input and return a {@link ModelRange} as output.
+ * This is intentionally "just a convention". Some things are better left unenforced.
+ * The output range should be a "sensible default" resulting range after the modification has happenen.
+ *
+ * e.g.: after inserting multiple nodes, a sensible range to return could be a range that encompasses all the inserted
+ * nodes exactly.
+ *
+ * When deciding what range to return, keep in mind that if you return an uncollapsed range, it is easy to collapse
+ * that to either of its extremes, but the other way round is more difficult.
+ */
 export interface Mutator {
-  /**
-   * @inheritDoc
-   * @param range
-   * @param nodes
-   * @return resultRange the resulting range of the execution
-   */
   insertNodes(range: ModelRange, ...nodes: ModelNode[]): ModelRange;
 
   insertAtPosition(position: ModelPosition, ...nodes: ModelNode[]): ModelRange;
@@ -19,21 +30,8 @@ export interface Mutator {
 
   mergeTextNodesInRange(range: ModelRange): void;
 
-  /**
-   * @inheritDoc
-   * @param rangeToMove
-   * @param targetPosition
-   * @return resultRange the resulting range of the execution
-   */
   moveToPosition(rangeToMove: ModelRange, targetPosition: ModelPosition): ModelRange;
 
-  /**
-   * @inheritDoc
-   * @param range
-   * @param key
-   * @param value
-   * @return resultRange the resulting range of the execution
-   */
   setTextProperty(range: ModelRange, key: TextAttribute, value: boolean): ModelRange;
 
   splitTextAt(position: ModelPosition): ModelPosition;

--- a/addon/core/operations/insert-operation.ts
+++ b/addon/core/operations/insert-operation.ts
@@ -4,6 +4,79 @@ import ModelNode from "@lblod/ember-rdfa-editor/core/model/model-node";
 import ModelPosition from "@lblod/ember-rdfa-editor/core/model/model-position";
 import OperationAlgorithms from "@lblod/ember-rdfa-editor/core/operations/operation-algorithms";
 
+/**
+ * The insert operation deals with inserting a list of nodes into a certain range.
+ * It is defined over a target range and a list of nodes to insert.
+ * **This list may be empty** (see below).
+ * Any content in the target range will get overwritten.
+ *
+ *  # Collapsed Range
+ *
+ *  Inserting nodes into a collapsed range is fairly intuitive to understand. The algorithm goes as follows:
+ *
+ *  - Split the textnode at range.start if necessary
+ *  - insert the nodes one by one, left to right at that position.
+ *  - return a collapsed range set after the last inserted node
+ *
+ *  Some invariants this implies:
+ *  - the first node of the nodeList will have previousSibling set to the node before the start position (or null if there is none)
+ *  - the last node of the nodeList will have nextSibling set to the node after the start position
+ *  (remember, we split first so this may be part of the textnode that was there before)
+ *
+ *  ### empty nodeList
+ *
+ *  If the range is collapsed and the nodeList is empty, the split still happens, but no nodes are inserted.
+ *  The resulting range is the same as the target range.
+ *
+ *  # Uncollapsed Range
+ *
+ *  With uncollapsed ranges, there are multiple ways to logically define an overwriting insert operation.
+ *  We do it as follows:
+ *
+ *  - delete the nodes in the range (see below)
+ *  - insert the nodes in the nodeList into the parentElement of the startPosition, at the parentOffset of that position
+ *  - return a range encompassing the newly inserted nodes
+ *
+ *  ### empty nodeList
+ *
+ *  With an empty nodeList, the nodes in the range are deleted, and none are inserted.
+ *  The resulting range is collapsed at range.start.
+ *
+ *  # Deleting nodes
+ *
+ *  Because the InsertOperation both overwrites and supports "inserting" an empty list,
+ *  we can see that it doubles as a DeleteOperation.
+ *  Once again, deleting nodes in a range can have multiple definitions. Here is how we do it:
+ *
+ *  - split the textNodes at start and end if necessary
+ *  - get the {@link ModelRange.getMinimumConfinedRanges minimum confined ranges} set of the range
+ *  - for every confined range in the set, use the {@link ModelTreeWalker} to walk from start to end **without descending**
+ *  - for every node that we encountered, remove it from the tree
+ *
+ *
+ *  _reminder_: a confined range is a range for which the start and end position have the same parent
+ *
+ *  A nice way to visualize this algorithm is as follows:
+ *
+ *  - take the xml representation of the tree and paste it in your favorite text editor
+ *  - split the textnodes at the start and end (aka `<text>abcd</text>` becomes `<text>ab</text><text>cd</text>` for example)
+ *  - put your cursor at the start position (this will now always be right before a full node because of the split*)
+ *  - drag a selection until the end position
+ *
+ *  Every node for which **both its start and end** tags are fully selected will be deleted.
+ *  Nodes with only their start **or** end tags in the selection will **not** be deleted
+ *  and their structure will be preserved.
+ *
+ *  (You can also look at it as follows: with your selection as described above,
+ *  hit delete, and then repair the resulting xml by adding start and end tags where appropriate)
+ *
+ *  \* quick reminder: with {@link ModelPosition modelpositions}
+ *  `|<text>...</text>` is the same position as `<text>|....</text>`, so choose the former here
+ *
+ *  ### collapsed range
+ *
+ *  When the range is collapsed, the split will still occur but no nodes will be deleted.
+ */
 export default class InsertOperation extends Operation {
   private _nodes: ModelNode[];
 
@@ -37,7 +110,7 @@ export default class InsertOperation extends Operation {
     }
 
     OperationAlgorithms.insert(this.range, ...this.nodes);
-    if(this.range.collapsed) {
+    if (this.range.collapsed) {
       const last = this.nodes[this.nodes.length - 1];
       const pos = ModelPosition.fromAfterNode(last);
       return new ModelRange(pos, pos);

--- a/addon/core/operations/operation.ts
+++ b/addon/core/operations/operation.ts
@@ -1,5 +1,24 @@
 import ModelRange from "@lblod/ember-rdfa-editor/core/model/model-range";
 
+/**
+ * Composable nuclear modification of {@link EditorModel} state.
+ * Think of this as something like the addition and subtraction operations in mathematics,
+ * which we can naturally combine to make multiplication, division and exponentiation operators.
+ *
+ * The goal is to have the set of operations to be as small as possible, since every operation needs to be able
+ * to be composed with any other operation, complexity of composition grows exponentially with the amount
+ * of operations.
+ *
+ * An example of this: you might be tempted to think of Insertion and Deletion as two separate basic operations.
+ * But what if we define insertion of content into a range as overwriting any content that may already exist there?
+ * Then we can simply implement Deletion as the Insertion of nothing.
+ *
+ * While minimalism is the general guideline, performance considerations will likely require pragmatism.
+ * e.g.: a move operation could be considered as 2 Insertion operations,
+ * (one to remove it from the original location, one to insert it at its destination), but implementing it
+ * as a single operation might provide opportunities for optimization.
+ * (think of CPU instruction sets as a possible analogy)
+ */
 export default abstract class Operation {
   private _range: ModelRange;
   protected constructor(range: ModelRange) {

--- a/addon/core/operations/split-operation.ts
+++ b/addon/core/operations/split-operation.ts
@@ -4,6 +4,66 @@ import OperationAlgorithms from "@lblod/ember-rdfa-editor/core/operations/operat
 import ModelPosition from "@lblod/ember-rdfa-editor/core/model/model-position";
 import {ModelError} from "@lblod/ember-rdfa-editor/archive/utils/errors";
 
+/**
+ * The split operation deals with splitting nodes into two new nodes at a certain position.
+ * Both nodes will have identical types and attributes.
+ *
+ * Like all operations, the split operation is defined over a ModelRange.
+ * In addition to the range, the split operation also takes a splitParent boolean, which is true by default.
+ * If splitParent is false, only textNodes at the edges of the range will be split.
+ * If it is true, textnodes will be split, and also the parentelement of the start and endpositions.
+ *
+ *
+ *  # Splitting
+ *
+ * While the operation is defined on a range, it makes more sense to describe the splitting algorithm with a single position.
+ * We define a single splitting operation on a position as follows:
+ *
+ * - if position is inside of a textnode, split it at that position.
+ *
+ * This will result in two textnodes either side of the position.
+ * The resulting position will be unchanged. e.g.:
+ *
+ * ```xml
+ * <text>ab|cd</text>
+ * ```
+ *
+ * will become
+ *
+ * ```xml
+ * <text>ab</text>|<text>cd</text>
+ * ```
+ *
+ * - then, if parentElement is true, split the parent of position. This goes as follows:
+ *     - create a shallow copy of the parent (a new node with identical type and attributes, but without any children)
+ *     - add all children of the parent after the position to the copy
+ *     - add the copy to the parent of the parent, at index parent.index + 1 (so the copy ends up being the nextSibling of the parent), e.g:
+ *       ```xml
+ *       <div><text>ab|cd</text></div>
+ *       ```
+ *       will become
+ *       ```xml
+ *       <div><text>ab</text></div>|<div><text>cd></text></div>
+ *       ```
+ *     - the resulting position is right between the parent and the copy
+ *
+ * # Ranges
+ *
+ * With the above algorithm in mind, we can now define how ranges are handled.
+ *
+ * ## Collapsed range:
+ *
+ * - perform the split on range.start.
+ * - The resulting range is a collapsed range on the resulting position
+ *
+ * ## Uncollapsed range:
+ *
+ * - perform the split on range.end
+ * - perform the split on range.start
+ * - the resulting range contains all content that was originally selected.
+ * This is not simply the same as a range made up of the two resulting positions,
+ * since the position from the first split will be invalid after the second split.
+ */
 export default class SplitOperation extends Operation {
   private _splitParent: boolean;
 
@@ -29,7 +89,7 @@ export default class SplitOperation extends Operation {
       // be careful making changes here
       const end = this.doSplit(this.range.end);
       const afterEnd = end.nodeAfter();
-      if(!afterEnd) {
+      if (!afterEnd) {
         throw new ModelError("Unexpected model state");
       }
       const start = this.doSplit(this.range.start);

--- a/addon/core/query.ts
+++ b/addon/core/query.ts
@@ -1,5 +1,9 @@
 import {ImmutableModel} from "@lblod/ember-rdfa-editor/core/editor-model";
 
+/**
+ * Second half of the {@link https://en.wikipedia.org/wiki/Command%E2%80%93query_separation CQS} pattern.
+ * Encapsulates a "question" you can ask the {@link EditorModel}. Cannot modify the model.
+ */
 export default abstract class Query<A extends unknown[], R> {
   protected model: ImmutableModel;
 


### PR DESCRIPTION
Expand documentation of core architecture and move some wiki information into the code.

The idea is to eventually follow [tsdoc](https://tsdoc.org/) as a standard and use something like typedoc as a doc generator, since it's at least **some** kind of standard, but the whole doc-comment landscape is a pretty sad affair at the moment so it's not an immediate priority, since it all basically looks like jsdoc anyway and it's the text content that really matters the most.