### PR TITLE
Fix broken datastore in prod

### DIFF
--- a/addon/model/util/gen-tree-walker.ts
+++ b/addon/model/util/gen-tree-walker.ts
@@ -249,6 +249,17 @@ export default class GenTreeWalker<T extends Walkable = Walkable> {
   }
 
   /**
+   * Walk over all nodes. Use this if you only care about the
+   * side-effects of the onEnter and onLeave callbacks
+   */
+  walk(): void {
+    let result = this.nextNode();
+    while (result) {
+      result = this.nextNode();
+    }
+  }
+
+  /**
    * Reset the walker state so the generator can be reused.
    */
   reset() {

--- a/addon/utils/rdfa-parser/rdfa-parser.ts
+++ b/addon/utils/rdfa-parser/rdfa-parser.ts
@@ -157,8 +157,7 @@ export class RdfaParser {
       onEnterNode: parser.onEnterNode,
       onLeaveNode: parser.onLeaveNode,
     });
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const _nodes = [...walker.nodes()];
+    walker.walk();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const _ of pathFromDomRoot) {
       parser.onTagClose();


### PR DESCRIPTION
Terser removes unused code by default, which got rid of the consumption of the walker, which meant the side-effects didn't trigger, which meant the rdfa-parser wasn't actually parsing very much.

_sigh_

So ignoring the "unused variables" lint has some consequences, watch out.
