### PR TITLE
Don't export the debug component

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,9 @@ This addon uses CSS variables to customise the styling. You can override these v
 
 
 ## Compatibility
-* Ember.js v3.12 or above
-* Ember CLI v2.13 or above
+* Ember.js v3.20 or above
+* Ember CLI v2.20 or above
 * Node.js v10 or above
-
 
 
 ## Contributing
@@ -220,10 +219,27 @@ export default {
 
 A plugin is an Ember addon providing a service that implements `execute` to handle changes in the editor and provides a component to display hints.
 
-If you want to test the addon with a dummy app, you could use the debug component to enable debugging features (this was previously done by copying dummy code from the editor). The debug component can be added with `<Rdfa::RdfaEditorWithDebug>` and should support the same variables as the `<Rdfa::RdfaEditor>`. The block content of the debug component is yielded at the top of the component, right before the debug features. E.g.:
+If you want to test the addon with a dummy app, you could use the debug component to enable debugging features (this was previously done by copying dummy code from the editor). 
+
+To use the debug component create an rdfa-editor-with-debug.js file in `/tests/dummy/app/components` with the contents:
+
+```js
+export {default} from "@lblod/ember-rdfa-editor/components/rdfa/rdfa-editor-with-debug";
+```
+
+include the following dependencies as devDependencies in `package.json`:
+
+```
+@codemirror/basic-setup
+@codemirror/lang-html
+@codemirror/lang-xml
+xml-formatter
+```
+
+The debug component can then be added with `<RdfaEditorWithDebug>` to your dummy app templates. It should support the same variables as the `<Rdfa::RdfaEditor>`. Note that the debug component does not require a namespace prefix because you just imported it directly in the dummy app with the previous steps. The block content of the debug component is yielded at the top of the component, right before the debug features. E.g.:
 
 ```handlebars
-<Rdfa::RdfaEditorWithDebug
+<RdfaEditorWithDebug
   @rdfaEditorInit={{this.rdfaEditorInit}}
   @plugins={{this.plugins}}
   @editorOptions={{hash
@@ -242,9 +258,8 @@ If you want to test the addon with a dummy app, you could use the debug componen
     showIndentButtons="true"
   }}>
   <h1>Plugin title - dummy app</h1>
-</Rdfa::RdfaEditorWithDebug>
+</RdfaEditorWithDebug>
 ```
-
 
 #### Service interface
 

--- a/app/components/rdfa/rdfa-editor-with-debug.js
+++ b/app/components/rdfa/rdfa-editor-with-debug.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-rdfa-editor/components/rdfa/rdfa-editor-with-debug';


### PR DESCRIPTION
Dont export the debug component so that apps that don't need it don't have to depend on heavy debug dependencies.

To use the debug component in a plugin, do the following:

- create an rdfa-editor-with-debug.js file in `/tests/dummy/app/components` with the contents:

```
export {default} from "@lblod/ember-rdfa-editor/components/rdfa/rdfa-editor-with-debug";
```

- include the following dependencies as devDependencies:
    - @codemirror/basic-setup
    - @codemirror/lang-html
    - @codemirror/lang-xml
    - xml-formatter

- use the debug component in your dummy templates as `<RdfaEditorWithDebug />`
