### PR TITLE
Add a todo test for the limitToRange method

### DIFF
--- a/tests/unit/model/utils/datastore-test.ts
+++ b/tests/unit/model/utils/datastore-test.ts
@@ -1,4 +1,4 @@
-import {module, test} from "qunit";
+import {module, test, todo} from "qunit";
 import {vdom} from "@lblod/ember-rdfa-editor/model/util/xml-utils";
 import {EditorStore} from "@lblod/ember-rdfa-editor/model/util/datastore";
 import ModelRange from "@lblod/ember-rdfa-editor/model/model-range";
@@ -114,5 +114,47 @@ module("Unit | model | utils | datastore-test", () => {
     const decisionUri = "http://data.lblod.info/artikels/bbeb89ae-998b-4339-8de4-c8ab3a0679b5";
     const decisionValueStore = dataStore.match(`>${decisionUri}`, 'prov:value');
     assert.strictEqual(decisionValueStore.size, 1);
+  });
+  // TODO limitToRange currently only works on subjectnodes, tbd how to handle this
+  todo("limitToRange works as expected", assert => {
+    //language=XML
+    const {root, elements: {selected}} = vdom`
+      <div vocab="http://data.vlaanderen.be/ns/besluit#"
+           prefix="eli: http://data.europa.eu/eli/ontology# prov: http://www.w3.org/ns/prov# mandaat: http://data.vlaanderen.be/ns/mandaat# besluit: http://data.vlaanderen.be/ns/besluit# xsd: http://www.w3.org/2001/XMLSchema#"
+           class="app-view">
+        <div typeof="Besluit">
+          <div property="prov:value"
+               datatype="xsd:string">
+            <div property="eli:has_part"
+                 resource="http://data.lblod.info/artikels/bbeb89ae-998b-4339-8de4-c8ab3a0679b5"
+                 typeof="besluit:Artikel">
+              <div property="eli:number" datatype="xsd:string">
+                <text>Artikel 1</text>
+              </div>
+              <span style="display:none;" property="eli:language"
+                    resource="http://publications.europa.eu/resource/authority/language/NLD" typeof="skos:Concept"/>
+              <div property="prov:value" datatype="xsd:string" __id="selected">
+                <span class="mark-highlight-manual">
+                  <text>Voer inhoud in</text>
+                </span>
+              </div>
+            </div>
+            <br/>
+            <div class="mark-highlight-manual">
+              <span data-editor-highlight="true">
+                <text>Voeg nieuw artikel in</text>
+              </span>
+            </div>
+            <br/>
+          </div>
+        </div>
+      </div>
+    `;
+    const datastore = EditorStore.fromParse({modelRoot: root, baseIRI: "http://test.org"});
+    const range = ModelRange.fromAroundNode(selected);
+    const limitedStore = datastore.limitToRange(range, "rangeContains");
+    assert.strictEqual(limitedStore.size, 1);
+
+
   });
 });


### PR DESCRIPTION
limitToRange will probably not work as expected. It currently does the following:
- start building a new empty dataset
- get the contextnodes for the range according to RangeContextStrategy
- for all contextnodes, check if the node has a mapping to a Subject (does not consider parents, only if the node directly defines a subject)
- if a subject is found, add all triples with that subject to the new dataset
- return a new datastore with the new dataset as backend, and with copies of the node-to-term mappings

This is not really "wrong" behavior or anything, but I don't think its very intuitive, and should be reworked. 
I'll add the above to the wiki entry as well.