### PR TITLE
Implement text-matching command

### DIFF
--- a/addon/commands/match-text-command.ts
+++ b/addon/commands/match-text-command.ts
@@ -1,0 +1,30 @@
+import Model from '@lblod/ember-rdfa-editor/model/model';
+import Command from '@lblod/ember-rdfa-editor/commands/command';
+import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
+
+export default class MatchTextCommand extends Command<
+  [ModelRange, RegExp],
+  ModelRange[]
+> {
+  name = 'match-text';
+
+  constructor(model: Model) {
+    super(model);
+  }
+
+  execute(limitRange: ModelRange, regex: RegExp): ModelRange[] {
+    const { textContent, indexToPos } = limitRange.getTextContentWithMapping();
+
+    const result = [];
+    for (const match of textContent.matchAll(regex)) {
+      const matchIndex = match.index;
+      if (matchIndex !== undefined) {
+        const startPos = indexToPos(matchIndex);
+        const matchedString = match[0];
+        const endPos = indexToPos(matchIndex + matchedString.length);
+        result.push(new ModelRange(startPos, endPos));
+      }
+    }
+    return result;
+  }
+}

--- a/addon/commands/match-text-command.ts
+++ b/addon/commands/match-text-command.ts
@@ -74,7 +74,7 @@ function convertMatch(
       input: match.input || '',
       text: matchedString,
       groups: match.slice(1),
-      range: new ModelRange(startPos, endPos),
+      range: new ModelRange(startPos, endPos).shrinkToTextNodes(),
       index: matchIndex,
     };
   }

--- a/addon/commands/match-text-command.ts
+++ b/addon/commands/match-text-command.ts
@@ -1,10 +1,34 @@
 import Model from '@lblod/ember-rdfa-editor/model/model';
 import Command from '@lblod/ember-rdfa-editor/commands/command';
 import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
+import ModelPosition from '@lblod/ember-rdfa-editor/model/model-position';
+
+export interface TextMatch {
+  /**
+   * The range that encompasses the matched text
+   */
+  range: ModelRange;
+  /**
+   * The matched text
+   */
+  text: string;
+  /**
+   * The matched text in the capture groups
+   */
+  groups: string[];
+  /**
+   * The index in the inputstring where the match was found (0-based)
+   */
+  index: number;
+  /**
+   * The inputstring that was matched against
+   */
+  input: string;
+}
 
 export default class MatchTextCommand extends Command<
   [ModelRange, RegExp],
-  ModelRange[]
+  TextMatch[]
 > {
   name = 'match-text';
 
@@ -12,19 +36,47 @@ export default class MatchTextCommand extends Command<
     super(model);
   }
 
-  execute(limitRange: ModelRange, regex: RegExp): ModelRange[] {
+  execute(limitRange: ModelRange, regex: RegExp): TextMatch[] {
     const { textContent, indexToPos } = limitRange.getTextContentWithMapping();
 
-    const result = [];
-    for (const match of textContent.matchAll(regex)) {
-      const matchIndex = match.index;
-      if (matchIndex !== undefined) {
-        const startPos = indexToPos(matchIndex);
-        const matchedString = match[0];
-        const endPos = indexToPos(matchIndex + matchedString.length);
-        result.push(new ModelRange(startPos, endPos));
+    const result: TextMatch[] = [];
+    if (regex.global) {
+      for (const match of textContent.matchAll(regex)) {
+        const textMatch = convertMatch(match, indexToPos);
+        if (textMatch) {
+          result.push(textMatch);
+        }
       }
+      return result;
+    } else {
+      const match = textContent.match(regex);
+      if (match) {
+        const textMatch = convertMatch(match, indexToPos);
+        if (textMatch) {
+          return [textMatch];
+        }
+      }
+      return [];
     }
-    return result;
   }
+}
+
+function convertMatch(
+  match: RegExpMatchArray,
+  indexToPos: (textIndex: number) => ModelPosition
+): TextMatch | null {
+  const matchIndex = match.index;
+  if (matchIndex !== undefined) {
+    const startPos = indexToPos(matchIndex);
+    const matchedString = match[0];
+    const endPos = indexToPos(matchIndex + matchedString.length);
+    return {
+      input: match.input || '',
+      text: matchedString,
+      groups: match.slice(1),
+      range: new ModelRange(startPos, endPos),
+      index: matchIndex,
+    };
+  }
+  return null;
 }

--- a/addon/commands/match-text-command.ts
+++ b/addon/commands/match-text-command.ts
@@ -74,7 +74,7 @@ function convertMatch(
       input: match.input || '',
       text: matchedString,
       groups: match.slice(1),
-      range: new ModelRange(startPos, endPos).shrinkToTextNodes(),
+      range: new ModelRange(startPos, endPos).shrinkToVisible(),
       index: matchIndex,
     };
   }

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -354,7 +354,7 @@ export default class ModelRange {
     for (const node of walker.nodes()) {
       if (ModelNode.isModelText(node)) {
         // keep a sparse mapping of character indices in the resulting string to paths
-        const sanitizedContent = node.content;
+        const sanitizedContent = node.content.replace(/\u200B/g, '');
         if (calculateMapping) {
           const path = ModelPosition.fromBeforeNode(node).path;
           mapping.push([

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -11,6 +11,7 @@ import ModelTreeWalker, {
 import GenTreeWalker from '@lblod/ember-rdfa-editor/model/util/gen-tree-walker';
 import { IllegalArgumentError } from '@lblod/ember-rdfa-editor/utils/errors';
 import { MarkSet } from '@lblod/ember-rdfa-editor/model/mark';
+import { INVISIBLE_SPACE } from '@lblod/ember-rdfa-editor/model/util/constants';
 
 /**
  * Model-space equivalent of a {@link Range}
@@ -354,7 +355,8 @@ export default class ModelRange {
     for (const node of walker.nodes()) {
       if (ModelNode.isModelText(node)) {
         // keep a sparse mapping of character indices in the resulting string to paths
-        const sanitizedContent = node.content.replace(/\u200B/g, '');
+        const pattern = new RegExp(`${INVISIBLE_SPACE}`, 'g');
+        const sanitizedContent = node.content.replace(pattern, '');
         if (calculateMapping) {
           const path = ModelPosition.fromBeforeNode(node).path;
           mapping.push([

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -11,7 +11,6 @@ import ModelTreeWalker, {
 import GenTreeWalker from '@lblod/ember-rdfa-editor/model/util/gen-tree-walker';
 import { IllegalArgumentError } from '@lblod/ember-rdfa-editor/utils/errors';
 import { MarkSet } from '@lblod/ember-rdfa-editor/model/mark';
-import { INVISIBLE_SPACE } from '@lblod/ember-rdfa-editor/model/util/constants';
 
 /**
  * Model-space equivalent of a {@link Range}
@@ -342,6 +341,7 @@ export default class ModelRange {
     // get all textnodes in range
     const walker = GenTreeWalker.fromRange({
       range: this,
+      descend: true,
     });
 
     // calculate difference between start of range and start of the first textnode
@@ -354,7 +354,7 @@ export default class ModelRange {
     for (const node of walker.nodes()) {
       if (ModelNode.isModelText(node)) {
         // keep a sparse mapping of character indices in the resulting string to paths
-        const sanitizedContent = node.content.replace(INVISIBLE_SPACE, '');
+        const sanitizedContent = node.content;
         if (calculateMapping) {
           const path = ModelPosition.fromBeforeNode(node).path;
           mapping.push([
@@ -363,7 +363,7 @@ export default class ModelRange {
           ]);
           currentIndex += sanitizedContent.length;
         }
-        textContent = textContent.concat(sanitizedContent);
+        textContent += sanitizedContent;
       } else if (node.isBlock) {
         if (calculateMapping) {
           const path = node.length

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -311,6 +311,75 @@ export default class ModelRange {
     }
   }
 
+  getTextContent(): string {
+    return this.textContentHelper(false).textContent;
+  }
+
+  getTextContentWithMapping(): { textContent: string, indexToPos: (textIndex: number) => ModelPosition } {
+    return this.textContentHelper(true);
+  }
+
+  private textContentHelper(calculateMapping: boolean): { textContent: string, indexToPos: (textIndex: number) => ModelPosition } {
+    let textContent = "";
+
+    // a sparse map of character indices of the resultstring to paths
+    // it looks something like this:
+    // [[4, [0, 0]], [18, [1,3,4]]]
+    // the first number is the limitnumber
+    // meaning all indices up to 4 correspond to textnode with path [0,0],
+    // all indices between 4 and 18 correspond to textnode with path [1,3,4], etc
+    // to get the final path of the index, add the difference between the index
+    // and the last encountered limit to the last element of the path
+    const mapping: [number, number[]][] = [];
+
+    // get all textnodes in range
+    const walker = new ModelTreeWalker<ModelText>({
+      range: this,
+      descend: true,
+      filter: toFilterSkipFalse(ModelNode.isModelText)
+    });
+    // calculate difference between start of range and start of the first textnode
+    const startOffset = this.start.isInsideText() ? this.start.parentOffset - this.start.nodeAfter()!.getOffset() : 0;
+
+    let currentIndex = 0;
+    // build the resultstring
+    for (const textNode of walker) {
+      // keep a sparse mapping of character indices in the resulting string to paths
+      if (calculateMapping) {
+        const path = ModelPosition.fromBeforeNode(textNode).path;
+        mapping.push([currentIndex + textNode.length - startOffset, path]);
+        currentIndex += textNode.length;
+      }
+      textContent = textContent.concat(textNode.content);
+    }
+
+    // calculate endoffset, or the difference between the offset just after the final textnode and the endposition of
+    // the range
+    let endOffset = textContent.length;
+    if (this.end.isInsideText()) {
+      const textNode = this.end.nodeAfter()!;
+      const maxOffset = textNode.getOffset() + textNode.length;
+      endOffset -= maxOffset - this.end.parentOffset;
+    }
+
+    // the mapping function to convert resultstring indices back to positions
+    const indexToPos = (index: number): ModelPosition => {
+
+      let lastLimit = 0;
+      for (const [limit, path] of mapping) {
+        if (index < limit) {
+          const resultPath = [...path];
+          const final = resultPath[resultPath.length - 1];
+          resultPath[resultPath.length - 1] = final + index - lastLimit;
+          return ModelPosition.fromPath(this.root, resultPath);
+        }
+        lastLimit = limit;
+      }
+      return this.end;
+    };
+
+    return {textContent: textContent.substring(startOffset, endOffset), indexToPos};
+  }
   toString(): string {
     return `ModelRange<[${this.start.path.toString()}] - [${this.end.path.toString()}]>`;
   }

--- a/addon/model/util/gen-tree-walker.ts
+++ b/addon/model/util/gen-tree-walker.ts
@@ -159,6 +159,16 @@ export default class GenTreeWalker<T extends Walkable = Walkable> {
     } else {
       startNode = getNextNodeFromPosition(startPos, reverse);
       endNode = getPrevNodeFromPosition(endPos, reverse);
+      if (startNode && endNode && startNode === endNode) {
+        return GenTreeWalker.fromSubTree({
+          root: startNode,
+          descend,
+          reverse,
+          visitParentUpwards,
+          onEnterNode,
+          onLeaveNode,
+        });
+      }
       if (!startNode) {
         const ancestorWithSibling = startPos.parent
           .findSelfOrAncestors((node) => !!getNextSibling(node, reverse))

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -21,7 +21,9 @@ import RemoveStrikethroughCommand from '@lblod/ember-rdfa-editor/commands/text-p
 import RemoveUnderlineCommand from '@lblod/ember-rdfa-editor/commands/text-properties/remove-underline-command';
 import UnindentListCommand from '@lblod/ember-rdfa-editor/commands/unindent-list-command';
 import Model from '@lblod/ember-rdfa-editor/model/model';
-import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
+import ModelRange, {
+  ModelRangeFactory,
+} from '@lblod/ember-rdfa-editor/model/model-range';
 import ModelSelection from '@lblod/ember-rdfa-editor/model/model-selection';
 import ModelSelectionTracker from '@lblod/ember-rdfa-editor/utils/ce/model-selection-tracker';
 import { walk as walkDomNode } from '@lblod/marawa/node-walker';
@@ -62,6 +64,7 @@ import AddMarkToRangeCommand from '@lblod/ember-rdfa-editor/commands/add-mark-to
 import RemoveMarkFromRangeCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-from-range-command';
 import PernetRawEditor from '@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor';
 import RemoveMarkCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-command';
+import MatchTextCommand from '@lblod/ember-rdfa-editor/commands/match-text-command';
 
 export interface RawEditorProperties {
   baseIRI: string;
@@ -100,6 +103,7 @@ export default class RawEditor {
    */
   @tracked
   richNode!: RichNode;
+  rangeFactory!: ModelRangeFactory;
 
   constructor(properties: RawEditorProperties) {
     this.eventBus = new EventBus();
@@ -187,6 +191,7 @@ export default class RawEditor {
     this.registerCommand(new AddMarkToRangeCommand(this.model));
     this.registerCommand(new RemoveMarkFromRangeCommand(this.model));
     this.registerCommand(new RemoveMarkCommand(this.model));
+    this.registerCommand(new MatchTextCommand(this.model));
     this.registerMark(highlightMarkSpec);
   }
 
@@ -205,6 +210,7 @@ export default class RawEditor {
       this.model.selection.collapseIn(this.model.rootModelNode);
       this.model.write();
       this.updateRichNode();
+      this.rangeFactory = new ModelRangeFactory(this.rootModelNode);
     }
   }
 

--- a/tests/unit/commands/match-text-command-test.ts
+++ b/tests/unit/commands/match-text-command-test.ts
@@ -4,6 +4,7 @@ import MatchTextCommand from '@lblod/ember-rdfa-editor/commands/match-text-comma
 import { vdom } from '@lblod/ember-rdfa-editor/model/util/xml-utils';
 import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
 import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
+import { INVISIBLE_SPACE } from '@lblod/ember-rdfa-editor/model/util/constants';
 
 module('Unit | commands | match-text-command-text', (hooks) => {
   const ctx = new ModelTestContext();
@@ -118,6 +119,21 @@ module('Unit | commands | match-text-command-text', (hooks) => {
     ctx.model.fillRoot(root as ModelElement);
     assert.strictEqual(results.length, 0);
   });
+  test('match across invisible spaces', (assert) => {
+    //language=XML
+    const { root } = vdom`
+      <modelRoot>
+        <div>
+          <text>te${INVISIBLE_SPACE}st</text>
+        </div>
+      </modelRoot>
+    `;
+    const searchRange = ModelRange.fromInElement(root as ModelElement);
+    const results = command.execute(searchRange, /test/g);
+
+    ctx.model.fillRoot(root as ModelElement);
+    assert.strictEqual(results.length, 1);
+  });
   test('match block node boundary as newline', (assert) => {
     //language=XML
     const { root } = vdom`
@@ -148,7 +164,7 @@ module('Unit | commands | match-text-command-text', (hooks) => {
     const { root } = vdom`
       <modelRoot>
         <span>text</span>
-        <div/>
+        <br/>
         <div/>
         <div>
           <text>st</text>

--- a/tests/unit/commands/match-text-command-test.ts
+++ b/tests/unit/commands/match-text-command-test.ts
@@ -1,0 +1,171 @@
+import { module, test } from 'qunit';
+import ModelTestContext from 'dummy/tests/utilities/model-test-context';
+import MatchTextCommand from '@lblod/ember-rdfa-editor/commands/match-text-command';
+import { vdom } from '@lblod/ember-rdfa-editor/model/util/xml-utils';
+import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
+import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
+
+module('Unit | commands | match-text-command-text', (hooks) => {
+  const ctx = new ModelTestContext();
+  let command: MatchTextCommand;
+  hooks.beforeEach(() => {
+    ctx.reset();
+    command = new MatchTextCommand(ctx.model);
+  });
+  test('finds text in simple range', (assert) => {
+    //language=XML
+    const {
+      root,
+      textNodes: { contentNode },
+    } = vdom`
+      <modelRoot>
+        <text __id="contentNode">xxxxtestxxx</text>
+      </modelRoot>
+    `;
+
+    const expectedRange = ModelRange.fromInNode(contentNode, 4, 8);
+    const result = command.execute(
+      ModelRange.fromInElement(root as ModelElement),
+      /test/g
+    );
+    ctx.model.fillRoot(root);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].text, 'test');
+    assert.strictEqual(result[0].index, 4);
+    assert.true(result[0].range.sameAs(expectedRange));
+  });
+  test('match across nodes', (assert) => {
+    //language=XML
+    const { root } = vdom`
+      <modelRoot>
+        <text>1234</text>
+        <span>
+          <text>5678</text>
+        </span>
+      </modelRoot>
+    `;
+    const expectedRange = ModelRange.fromPaths(
+      root as ModelElement,
+      [2],
+      [4, 2]
+    );
+    const searchRange = ModelRange.fromInElement(root as ModelElement);
+    const result = command.execute(searchRange, /3456/);
+    ctx.model.fillRoot(root);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].text, '3456');
+    assert.strictEqual(result[0].index, 2);
+    assert.true(result[0].range.sameAs(expectedRange));
+  });
+  test('match multiple occurences', (assert) => {
+    //language=XML
+    const { root } = vdom`
+      <modelRoot>
+        <text>te</text>
+        <text>st</text>
+        <span>
+          <text>test</text>
+        </span>
+
+        <span>
+          <text>t</text>
+        </span>
+        <span>
+          <span>
+            <text>es</text>
+          </span>
+        </span>
+        <span>
+          <text>t</text>
+        </span>
+      </modelRoot>
+    `;
+    const searchRange = ModelRange.fromInElement(root as ModelElement);
+    const results = command.execute(searchRange, /test/g);
+    const expectedRange1 = ModelRange.fromPaths(root as ModelElement, [0], [4]);
+    const expectedRange2 = ModelRange.fromPaths(
+      root as ModelElement,
+      [4, 0],
+      [4, 4]
+    );
+    const expectedRange3 = ModelRange.fromPaths(
+      root as ModelElement,
+      [5, 0],
+      [7, 1]
+    );
+
+    ctx.model.fillRoot(root as ModelElement);
+    assert.strictEqual(results.length, 3);
+    assert.true(results[0].range.sameAs(expectedRange1));
+    assert.true(results[1].range.sameAs(expectedRange2));
+    assert.true(results[2].range.sameAs(expectedRange3));
+  });
+  test('dont match across block nodes', (assert) => {
+    //language=XML
+    const { root } = vdom`
+      <modelRoot>
+        <div>
+          <text>te</text>
+        </div>
+        <div>
+          <text>st</text>
+        </div>
+      </modelRoot>
+    `;
+    const searchRange = ModelRange.fromInElement(root as ModelElement);
+    const results = command.execute(searchRange, /test/g);
+
+    ctx.model.fillRoot(root as ModelElement);
+    assert.strictEqual(results.length, 0);
+  });
+  test('match block node boundary as newline', (assert) => {
+    //language=XML
+    const { root } = vdom`
+      <modelRoot>
+        <div>
+          <text>te</text>
+        </div>
+        <div>
+          <text>st</text>
+        </div>
+      </modelRoot>
+    `;
+    const searchRange = ModelRange.fromInElement(root as ModelElement);
+    const results = command.execute(searchRange, /te\nst/g);
+
+    const expectedRange = ModelRange.fromPaths(
+      root as ModelElement,
+      [0, 0],
+      [1, 2]
+    );
+    ctx.model.fillRoot(root as ModelElement);
+    assert.strictEqual(results.length, 1);
+
+    assert.true(results[0].range.sameAs(expectedRange));
+  });
+  test('match block nodes as newlines', (assert) => {
+    //language=XML
+    const { root } = vdom`
+      <modelRoot>
+        <span>text</span>
+        <div/>
+        <div/>
+        <div>
+          <text>st</text>
+        </div>
+      </modelRoot>
+    `;
+    const searchRange = ModelRange.fromInElement(root as ModelElement);
+    const results = command.execute(searchRange, /\n\n\n/g);
+
+    const expectedRange = ModelRange.fromPaths(
+      root as ModelElement,
+      [1],
+      [3, 0]
+    );
+    ctx.model.fillRoot(root as ModelElement);
+    assert.strictEqual(results.length, 1);
+
+    assert.true(results[0].range.sameAs(expectedRange));
+  });
+});


### PR DESCRIPTION
Provides a way to regex-search the text inside a range.
Handles blocknodes (treated as newlines for searching purposes) and invisible spaces (ignored).

This is a heavily modified port of the match-text command from the now-defunct plugin-rework branch, for those that remember that.
