### PR TITLE
Bugfix: we should not have contenteditable tables exported outside the editor

### DIFF
--- a/addon/model/writers/html-export-writer.ts
+++ b/addon/model/writers/html-export-writer.ts
@@ -20,7 +20,6 @@ export default class HTMLExportWriter implements Writer<ModelNode, Node> {
 
     if (ModelNode.isModelElement(modelNode)) {
       modelNode.removeAttribute('contenteditable');
-
       result = this.htmlElementWriter.write(modelNode);
       for (const child of modelNode.children) {
         result.appendChild(this.write(child));

--- a/addon/model/writers/html-export-writer.ts
+++ b/addon/model/writers/html-export-writer.ts
@@ -19,6 +19,8 @@ export default class HTMLExportWriter implements Writer<ModelNode, Node> {
     let result = null;
 
     if (ModelNode.isModelElement(modelNode)) {
+      modelNode.removeAttribute('contenteditable');
+
       result = this.htmlElementWriter.write(modelNode);
       for (const child of modelNode.children) {
         result.appendChild(this.write(child));

--- a/addon/model/writers/html-export-writer.ts
+++ b/addon/model/writers/html-export-writer.ts
@@ -19,7 +19,6 @@ export default class HTMLExportWriter implements Writer<ModelNode, Node> {
     let result = null;
 
     if (ModelNode.isModelElement(modelNode)) {
-      modelNode.removeAttribute('contenteditable');
       result = this.htmlElementWriter.write(modelNode);
       for (const child of modelNode.children) {
         result.appendChild(this.write(child));

--- a/addon/model/writers/unpolluted-html-element-writer.ts
+++ b/addon/model/writers/unpolluted-html-element-writer.ts
@@ -2,7 +2,7 @@ import Writer from "@lblod/ember-rdfa-editor/model/writers/writer";
 import ModelElement from "@lblod/ember-rdfa-editor/model/model-element";
 import Model from "@lblod/ember-rdfa-editor/model/model";
 
-const INTERNAL_ATTRIBUTES = ['data-editor-highlight', 'data-editor-position-level', 'data-editor-rdfa-position-level'];
+const INTERNAL_ATTRIBUTES = ['data-editor-highlight', 'data-editor-position-level', 'data-editor-rdfa-position-level', 'contenteditable'];
 
 export default class UnpollutedHtmlElementWriter implements Writer<ModelElement, HTMLElement> {
   constructor(private model: Model) {}


### PR DESCRIPTION
fixes a bug where after saving tables would still have a cursor inside them