### PR TITLE
set field directly instead of using this.set

### DIFF
--- a/addon/utils/ce/editor/update.js
+++ b/addon/utils/ce/editor/update.js
@@ -143,7 +143,7 @@ function updateEditorStateAfterUpdate(selection, relativePosition, currentNode) 
     const richNode = this.getRichNodeFor(this.currentNode);
     this.setCaret(richNode.domNode, Math.min(relativePosition, richNode.end));
   } else {
-    this.set('currentNode', null);
+    this.currentNode = null;
     this.setCurrentPosition(this.currentPosition);
   }
 }


### PR DESCRIPTION
pernet update works in the scope of pernet-raw-editor (we should consider merging this into pernet-raw-editor) and that's no longer an emberobject.
This bug affects the decision type plugin
