### PR TITLE
Also recalculate datastore on model-read

### DIFF
--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -114,6 +114,17 @@ export default class RawEditor {
       },
       { priority: 'highest' }
     );
+    this.eventBus.on(
+      'modelRead',
+      () => {
+        this._datastore = EditorStore.fromParse({
+          modelRoot: this.model.rootModelNode,
+          pathFromDomRoot: getPathFromRoot(this.model.rootNode, false),
+          baseIRI: (properties?.baseIRI as string | null) || document.baseURI,
+        });
+      },
+      { priority: 'highest' }
+    );
   }
 
   /**


### PR DESCRIPTION
Datastore was only being updated on contentChange, but modelRead also changes the vdom state so needs another recalc
