### PR TITLE
bump docker ember image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM madnificent/ember:3.5.0 as builder
+FROM madnificent/ember:3.26.1 as builder
 
 LABEL maintainer="info@redpencil.io"
 


### PR DESCRIPTION
the docker ember image we were using for our builds was quite old, i don't think
we actually use the build version of the rdfa editor anywhere... but just in
case :).