### PR TITLE
Add a new way to initialize plugins

### DIFF
--- a/addon/components/rdfa/rdfa-editor.hbs
+++ b/addon/components/rdfa/rdfa-editor.hbs
@@ -12,6 +12,9 @@
         Voeg sjabloon in
       </AuButton>
       {{/if}}
+      {{#each this.toolbarWidgets as |widget|}}
+        {{component widget.componentName controller=widget.controller plugin=widget.plugin}}
+      {{/each}}
     </Rdfa::EditorToolbar>
   {{/if}}
 
@@ -40,6 +43,13 @@
               </li>
             {{/each}}
           {{/if}}
+          {{#each this.sidebarWidgets as |widget|}}
+            <li class="say-editor-hints__list-item">
+              <div class="say-card"> {{!-- Todo: remove this div once it is over --}}
+                {{component widget.componentName controller=widget.controller plugin=widget.plugin}}
+              </div>
+            </li>
+          {{/each}}
         </ul>
       </div>
       {{yield}}

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -197,6 +197,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
    */
   @action
   async handleRawEditorInit(editor: PernetRawEditor) {
+    console.log("yeet")
     this.editor = editor;
     await this.initializePlugins(editor);
     this.toolbarWidgets = editor.widgetMap.get("toolbar") || [];

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -7,6 +7,7 @@ import {analyse as analyseRdfa} from '@lblod/marawa/rdfa-context-scanner';
 import EventProcessor from '../../utils/rdfa/event-processor';
 import HintsRegistry from '../../utils/rdfa/hints-registry';
 import RdfaDocument from '../../utils/rdfa/rdfa-document';
+import RdfaDocumentController from '../../utils/rdfa/rdfa-document';
 import type IntlService from 'ember-intl/services/intl';
 import RdfaEditorDispatcher from 'dummy/services/rdfa-editor-dispatcher';
 import RawEditor from '@lblod/ember-rdfa-editor/utils/ce/raw-editor';
@@ -230,7 +231,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
       };
       this.args.initDebug(debugInfo);
     }
-    const rdfaDocument = new RdfaDocument(editor);
+    const rdfaDocument = new RdfaDocumentController("host-controller", editor);
     if (this.args.rdfaEditorInit) {
       this.args.rdfaEditorInit(rdfaDocument);
     }

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -198,7 +198,6 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
    */
   @action
   async handleRawEditorInit(editor: PernetRawEditor) {
-    console.log("yeet")
     this.editor = editor;
     await this.initializePlugins(editor);
     this.toolbarWidgets = editor.widgetMap.get("toolbar") || [];

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -13,7 +13,7 @@ import RawEditor from '@lblod/ember-rdfa-editor/utils/ce/raw-editor';
 import PernetRawEditor from '@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor';
 import {EditorPlugin} from "@lblod/ember-rdfa-editor/utils/editor-plugin";
 import ApplicationInstance from '@ember/application/instance';
-import {RawEditorController} from "@lblod/ember-rdfa-editor/model/controller";
+import {InternalWidgetSpec, RawEditorController} from "@lblod/ember-rdfa-editor/model/controller";
 
 interface DebugInfo {
   hintsRegistry: HintsRegistry
@@ -101,6 +101,8 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
   @tracked hintsRegistry?: HintsRegistry;
 
   @tracked suggestedHints: SuggestedHint[] = [];
+  @tracked toolbarWidgets: InternalWidgetSpec[] = [];
+  @tracked sidebarWidgets: InternalWidgetSpec[] = [];
   private owner: ApplicationInstance;
   activePlugins: EditorPlugin[] = [];
 
@@ -138,6 +140,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
   get plugins(): string[] {
     return this.args.plugins || [];
   }
+
 
   /**
    * editor controller
@@ -196,6 +199,8 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
   async handleRawEditorInit(editor: PernetRawEditor) {
     this.editor = editor;
     await this.initializePlugins(editor);
+    this.toolbarWidgets = editor.widgetMap.get("toolbar") || [];
+    this.sidebarWidgets = editor.widgetMap.get("sidebar") || [];
     this.hintsRegistry = new HintsRegistry(editor);
     this.eventProcessor = new EventProcessor({
       registry: this.hintsRegistry,

--- a/addon/model/controller.ts
+++ b/addon/model/controller.ts
@@ -38,7 +38,7 @@ export default interface Controller {
 
 export class RawEditorController implements Controller {
   private readonly _name: string;
-  private readonly _rawEditor: RawEditor;
+  protected readonly _rawEditor: RawEditor;
   private _rangeFactory: RangeFactory;
 
   constructor(name: string, rawEditor: RawEditor) {

--- a/addon/model/controller.ts
+++ b/addon/model/controller.ts
@@ -3,6 +3,7 @@ import {AnyEventName, EditorEventListener, ListenerConfig} from "@lblod/ember-rd
 import ModelSelection from "@lblod/ember-rdfa-editor/model/model-selection";
 import RawEditor from "@lblod/ember-rdfa-editor/utils/ce/raw-editor";
 import {EditorPlugin} from "@lblod/ember-rdfa-editor/utils/editor-plugin";
+import ModelRange, {ModelRangeFactory, RangeFactory} from "@lblod/ember-rdfa-editor/model/model-range";
 
 export type WidgetLocation = "toolbar" | "sidebar";
 
@@ -21,6 +22,8 @@ export default interface Controller {
 
   get selection(): ModelSelection;
 
+  get rangeFactory(): RangeFactory;
+
   executeCommand<A extends unknown[], R>(commandName: string, ...args: A): R | void;
 
   registerCommand<A extends unknown[], R>(command: Command<A, R>): void;
@@ -36,10 +39,12 @@ export default interface Controller {
 export class RawEditorController implements Controller {
   private readonly _name: string;
   private readonly _rawEditor: RawEditor;
+  private _rangeFactory: RangeFactory;
 
   constructor(name: string, rawEditor: RawEditor) {
     this._name = name;
     this._rawEditor = rawEditor;
+    this._rangeFactory = new ModelRangeFactory(this._rawEditor.rootModelNode);
   }
 
   get name(): string {
@@ -48,6 +53,10 @@ export class RawEditorController implements Controller {
 
   get selection(): ModelSelection {
     return this._rawEditor.selection;
+  }
+
+  get rangeFactory(): RangeFactory {
+    return this._rangeFactory;
   }
 
   executeCommand<A extends unknown[], R>(commandName: string, ...args: A): R | void {

--- a/addon/model/controller.ts
+++ b/addon/model/controller.ts
@@ -3,7 +3,7 @@ import {AnyEventName, EditorEventListener, ListenerConfig} from "@lblod/ember-rd
 import ModelSelection from "@lblod/ember-rdfa-editor/model/model-selection";
 import RawEditor from "@lblod/ember-rdfa-editor/utils/ce/raw-editor";
 import {EditorPlugin} from "@lblod/ember-rdfa-editor/utils/editor-plugin";
-import ModelRange, {ModelRangeFactory, RangeFactory} from "@lblod/ember-rdfa-editor/model/model-range";
+import {ModelRangeFactory, RangeFactory} from "@lblod/ember-rdfa-editor/model/model-range";
 
 export type WidgetLocation = "toolbar" | "sidebar";
 

--- a/addon/model/controller.ts
+++ b/addon/model/controller.ts
@@ -2,14 +2,19 @@ import Command from "@lblod/ember-rdfa-editor/commands/command";
 import {AnyEventName, EditorEventListener, ListenerConfig} from "@lblod/ember-rdfa-editor/utils/event-bus";
 import ModelSelection from "@lblod/ember-rdfa-editor/model/model-selection";
 import RawEditor from "@lblod/ember-rdfa-editor/utils/ce/raw-editor";
-import {NotImplementedError} from "@lblod/ember-rdfa-editor/utils/errors";
+import {EditorPlugin} from "@lblod/ember-rdfa-editor/utils/editor-plugin";
 
 export type WidgetLocation = "toolbar" | "sidebar";
 
 export interface WidgetSpec {
   componentName: string;
   desiredLocation: WidgetLocation;
+  plugin: EditorPlugin;
 }
+
+export type InternalWidgetSpec = WidgetSpec & {
+  controller: Controller
+};
 
 export default interface Controller {
   get name(): string;
@@ -62,7 +67,7 @@ export class RawEditorController implements Controller {
   }
 
   registerWidget(_spec: WidgetSpec): void {
-    throw new NotImplementedError();
+    this._rawEditor.registerWidget({..._spec, controller: this});
   }
 
 

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -279,3 +279,50 @@ export default class ModelRange {
   }
 }
 
+export interface RangeFactory {
+  fromPaths(path1: number[], path2: number[], root?: ModelElement): ModelRange;
+
+  fromInElement(element: ModelElement, startOffset: number, endOffset: number): ModelRange;
+
+  fromAroundNode(node: ModelNode): ModelRange;
+
+  fromInTextNode(node: ModelText, startOffset: number, endOffset: number): ModelRange;
+
+  fromInNode(node: ModelNode, startOffset: number, endOffset: number): ModelRange;
+
+  fromAroundAll(): ModelRange;
+}
+
+export class ModelRangeFactory implements RangeFactory {
+  private readonly root: ModelElement;
+
+  constructor(root: ModelElement) {
+    this.root = root;
+  }
+
+  fromPaths(path1: number[], path2: number[], root: ModelElement = this.root): ModelRange {
+    return ModelRange.fromPaths(root, path1, path2);
+  }
+
+  fromInElement(element: ModelElement, startOffset = 0, endOffset: number = element.getMaxOffset()): ModelRange {
+    return ModelRange.fromInElement(element, startOffset, endOffset);
+  }
+
+  fromAroundNode(node: ModelNode): ModelRange {
+    return ModelRange.fromAroundNode(node);
+  }
+
+  fromInTextNode(node: ModelText, startOffset = 0, endOffset: number = node.length): ModelRange {
+    return ModelRange.fromInTextNode(node, startOffset, endOffset);
+  }
+
+  fromInNode(node: ModelNode, startOffset: number, endOffset: number): ModelRange {
+    return ModelRange.fromInNode(node, startOffset, endOffset);
+  }
+
+  fromAroundAll(): ModelRange {
+    return this.fromInElement(this.root);
+  }
+
+
+}

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -40,6 +40,7 @@ import InsertTableColumnBeforeCommand from "@lblod/ember-rdfa-editor/commands/in
 import InsertTableColumnAfterCommand from "@lblod/ember-rdfa-editor/commands/insert-table-column-after-command";
 import ReadSelectionCommand from "@lblod/ember-rdfa-editor/commands/read-selection-command";
 import UndoCommand from "@lblod/ember-rdfa-editor/commands/undo-command";
+import {InternalWidgetSpec, WidgetLocation} from "@lblod/ember-rdfa-editor/model/controller";
 
 /**
  * Raw contenteditable editor. This acts as both the internal and external API to the DOM.
@@ -60,6 +61,11 @@ class RawEditor extends EmberObject {
   private _model?: Model;
   protected tryOutVdom = true;
   protected eventBus: EventBus;
+  widgetMap: Map<WidgetLocation, InternalWidgetSpec[]> = new Map<WidgetLocation, InternalWidgetSpec[]>(
+    [
+      ["toolbar", []],
+      ["sidebar", []]
+    ]);
 
   /**
    * a rich representation of the dom tree created with {{#crossLink "NodeWalker"}}NodeWalker{{/crossLink}}
@@ -172,6 +178,10 @@ class RawEditor extends EmberObject {
    */
   registerCommand(command: Command) {
     this.registeredCommands.set(command.name, command);
+  }
+
+  registerWidget(widget: InternalWidgetSpec): void {
+    this.widgetMap.get(widget.desiredLocation)!.push(widget);
   }
 
   /**

--- a/addon/utils/editor-plugin.ts
+++ b/addon/utils/editor-plugin.ts
@@ -1,0 +1,46 @@
+/**
+ * In rdfa-editor, we make a distinction the "core" and plugins.
+ * The core takes care of managing the VDOM state and 2-way sync between DOM and VDOM.
+ * It defines a set of primitive operations with which the document state can be queried and changed.
+ *
+ * Plugins use these primitives to actually implement the desired user-facing behavior and UI.
+ * Some plugins are developed right in the rdfa-editor repo and can be considered "internal" plugins.
+ * There is however no real distinction between them and "external" plugins,
+ * they use the exact same interface to do their thing.
+ */
+import Controller from "@lblod/ember-rdfa-editor/model/controller";
+
+export interface EditorPlugin {
+
+  /**
+   * Name of the plugin. Should be unique.
+   * Convention is to use kebab-case for plugin names and to not repeat the word "plugin".
+   *
+   * example:
+   * if your EditorPlugin class is called StandardTemplatesPlugin, this method should return
+   * "standard-templates".
+   */
+  get name(): string;
+
+  /**
+   * This is the entrypoint for a plugin.
+   *
+   * In this method, plugins should:
+   * - register any {@link Command commands} and {@link Query queries} they themselves define
+   * - register any widgets
+   * - setup any event listeners
+   *
+   * The method is awaited on, so plugins are able to depend on async operations
+   * before they are expected to be "ready".
+   *
+   * In this method, plugins should not:
+   * - execute {@link Command commands} (this will most likely simply fail, and will probably be completely impossible in the future)
+   *
+   * Plugins can expect other plugins that come before them in the plugin-config array
+   * (aka editor-profile, to be refined) to be fully initialized.
+   *
+   * However, it is not advised to depend on this fact.
+   * @param controller Each plugin receives a unique controller instance. It is their only interface to the editor.
+   */
+  initialize(controller: Controller): Promise<void>;
+}

--- a/addon/utils/rdfa/rdfa-document.ts
+++ b/addon/utils/rdfa/rdfa-document.ts
@@ -1,8 +1,32 @@
-import PernetRawEditor from '../ce/pernet-raw-editor';
 import xmlFormat from 'xml-formatter';
 import HTMLExportWriter from '@lblod/ember-rdfa-editor/model/writers/html-export-writer';
 import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
-import {EditorEventListener} from "@lblod/ember-rdfa-editor/utils/event-bus";
+import {AnyEventName, EditorEventListener, ListenerConfig} from "@lblod/ember-rdfa-editor/utils/event-bus";
+import {RawEditorController} from "@lblod/ember-rdfa-editor/model/controller";
+
+/**
+ * Legacy interface for external consumers. They expect to receive this interface
+ * upon initialization of the editor. Very similar to a controller, which is why we provide
+ * backwards compat in this way
+ */
+interface RdfaDocument {
+  get htmlContent(): string;
+
+  set htmlContent(html: string);
+
+  get xmlContent(): string;
+
+  set xmlContent(xml: string);
+
+  get xmlContentPrettified(): string;
+
+  setHtmlContent(html: string): void;
+
+  on<E extends AnyEventName>(eventName: E, callback: EditorEventListener<E>, config?: ListenerConfig): void;
+
+  off<E extends AnyEventName>(eventName: E, callback: EditorEventListener<E>, config?: ListenerConfig): void;
+
+}
 
 /**
  * RdfaDocument is a virtual representation of the document
@@ -11,39 +35,35 @@ import {EditorEventListener} from "@lblod/ember-rdfa-editor/utils/event-bus";
  *
  * This is both to protect the internal dom of the editor and to remove internals
  */
-export default class RdfaDocument {
-  private _editor: PernetRawEditor;
+export default class RdfaDocumentController extends RawEditorController implements RdfaDocument {
 
-  constructor(editor: PernetRawEditor) {
-    this._editor = editor;
-  }
 
   get htmlContent() {
-    const htmlWriter = new HTMLExportWriter(this._editor.model);
-    const output = (htmlWriter.write(this._editor.model.rootModelNode) as HTMLElement);
+    const htmlWriter = new HTMLExportWriter(this._rawEditor.model);
+    const output = (htmlWriter.write(this._rawEditor.model.rootModelNode) as HTMLElement);
     return output.innerHTML;
   }
 
   set htmlContent(html: string) {
-    const root = this._editor.model.rootModelNode;
+    const root = this._rawEditor.model.rootModelNode;
     const range = ModelRange.fromPaths(root, [0], [root.getMaxOffset()]);
-    this._editor.executeCommand("insert-html", html, range);
-    this._editor.selection.lastRange?.collapse(true);
-    this._editor.model.writeSelection();
+    this._rawEditor.executeCommand("insert-html", html, range);
+    this._rawEditor.selection.lastRange?.collapse(true);
+    this._rawEditor.model.writeSelection();
   }
 
   get xmlContent() {
-    return (this._editor.model.toXml() as Element).innerHTML;
+    return (this._rawEditor.model.toXml() as Element).innerHTML;
   }
 
   set xmlContent(xml: string) {
-    const root = this._editor.model.rootModelNode;
+    const root = this._rawEditor.model.rootModelNode;
     const range = ModelRange.fromPaths(root, [0], [root.getMaxOffset()]);
-    this._editor.executeCommand("insert-xml", xml, range);
+    this._rawEditor.executeCommand("insert-xml", xml, range);
   }
 
   get xmlContentPrettified() {
-    const root = this._editor.model.toXml() as Element;
+    const root = this._rawEditor.model.toXml() as Element;
     let result = '';
     for (const child of root.childNodes) {
       let formatted;
@@ -64,12 +84,11 @@ export default class RdfaDocument {
     this.htmlContent = html;
   }
 
-  // this shows how we can limit the public events with types
-  on<E extends "contentChanged">(eventName: E, callback: EditorEventListener<E>) {
-    this._editor.on(eventName, callback);
+  on<E extends AnyEventName>(eventName: E, callback: EditorEventListener<E>) {
+    this._rawEditor.on(eventName, callback);
   }
 
-  off<E extends "contentChanged">(eventName: E, callback: EditorEventListener<E>) {
-    this._editor.off(eventName, callback);
+  off<E extends AnyEventName>(eventName: E, callback: EditorEventListener<E>) {
+    this._rawEditor.off(eventName, callback);
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
 module.exports = {
+  isDevelopingAddon() {
+    return this.app.env === 'development';
+  },
   name: require('./package').name,
   options: {
     babel: {


### PR DESCRIPTION
The system exists separately from the existing way of registering plugins and is fully backwards compatible.
Makes sure a bare-minimum toolkit is provided to plugins in the form of the RawEditorController, which currently only implements a few methods of the RFC