### PR TITLE
Bug/mark attribute rendering

### DIFF
--- a/addon/model/mark.ts
+++ b/addon/model/mark.ts
@@ -119,6 +119,7 @@ export class MarkSet extends HashSet<Mark> {
     }
     return false;
   }
+
   clone(): this {
     return new MarkSet() as this;
   }
@@ -142,7 +143,9 @@ function renderFromSpec(spec: RenderSpec, block: Node): Node {
     } else {
       result = document.createElement(nodeSpec.tag);
       for (const [key, val] of Object.entries(nodeSpec.attributes)) {
-        result.setAttribute(key, val.toString());
+        if (val !== undefined) {
+          result.setAttribute(key, val.toString());
+        }
       }
     }
 

--- a/tests/unit/commands/match-text-command-test.ts
+++ b/tests/unit/commands/match-text-command-test.ts
@@ -184,4 +184,42 @@ module('Unit | commands | match-text-command-text', (hooks) => {
 
     assert.true(results[0].range.sameAs(expectedRange));
   });
+  test('only match inside of searchRange', (assert) => {
+    //language=XML
+    const {
+      root,
+      textNodes: { resultNode },
+      elements: { searchContainer },
+    } = vdom`
+      <modelRoot>
+        <div __id="searchContainer">
+          <span><text __id="resultNode">text</text></span>
+        </div>
+        <span>text</span>
+      </modelRoot>
+    `;
+    const searchRange = ModelRange.fromInElement(searchContainer);
+    const results = command.execute(searchRange, /text/g);
+    assert.strictEqual(results.length, 1);
+    assert.true(results[0].range.sameAs(ModelRange.fromAroundNode(resultNode)));
+  });
+  test('only match greedy', (assert) => {
+    //language=XML
+    const {
+      root,
+      textNodes: { resultNode },
+      elements: { searchContainer },
+    } = vdom`
+      <modelRoot>
+        <div __id="searchContainer">
+          <span><text __id="resultNode">text</text></span>
+        </div>
+        <span>text</span>
+      </modelRoot>
+    `;
+    const searchRange = ModelRange.fromInElement(searchContainer);
+    const results = command.execute(searchRange, /t.*/g);
+    assert.strictEqual(results.length, 1);
+    assert.true(results[0].range.sameAs(ModelRange.fromAroundNode(resultNode)));
+  });
 });

--- a/tests/unit/commands/match-text-command-test.ts
+++ b/tests/unit/commands/match-text-command-test.ts
@@ -187,7 +187,6 @@ module('Unit | commands | match-text-command-text', (hooks) => {
   test('only match inside of searchRange', (assert) => {
     //language=XML
     const {
-      root,
       textNodes: { resultNode },
       elements: { searchContainer },
     } = vdom`
@@ -206,7 +205,6 @@ module('Unit | commands | match-text-command-text', (hooks) => {
   test('only match greedy', (assert) => {
     //language=XML
     const {
-      root,
       textNodes: { resultNode },
       elements: { searchContainer },
     } = vdom`


### PR DESCRIPTION
fix mark rendering crashing when an attribute had `undefined` as a value