### PR TITLE
Make backspace handler trigger contentchanged event

### DIFF
--- a/addon/editor/input-handlers/backspace-handler.ts
+++ b/addon/editor/input-handlers/backspace-handler.ts
@@ -38,6 +38,8 @@ import {
   isBeforeInputEvent,
   isKeyDownEvent,
 } from '@lblod/ember-rdfa-editor/editor/input-handlers/event-helpers';
+import { ContentChangedEvent } from '@lblod/ember-rdfa-editor/utils/editor-event';
+import { CORE_OWNER } from '@lblod/ember-rdfa-editor/model/util/constants';
 
 /**
  * Represents the coordinates of a DOMRect relative to RootNode of the editor.
@@ -386,6 +388,15 @@ export default class BackspaceHandler extends InputHandler {
 
     void this.backspace().then(() => {
       this.rawEditor.updateSelectionAfterComplexInput(); // make sure currentSelection of editor is up to date with actual cursor position
+      this.rawEditor.eventBus.emit(
+        new ContentChangedEvent({
+          owner: CORE_OWNER,
+          payload: {
+            type: 'unknown',
+            rootModelNode: this.rawEditor.rootModelNode,
+          },
+        })
+      );
     });
 
     return { allowPropagation: false };

--- a/addon/model/marks-registry.ts
+++ b/addon/model/marks-registry.ts
@@ -53,6 +53,8 @@ export default class MarksRegistry {
       const { insertedNodes, _markCheckNodes } = payload;
       this.updateMarksForNodes(insertedNodes);
       this.updateMarksForNodes(_markCheckNodes);
+    } else if (payload.type === 'unknown') {
+      this.updateMarksForNodes(payload.rootModelNode.children);
     }
   };
 

--- a/addon/utils/ce/pernet-raw-editor.ts
+++ b/addon/utils/ce/pernet-raw-editor.ts
@@ -314,14 +314,6 @@ export default class PernetRawEditor extends RawEditor implements Editor {
       }
       this.updateRichNode();
     }
-    // this.eventBus.emit(
-    //   new ContentChangedEvent({
-    //     owner: CORE_OWNER,
-    //     payload: {
-    //       type: 'legacy',
-    //     },
-    //   })
-    // );
   }
 
   /**

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -86,7 +86,7 @@ export default class RawEditor {
   private _model?: Model;
   private _datastore!: Datastore;
   protected tryOutVdom = true;
-  protected eventBus: EventBus;
+  eventBus: EventBus;
   widgetMap: Map<WidgetLocation, InternalWidgetSpec[]> = new Map<
     WidgetLocation,
     InternalWidgetSpec[]

--- a/addon/utils/editor-event.ts
+++ b/addon/utils/editor-event.ts
@@ -4,6 +4,7 @@ import { CORE_OWNER } from '@lblod/ember-rdfa-editor/model/util/constants';
 import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
 import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
 import ModelPosition from '@lblod/ember-rdfa-editor/model/model-position';
+import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
 
 export type EDITOR_EVENT_MAP = {
   dummy: DummyEvent;
@@ -98,8 +99,9 @@ export class DummyEvent extends AbstractEditorEvent<void> {
   }
 }
 
-interface LegacyPayload {
-  type: 'legacy';
+interface UnknownPayload {
+  type: 'unknown';
+  rootModelNode: ModelElement;
 }
 
 interface MovePayload {
@@ -133,7 +135,7 @@ interface InsertionPayload {
   _markCheckNodes: ModelNode[];
 }
 
-type ContentChangedPayload = InsertionPayload | MovePayload | LegacyPayload;
+type ContentChangedPayload = InsertionPayload | MovePayload | UnknownPayload;
 
 export class ContentChangedEvent extends AbstractEditorEvent<ContentChangedPayload> {
   _name: EditorEventName = 'contentChanged';


### PR DESCRIPTION
Because we can't really know what changed when dealing with old code, the content-changed event thrown has a payload of `{type: 'unknown', rootModelNode: root}`.
