### PR TITLE
Implement incremental dom writing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -97,6 +97,6 @@ name: npm_access_token
 data: GrKv0avLg7OMiirYoRceI3ktIBjZeFYt2yblNKuAxUY46SBgX8yPtCe82q5ASQY2kfEwT+FDB1MkpTJDXU0z8nZDzrM=
 ---
 kind: signature
-hmac: 84b099e7da9c6ac914adadfabe9fcf499154004904f5356dcacc91219fa760b1
+hmac: a506def5e16463b6ae930259bbb866633ae7f7f104e7a1ac5c7c0d0467164d3f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,15 +4,15 @@ type: docker
 name: verify-pr
 steps:
 - name: install
-  image: danlynn/ember-cli:3.20.0
+  image: danlynn/ember-cli:3.28.2
   commands:
   - npm ci
 - name: lint
-  image: danlynn/ember-cli:3.20.0
+  image: danlynn/ember-cli:3.28.2
   commands:
   - npm run lint
 - name: test
-  image: danlynn/ember-cli:3.20.0
+  image: danlynn/ember-cli:3.28.2
   commands:
   - npm run test:ember
 trigger:
@@ -44,7 +44,7 @@ type: docker
 name: ember-compat-test
 steps:
 - name: ember-try
-  image: danlynn/ember-cli:3.20.0
+  image: danlynn/ember-cli:3.28.2
   commands:
     - npm ci
     - npm run test:ember-compatibility

--- a/addon/commands/insert-html-command.ts
+++ b/addon/commands/insert-html-command.ts
@@ -35,6 +35,7 @@ export default class InsertHtmlCommand extends Command {
           modelNodes.push(...parsed);
         }
       });
+      modelNodes.forEach((node) => console.log(node.toXml()));
 
       const newRange = mutator.insertNodes(range, ...modelNodes);
       this.model.selectRange(newRange);

--- a/addon/commands/insert-html-command.ts
+++ b/addon/commands/insert-html-command.ts
@@ -35,7 +35,6 @@ export default class InsertHtmlCommand extends Command {
           modelNodes.push(...parsed);
         }
       });
-      modelNodes.forEach((node) => console.log(node.toXml()));
 
       const newRange = mutator.insertNodes(range, ...modelNodes);
       this.model.selectRange(newRange);

--- a/addon/commands/insert-text-command.ts
+++ b/addon/commands/insert-text-command.ts
@@ -22,12 +22,8 @@ export default class InsertTextCommand extends Command {
 
     this.model.change((mutator) => {
       const resultRange = mutator.insertText(range, text);
-      // TODO re-enable incremental updates somehow
-      // const commonAncestor = resultRange.getCommonAncestor();
       resultRange.collapse();
       this.model.selectRange(resultRange);
-
-      // return commonAncestor;
     });
   }
 }

--- a/addon/commands/insert-xml-command.ts
+++ b/addon/commands/insert-xml-command.ts
@@ -4,6 +4,8 @@ import { parseXmlSiblings } from '@lblod/ember-rdfa-editor/model/util/xml-utils'
 import Model from '@lblod/ember-rdfa-editor/model/model';
 import { logExecute } from '@lblod/ember-rdfa-editor/utils/logging-utils';
 import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
+import ModelNode from '../model/model-node';
+import ModelElement from '../model/model-element';
 
 /**
  * Allows you to insert model nodes from an xml string.
@@ -26,8 +28,17 @@ export default class InsertXmlCommand extends Command {
 
     const parsedModelNodes = parseXmlSiblings(xml);
     this.model.change((mutator) => {
+      parsedModelNodes.forEach((node) => this.setNodeAndChildDirty(node));
       const newRange = mutator.insertNodes(range, ...parsedModelNodes);
       this.model.selectRange(newRange);
     });
+  }
+  setNodeAndChildDirty(node: ModelNode) {
+    node.addDirty('content');
+    if (ModelElement.isModelElement(node)) {
+      for (const child of node.children) {
+        this.setNodeAndChildDirty(child);
+      }
+    }
   }
 }

--- a/addon/components/ce/content-editable.ts
+++ b/addon/components/ce/content-editable.ts
@@ -210,6 +210,7 @@ export default class ContentEditable extends Component<ContentEditableArgs> {
    */
   @action
   handleKeyDown(event: KeyboardEvent) {
+    console.log("yeet")
     if (!this.keydownMapsToOtherEvent(event)) {
       const preventDefault = this.passEventToHandlers(event);
       if (preventDefault) {

--- a/addon/components/ce/content-editable.ts
+++ b/addon/components/ce/content-editable.ts
@@ -210,7 +210,6 @@ export default class ContentEditable extends Component<ContentEditableArgs> {
    */
   @action
   handleKeyDown(event: KeyboardEvent) {
-    console.log("yeet")
     if (!this.keydownMapsToOtherEvent(event)) {
       const preventDefault = this.passEventToHandlers(event);
       if (preventDefault) {

--- a/addon/components/ce/content-editable.ts
+++ b/addon/components/ce/content-editable.ts
@@ -333,10 +333,8 @@ export default class ContentEditable extends Component<ContentEditableArgs> {
       }
       // eslint-disable-next-line @typescript-eslint/unbound-method
       void taskFor(this.rawEditor.generateDiffEvents).perform();
-      this.rawEditor.model.read();
       return preventDefault;
     } else {
-      this.rawEditor.model.read();
       return false;
     }
   }

--- a/addon/components/rdfa/toolbar-dropdown.js
+++ b/addon/components/rdfa/toolbar-dropdown.js
@@ -26,7 +26,7 @@ export default class AuDropdown extends Component {
     // some kind of focus event always seems to happen at the wrong time
     // so this is a bit of hack, but it works well.
     await paintCycleHappened();
-    this.args.editor.model.selection.lastRange.start.parent.boundNode?.focus();
+    this.args.editor.model.selection.lastRange.start.parent.viewRoot?.focus();
     this.args.editor.model.writeSelection();
     return true;
   }

--- a/addon/editor/input-handlers/arrow-handler.ts
+++ b/addon/editor/input-handlers/arrow-handler.ts
@@ -98,6 +98,7 @@ export default class ArrowHandler extends InputHandler {
         id: 'contenteditable.invalid-start',
       });
     }
+    this.rawEditor.model.read();
 
     return { allowPropagation: false, allowBrowserDefault: false };
   }

--- a/addon/editor/input-handlers/backspace-handler.ts
+++ b/addon/editor/input-handlers/backspace-handler.ts
@@ -388,6 +388,7 @@ export default class BackspaceHandler extends InputHandler {
 
     void this.backspace().then(() => {
       this.rawEditor.updateSelectionAfterComplexInput(); // make sure currentSelection of editor is up to date with actual cursor position
+      this.rawEditor.model.read();
       this.rawEditor.eventBus.emit(
         new ContentChangedEvent({
           owner: CORE_OWNER,
@@ -397,7 +398,6 @@ export default class BackspaceHandler extends InputHandler {
           },
         })
       );
-      this.rawEditor.model.read();
     });
 
     return { allowPropagation: false };

--- a/addon/editor/input-handlers/backspace-handler.ts
+++ b/addon/editor/input-handlers/backspace-handler.ts
@@ -397,6 +397,7 @@ export default class BackspaceHandler extends InputHandler {
           },
         })
       );
+      this.rawEditor.model.read();
     });
 
     return { allowPropagation: false };

--- a/addon/editor/input-handlers/delete-handler.ts
+++ b/addon/editor/input-handlers/delete-handler.ts
@@ -446,6 +446,7 @@ export default class DeleteHandler extends InputHandler {
 
     void this.deleteForward().then(() => {
       this.rawEditor.updateSelectionAfterComplexInput(); // make sure currentSelection of editor is up to date with actual cursor position
+      this.rawEditor.model.read();
     });
     return { allowPropagation: false };
   }

--- a/addon/editor/input-handlers/disable-delete-handler.ts
+++ b/addon/editor/input-handlers/disable-delete-handler.ts
@@ -13,7 +13,6 @@ export default class DisableDeleteHandler extends InputHandler {
   }
 
   handleEvent(_: KeyboardEvent): HandlerResponse {
-    this.rawEditor.model.read();
     return { allowPropagation: false, allowBrowserDefault: false };
   }
 }

--- a/addon/editor/input-handlers/disable-delete-handler.ts
+++ b/addon/editor/input-handlers/disable-delete-handler.ts
@@ -13,6 +13,7 @@ export default class DisableDeleteHandler extends InputHandler {
   }
 
   handleEvent(_: KeyboardEvent): HandlerResponse {
+    this.rawEditor.model.read();
     return { allowPropagation: false, allowBrowserDefault: false };
   }
 }

--- a/addon/editor/input-handlers/fallback-input-handler.ts
+++ b/addon/editor/input-handlers/fallback-input-handler.ts
@@ -42,6 +42,7 @@ export default class FallbackInputHandler extends InputHandler {
     this.rawEditor.externalDomUpdate(
       `Uncaptured event of type ${event.type}, restoring editor state.`
     );
+    this.rawEditor.model.read();
     return { allowPropagation: false, allowBrowserDefault: true };
   }
 }

--- a/addon/editor/input-handlers/tab-handler.ts
+++ b/addon/editor/input-handlers/tab-handler.ts
@@ -106,6 +106,7 @@ export default class TabInputHandler extends InputHandler {
       this.handleNativeManipulation(manipulation);
     }
 
+    this.rawEditor.model.read();
     return { allowPropagation: false };
   }
 

--- a/addon/editor/input-handlers/text-input-handler.ts
+++ b/addon/editor/input-handlers/text-input-handler.ts
@@ -10,7 +10,6 @@ import {
 } from '@lblod/ember-rdfa-editor/utils/errors';
 import PernetRawEditor from '@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor';
 import { isKeyDownEvent } from '@lblod/ember-rdfa-editor/editor/input-handlers/event-helpers';
-import { restartableTask, TaskGenerator, timeout } from 'ember-concurrency';
 
 export type TextHandlerManipulation = InsertTextIntoRange;
 
@@ -37,7 +36,6 @@ export interface TextInputPlugin extends InputPlugin {
  */
 export default class TextInputHandler extends InputHandler {
   plugins: Array<TextInputPlugin>;
-  capturedText = '';
 
   constructor({ rawEditor }: { rawEditor: PernetRawEditor }) {
     super(rawEditor);
@@ -90,16 +88,8 @@ export default class TextInputHandler extends InputHandler {
     return { allowPropagation: false };
   }
 
-  @restartableTask
-  *inserText(): TaskGenerator<void> {
-    yield timeout(50);
-    this.rawEditor.executeCommand('insert-text', this.capturedText);
-    this.capturedText = '';
-  }
-
   handleNativeManipulation(manipulation: TextHandlerManipulation) {
     if (manipulation.type === 'insertTextIntoRange') {
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       this.rawEditor.executeCommand('insert-text', manipulation.text);
     } else {
       throw new UnsupportedManipulationError(manipulation);

--- a/addon/editor/input-handlers/text-input-handler.ts
+++ b/addon/editor/input-handlers/text-input-handler.ts
@@ -11,7 +11,6 @@ import {
 import PernetRawEditor from '@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor';
 import { isKeyDownEvent } from '@lblod/ember-rdfa-editor/editor/input-handlers/event-helpers';
 import { restartableTask, TaskGenerator, timeout } from 'ember-concurrency';
-import { taskFor } from 'ember-concurrency-ts';
 
 export type TextHandlerManipulation = InsertTextIntoRange;
 
@@ -100,9 +99,8 @@ export default class TextInputHandler extends InputHandler {
 
   handleNativeManipulation(manipulation: TextHandlerManipulation) {
     if (manipulation.type === 'insertTextIntoRange') {
-      this.capturedText = `${this.capturedText}${manipulation.text}`;
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      void taskFor(this.inserText).perform();
+      this.rawEditor.executeCommand('insert-text', manipulation.text);
     } else {
       throw new UnsupportedManipulationError(manipulation);
     }

--- a/addon/editor/input-handlers/undo-handler.ts
+++ b/addon/editor/input-handlers/undo-handler.ts
@@ -17,8 +17,7 @@ export default class UndoHandler extends InputHandler {
   }
 
   handleEvent(_: KeyboardEvent): HandlerResponse {
-    this.rawEditor.undo();
-
+    this.rawEditor.model.read();
     return { allowPropagation: false, allowBrowserDefault: true };
   }
 }

--- a/addon/editor/input-handlers/undo-handler.ts
+++ b/addon/editor/input-handlers/undo-handler.ts
@@ -17,6 +17,7 @@ export default class UndoHandler extends InputHandler {
   }
 
   handleEvent(_: KeyboardEvent): HandlerResponse {
+    this.rawEditor.undo();
     this.rawEditor.model.read();
     return { allowPropagation: false, allowBrowserDefault: true };
   }

--- a/addon/model/mark.ts
+++ b/addon/model/mark.ts
@@ -104,10 +104,11 @@ export interface Renderable<A extends Record<string, Serializable> | void> {
 }
 
 export class MarkSet extends HashSet<Mark> {
-  constructor() {
+  constructor(init?: Iterable<Mark>) {
     super({
       hashFunc: (mark: Mark) =>
         `${mark.name}-${mark.attributes.setBy || CORE_OWNER}`,
+      init,
     });
   }
 
@@ -121,7 +122,7 @@ export class MarkSet extends HashSet<Mark> {
   }
 
   clone(): this {
-    return new MarkSet() as this;
+    return new MarkSet(this.values()) as this;
   }
 }
 

--- a/addon/model/model-element.ts
+++ b/addon/model/model-element.ts
@@ -16,6 +16,7 @@ import { parsePrefixString } from '@lblod/ember-rdfa-editor/model/util/rdfa-util
 import RdfaAttributes from '@lblod/marawa/rdfa-attributes';
 import { TextAttribute } from '@lblod/ember-rdfa-editor/commands/text-properties/set-text-property-command';
 import SetUtils from '@lblod/ember-rdfa-editor/model/util/set-utils';
+import { ElementView } from '@lblod/ember-rdfa-editor/model/node-view';
 
 export type ElementType = keyof HTMLElementTagNameMap;
 
@@ -28,7 +29,7 @@ export default class ModelElement
   private _children: ModelNode[] = [];
   private _type: ElementType;
   private _currentRdfaPrefixes: Map<string, string>;
-  protected _viewRoot: HTMLElement | null = null;
+  protected _view: ElementView | null = null;
 
   constructor(type: ElementType = 'span', config?: NodeConfig) {
     super(config);
@@ -88,20 +89,16 @@ export default class ModelElement
     return !NON_BLOCK_NODES.has(this.type);
   }
 
+  get view(): ElementView | null {
+    return this._view;
+  }
+
+  set view(value: ElementView | null) {
+    this._view = value;
+  }
+
   get viewRoot(): HTMLElement | null {
-    return this._viewRoot;
-  }
-
-  set viewRoot(value: HTMLElement | null) {
-    this._viewRoot = value;
-  }
-
-  get contentRoot(): HTMLElement | null {
-    return this._viewRoot;
-  }
-
-  set contentRoot(node: HTMLElement | null) {
-    this._viewRoot = node;
+    return this.view?.viewRoot || null;
   }
 
   /**
@@ -125,7 +122,6 @@ export default class ModelElement
 
     result.attributeMap = new Map<string, string>(this.attributeMap);
     result.modelNodeType = this.modelNodeType;
-    result.viewRoot = this.viewRoot;
 
     const clonedChildren = this.children.map((c) => c.clone());
     result.appendChildren(...clonedChildren);

--- a/addon/model/model-element.ts
+++ b/addon/model/model-element.ts
@@ -16,7 +16,6 @@ import { parsePrefixString } from '@lblod/ember-rdfa-editor/model/util/rdfa-util
 import RdfaAttributes from '@lblod/marawa/rdfa-attributes';
 import { TextAttribute } from '@lblod/ember-rdfa-editor/commands/text-properties/set-text-property-command';
 import SetUtils from '@lblod/ember-rdfa-editor/model/util/set-utils';
-import { ElementView } from '@lblod/ember-rdfa-editor/model/node-view';
 
 export type ElementType = keyof HTMLElementTagNameMap;
 
@@ -29,7 +28,6 @@ export default class ModelElement
   private _children: ModelNode[] = [];
   private _type: ElementType;
   private _currentRdfaPrefixes: Map<string, string>;
-  protected _view: ElementView | null = null;
 
   constructor(type: ElementType = 'span', config?: NodeConfig) {
     super(config);
@@ -87,18 +85,6 @@ export default class ModelElement
 
   get isBlock() {
     return !NON_BLOCK_NODES.has(this.type);
-  }
-
-  get view(): ElementView | null {
-    return this._view;
-  }
-
-  set view(value: ElementView | null) {
-    this._view = value;
-  }
-
-  get viewRoot(): HTMLElement | null {
-    return this.view?.viewRoot || null;
   }
 
   /**

--- a/addon/model/model-element.ts
+++ b/addon/model/model-element.ts
@@ -42,6 +42,7 @@ export default class ModelElement
 
   set type(value: ElementType) {
     this._type = value;
+    this.addDirty('node');
   }
 
   set className(value: string) {
@@ -63,6 +64,7 @@ export default class ModelElement
 
   set children(value: ModelNode[]) {
     this._children = value;
+    this.addDirty('content');
   }
 
   get childCount() {
@@ -148,6 +150,7 @@ export default class ModelElement
     }
 
     child.parent = this;
+    this.addDirty('content');
   }
 
   insertChildAtOffset(child: ModelNode, offset: number) {
@@ -181,6 +184,9 @@ export default class ModelElement
 
   removeChild(child: ModelNode) {
     const index = this.children.indexOf(child);
+    if (index === -1) {
+      return;
+    }
     if (child.previousSibling) {
       child.previousSibling.nextSibling = child.nextSibling;
     }
@@ -193,6 +199,7 @@ export default class ModelElement
         this.children[index - 1] || null;
     }
     this.children.splice(index, 1);
+    this.addDirty('content');
   }
 
   getChildIndex(child: ModelNode): number | null {
@@ -229,6 +236,7 @@ export default class ModelElement
     }
 
     this.children = leftChildren;
+    this.addDirty('content');
     const right = this.clone();
     right.children = [];
     right.appendChildren(...rightChildren);
@@ -424,6 +432,7 @@ export default class ModelElement
     if (key === 'prefix') {
       this.updateRdfaPrefixes();
     }
+    this.addDirty('node');
   }
 
   /**

--- a/addon/model/model-element.ts
+++ b/addon/model/model-element.ts
@@ -28,6 +28,7 @@ export default class ModelElement
   private _children: ModelNode[] = [];
   private _type: ElementType;
   private _currentRdfaPrefixes: Map<string, string>;
+  protected _viewRoot: HTMLElement | null = null;
 
   constructor(type: ElementType = 'span', config?: NodeConfig) {
     super(config);
@@ -87,6 +88,22 @@ export default class ModelElement
     return !NON_BLOCK_NODES.has(this.type);
   }
 
+  get viewRoot(): HTMLElement | null {
+    return this._viewRoot;
+  }
+
+  set viewRoot(value: HTMLElement | null) {
+    this._viewRoot = value;
+  }
+
+  get contentRoot(): HTMLElement | null {
+    return this._viewRoot;
+  }
+
+  set contentRoot(node: HTMLElement | null) {
+    this._viewRoot = node;
+  }
+
   /**
    * Get the largest valid offset inside this element.
    * You can think of it as the cursor position right before the
@@ -108,7 +125,7 @@ export default class ModelElement
 
     result.attributeMap = new Map<string, string>(this.attributeMap);
     result.modelNodeType = this.modelNodeType;
-    result.boundNode = this.boundNode;
+    result.viewRoot = this.viewRoot;
 
     const clonedChildren = this.children.map((c) => c.clone());
     result.appendChildren(...clonedChildren);

--- a/addon/model/model-node.ts
+++ b/addon/model/model-node.ts
@@ -33,7 +33,7 @@ export default abstract class ModelNode implements Walkable {
 
   private _attributeMap: Map<string, string>;
   private _parent: ModelElement | null = null;
-  private _boundNode: HTMLElement | null = null;
+  private _boundNode: Node | null = null;
   private _nextSibling: ModelNode | null = null;
   private _previousSibling: ModelNode | null = null;
   private _debugInfo: unknown;
@@ -111,11 +111,11 @@ export default abstract class ModelNode implements Walkable {
     return root;
   }
 
-  get boundNode(): HTMLElement | null {
+  get boundNode(): Node | null {
     return this._boundNode;
   }
 
-  set boundNode(value: HTMLElement | null) {
+  set boundNode(value: Node | null) {
     this._boundNode = value;
   }
 

--- a/addon/model/model-node.ts
+++ b/addon/model/model-node.ts
@@ -33,7 +33,8 @@ export default abstract class ModelNode implements Walkable {
 
   private _attributeMap: Map<string, string>;
   private _parent: ModelElement | null = null;
-  private _boundNode: Node | null = null;
+  protected _viewRoot: Node | null = null;
+  protected _contentRoot: Node | null = null;
   private _nextSibling: ModelNode | null = null;
   private _previousSibling: ModelNode | null = null;
   private _debugInfo: unknown;
@@ -111,12 +112,20 @@ export default abstract class ModelNode implements Walkable {
     return root;
   }
 
-  get boundNode(): Node | null {
-    return this._boundNode;
+  get viewRoot(): Node | null {
+    return this._viewRoot;
   }
 
-  set boundNode(value: Node | null) {
-    this._boundNode = value;
+  set viewRoot(value: Node | null) {
+    this._viewRoot = value;
+  }
+
+  get contentRoot(): Node | null {
+    return this._contentRoot;
+  }
+
+  set contentRoot(value: Node | null) {
+    this._contentRoot = value;
   }
 
   abstract get length(): number;

--- a/addon/model/model-node.ts
+++ b/addon/model/model-node.ts
@@ -10,10 +10,13 @@ import { Walkable } from '@lblod/ember-rdfa-editor/model/util/gen-tree-walker';
 import { Predicate } from '@lblod/ember-rdfa-editor/model/util/predicate-utils';
 import { TextAttribute } from '@lblod/ember-rdfa-editor/commands/text-properties/set-text-property-command';
 import SetUtils from '@lblod/ember-rdfa-editor/model/util/set-utils';
+import Model from '@lblod/ember-rdfa-editor/model/model';
+import NodeView from '@lblod/ember-rdfa-editor/model/node-view';
 
 export type ModelNodeType = 'TEXT' | 'ELEMENT' | 'FRAGMENT';
 
 export interface NodeConfig {
+  model?: Model;
   debugInfo: unknown;
   rdfaPrefixes?: Map<string, string>;
 }
@@ -33,17 +36,20 @@ export default abstract class ModelNode implements Walkable {
 
   private _attributeMap: Map<string, string>;
   private _parent: ModelElement | null = null;
-  protected _viewRoot: Node | null = null;
-  protected _contentRoot: Node | null = null;
+  protected _view: NodeView | null = null;
   private _nextSibling: ModelNode | null = null;
   private _previousSibling: ModelNode | null = null;
   private _debugInfo: unknown;
   public dirtiness: Set<DirtyType>;
+  private _model: Model | null = null;
 
   protected constructor(config?: NodeConfig) {
     this._attributeMap = new Map<string, string>();
     if (config) {
       this._debugInfo = config.debugInfo;
+      if (config.model) {
+        this._model = config.model;
+      }
     }
     this.dirtiness = new Set<DirtyType>(['node', 'content']);
   }
@@ -112,20 +118,24 @@ export default abstract class ModelNode implements Walkable {
     return root;
   }
 
+  get model(): Model | null {
+    return this.root._model;
+  }
+
+  set model(model: Model | null) {
+    this.root._model = model;
+  }
+
+  get view(): NodeView | null {
+    return this._view;
+  }
+
+  set view(value: NodeView | null) {
+    this._view = value;
+  }
+
   get viewRoot(): Node | null {
-    return this._viewRoot;
-  }
-
-  set viewRoot(value: Node | null) {
-    this._viewRoot = value;
-  }
-
-  get contentRoot(): Node | null {
-    return this._contentRoot;
-  }
-
-  set contentRoot(value: Node | null) {
-    this._contentRoot = value;
+    return this._view?.viewRoot || null;
   }
 
   abstract get length(): number;

--- a/addon/model/model-node.ts
+++ b/addon/model/model-node.ts
@@ -33,7 +33,7 @@ export default abstract class ModelNode implements Walkable {
 
   private _attributeMap: Map<string, string>;
   private _parent: ModelElement | null = null;
-  private _boundNode: Node | null = null;
+  private _boundNode: HTMLElement | null = null;
   private _nextSibling: ModelNode | null = null;
   private _previousSibling: ModelNode | null = null;
   private _debugInfo: unknown;
@@ -111,11 +111,11 @@ export default abstract class ModelNode implements Walkable {
     return root;
   }
 
-  get boundNode(): Node | null {
+  get boundNode(): HTMLElement | null {
     return this._boundNode;
   }
 
-  set boundNode(value: Node | null) {
+  set boundNode(value: HTMLElement | null) {
     this._boundNode = value;
   }
 

--- a/addon/model/model-node.ts
+++ b/addon/model/model-node.ts
@@ -10,13 +10,10 @@ import { Walkable } from '@lblod/ember-rdfa-editor/model/util/gen-tree-walker';
 import { Predicate } from '@lblod/ember-rdfa-editor/model/util/predicate-utils';
 import { TextAttribute } from '@lblod/ember-rdfa-editor/commands/text-properties/set-text-property-command';
 import SetUtils from '@lblod/ember-rdfa-editor/model/util/set-utils';
-import Model from '@lblod/ember-rdfa-editor/model/model';
-import NodeView from '@lblod/ember-rdfa-editor/model/node-view';
 
 export type ModelNodeType = 'TEXT' | 'ELEMENT' | 'FRAGMENT';
 
 export interface NodeConfig {
-  model?: Model;
   debugInfo: unknown;
   rdfaPrefixes?: Map<string, string>;
 }
@@ -36,20 +33,15 @@ export default abstract class ModelNode implements Walkable {
 
   private _attributeMap: Map<string, string>;
   private _parent: ModelElement | null = null;
-  protected _view: NodeView | null = null;
   private _nextSibling: ModelNode | null = null;
   private _previousSibling: ModelNode | null = null;
   private _debugInfo: unknown;
   public dirtiness: Set<DirtyType>;
-  private _model: Model | null = null;
 
   protected constructor(config?: NodeConfig) {
     this._attributeMap = new Map<string, string>();
     if (config) {
       this._debugInfo = config.debugInfo;
-      if (config.model) {
-        this._model = config.model;
-      }
     }
     this.dirtiness = new Set<DirtyType>(['node', 'content']);
   }
@@ -116,26 +108,6 @@ export default abstract class ModelNode implements Walkable {
       root = root.parent;
     }
     return root;
-  }
-
-  get model(): Model | null {
-    return this.root._model;
-  }
-
-  set model(model: Model | null) {
-    this.root._model = model;
-  }
-
-  get view(): NodeView | null {
-    return this._view;
-  }
-
-  set view(value: NodeView | null) {
-    this._view = value;
-  }
-
-  get viewRoot(): Node | null {
-    return this._view?.viewRoot || null;
   }
 
   abstract get length(): number;

--- a/addon/model/model-node.ts
+++ b/addon/model/model-node.ts
@@ -140,6 +140,9 @@ export default abstract class ModelNode implements Walkable {
 
   setDirty(...dirtyTypes: DirtyType[]) {
     this.dirtiness = new Set<DirtyType>(dirtyTypes);
+    if (!this.parent?.isDirty('content')) {
+      this.parent?.setDirty('content');
+    }
   }
 
   isDirty(type: DirtyType) {

--- a/addon/model/model-text.ts
+++ b/addon/model/model-text.ts
@@ -27,6 +27,7 @@ export default class ModelText extends ModelNode {
 
   set content(value: string) {
     this._content = value;
+    this.addDirty('content');
   }
 
   get marks(): MarkSet {
@@ -35,6 +36,7 @@ export default class ModelText extends ModelNode {
 
   set marks(value: MarkSet) {
     this._marks = value;
+    this.addDirty('mark');
   }
 
   get length() {
@@ -59,10 +61,12 @@ export default class ModelText extends ModelNode {
 
   addMark(mark: Mark) {
     this.marks.add(mark);
+    this.addDirty('mark');
   }
 
   removeMarkByName(markName: string) {
     this.marks.deleteHash(markName);
+    this.addDirty('mark');
   }
 
   insertTextNodeAt(index: number): ModelText {

--- a/addon/model/model-text.ts
+++ b/addon/model/model-text.ts
@@ -8,7 +8,6 @@ import { stringToVisibleText } from '@lblod/ember-rdfa-editor/editor/utils';
 import ModelNodeUtils from '@lblod/ember-rdfa-editor/model/util/model-node-utils';
 import { Mark, MarkSet } from '@lblod/ember-rdfa-editor/model/mark';
 import SetUtils from '@lblod/ember-rdfa-editor/model/util/set-utils';
-import { TextView } from '@lblod/ember-rdfa-editor/model/node-view';
 
 const NON_BREAKING_SPACE = '\u00A0';
 
@@ -16,7 +15,6 @@ export default class ModelText extends ModelNode {
   modelNodeType: ModelNodeType = 'TEXT';
   private _content: string;
   private _marks: MarkSet = new MarkSet();
-  protected _view: TextView | null = null;
 
   constructor(content = '', config?: NodeConfig) {
     super(config);
@@ -51,14 +49,6 @@ export default class ModelText extends ModelNode {
 
   get offsetSize() {
     return this.length;
-  }
-
-  get view(): TextView | null {
-    return this._view;
-  }
-
-  set view(value: TextView | null) {
-    this._view = value;
   }
 
   hasMarkName(markName: string): boolean {

--- a/addon/model/model-text.ts
+++ b/addon/model/model-text.ts
@@ -80,8 +80,6 @@ export default class ModelText extends ModelNode {
     result.modelNodeType = this.modelNodeType;
     result.content = this.content;
     result.marks = this.marks.clone();
-    result.dirtiness = new Set(this.dirtiness);
-    result.boundNode = this.boundNode;
 
     return result;
   }

--- a/addon/model/model-text.ts
+++ b/addon/model/model-text.ts
@@ -80,6 +80,8 @@ export default class ModelText extends ModelNode {
     result.modelNodeType = this.modelNodeType;
     result.content = this.content;
     result.marks = this.marks.clone();
+    result.dirtiness = new Set(this.dirtiness);
+    result.boundNode = this.boundNode;
 
     return result;
   }

--- a/addon/model/model-text.ts
+++ b/addon/model/model-text.ts
@@ -8,6 +8,7 @@ import { stringToVisibleText } from '@lblod/ember-rdfa-editor/editor/utils';
 import ModelNodeUtils from '@lblod/ember-rdfa-editor/model/util/model-node-utils';
 import { Mark, MarkSet } from '@lblod/ember-rdfa-editor/model/mark';
 import SetUtils from '@lblod/ember-rdfa-editor/model/util/set-utils';
+import { TextView } from '@lblod/ember-rdfa-editor/model/node-view';
 
 const NON_BREAKING_SPACE = '\u00A0';
 
@@ -15,7 +16,7 @@ export default class ModelText extends ModelNode {
   modelNodeType: ModelNodeType = 'TEXT';
   private _content: string;
   private _marks: MarkSet = new MarkSet();
-  private _contentRoot: Text | null = null;
+  protected _view: TextView | null = null;
 
   constructor(content = '', config?: NodeConfig) {
     super(config);
@@ -52,12 +53,12 @@ export default class ModelText extends ModelNode {
     return this.length;
   }
 
-  get contentRoot(): Text | null {
-    return this._contentRoot;
+  get view(): TextView | null {
+    return this._view;
   }
 
-  set contentRoot(value: Text | null) {
-    this._contentRoot = value;
+  set view(value: TextView | null) {
+    this._view = value;
   }
 
   hasMarkName(markName: string): boolean {

--- a/addon/model/model-text.ts
+++ b/addon/model/model-text.ts
@@ -15,6 +15,7 @@ export default class ModelText extends ModelNode {
   modelNodeType: ModelNodeType = 'TEXT';
   private _content: string;
   private _marks: MarkSet = new MarkSet();
+  private _contentRoot: Text | null = null;
 
   constructor(content = '', config?: NodeConfig) {
     super(config);
@@ -49,6 +50,14 @@ export default class ModelText extends ModelNode {
 
   get offsetSize() {
     return this.length;
+  }
+
+  get contentRoot(): Text | null {
+    return this._contentRoot;
+  }
+
+  set contentRoot(value: Text | null) {
+    this._contentRoot = value;
   }
 
   hasMarkName(markName: string): boolean {

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -143,7 +143,7 @@ export default class Model {
     document.dispatchEvent(modelWriteEvent);
     this.rootModelNode.removeDirty('node');
 
-    this.writer.write(this.rootModelNode);
+    this.writer.write(tree);
 
     if (writeSelection) {
       this.writeSelection();

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -203,7 +203,6 @@ export default class Model {
     if (writeBack) {
       this.write();
     }
-    console.log(this.toXml());
   }
 
   static getChildIndex(child: Node): number | null {

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -58,7 +58,7 @@ export default class Model {
     this.reader = new HtmlReader(this);
     this.writer = new HtmlWriter(this);
     this.selectionReader = new SelectionReader(this);
-    this.selectionWriter = new SelectionWriter();
+    this.selectionWriter = new SelectionWriter(this);
     this._selection = new ModelSelection();
     this._eventBus = eventBus;
     this.logger = createLogger('RawEditor');

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -135,7 +135,11 @@ export default class Model {
    * have a real dom available.
    */
   write(tree: ModelElement = this.rootModelNode, writeSelection = true) {
+    console.log(tree.toXml());
     const modelWriteEvent = new CustomEvent('editorModelWrite');
+    if (tree === this.rootModelNode) {
+      tree.removeDirty('node');
+    }
     document.dispatchEvent(modelWriteEvent);
 
     this.writer.write(tree);

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -165,7 +165,7 @@ export default class Model {
    */
   bindNode(modelNode: ModelNode, domNode: Node): void {
     this.nodeMap.delete(domNode);
-    modelNode.boundNode = domNode;
+    modelNode.viewRoot = domNode;
     this.nodeMap.set(domNode, modelNode);
   }
 

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -100,7 +100,6 @@ export default class Model {
     }
 
     this._rootModelNode = newRoot;
-    this.registerNodeView(this.rootModelNode, this.rootNode);
 
     // This is essential, we change the root so we need to make sure the selection uses the new root.
     if (readSelection) {

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -1,14 +1,8 @@
 import HtmlReader from '@lblod/ember-rdfa-editor/model/readers/html-reader';
 import HtmlWriter from '@lblod/ember-rdfa-editor/model/writers/html-writer';
 import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
-import {
-  getWindowSelection,
-  isElement,
-} from '@lblod/ember-rdfa-editor/utils/dom-helpers';
-import {
-  ModelError,
-  NotImplementedError,
-} from '@lblod/ember-rdfa-editor/utils/errors';
+import { getWindowSelection } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+import { ModelError } from '@lblod/ember-rdfa-editor/utils/errors';
 import ModelSelection from '@lblod/ember-rdfa-editor/model/model-selection';
 import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
 import SelectionReader from '@lblod/ember-rdfa-editor/model/readers/selection-reader';
@@ -144,24 +138,7 @@ export default class Model {
     const modelWriteEvent = new CustomEvent('editorModelWrite');
     document.dispatchEvent(modelWriteEvent);
 
-    const oldRoot = tree.boundNode;
-    if (!oldRoot) {
-      throw new Error('Container without boundNode');
-    }
-
-    if (!isElement(oldRoot)) {
-      throw new NotImplementedError(
-        'Root is not an element, not sure what to do'
-      );
-    }
-
-    const newRoot = this.writer.write(tree);
-    while (oldRoot.firstChild) {
-      oldRoot.removeChild(oldRoot.firstChild);
-    }
-
-    oldRoot.append(...newRoot.childNodes);
-    this.bindNode(tree, oldRoot);
+    this.writer.write(tree);
 
     if (writeSelection) {
       this.writeSelection();

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -139,14 +139,11 @@ export default class Model {
    * have a real dom available.
    */
   write(tree: ModelElement = this.rootModelNode, writeSelection = true) {
-    console.log(tree.toXml());
     const modelWriteEvent = new CustomEvent('editorModelWrite');
-    if (tree === this.rootModelNode) {
-      tree.removeDirty('node');
-    }
     document.dispatchEvent(modelWriteEvent);
+    this.rootModelNode.removeDirty('node');
 
-    this.writer.write(tree);
+    this.writer.write(this.rootModelNode);
 
     if (writeSelection) {
       this.writeSelection();

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -55,7 +55,7 @@ export default class Model {
 
   constructor(rootNode: HTMLElement, eventBus?: EventBus) {
     this._rootNode = rootNode;
-    this.reader = new HtmlReader(this);
+    this.reader = new HtmlReader(this, true);
     this.writer = new HtmlWriter(this);
     this.selectionReader = new SelectionReader(this);
     this.selectionWriter = new SelectionWriter(this);
@@ -198,15 +198,12 @@ export default class Model {
     writeBack = true
   ) {
     const mutator = new ImmediateModelMutator(this._eventBus);
-    const subTree = callback(mutator);
+    callback(mutator);
 
     if (writeBack) {
-      if (subTree) {
-        this.write(subTree);
-      } else {
-        this.write(this.rootModelNode);
-      }
+      this.write();
     }
+    console.log(this.toXml());
   }
 
   static getChildIndex(child: Node): number | null {

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -95,6 +95,7 @@ export default class Model {
     }
 
     this._rootModelNode = newRoot;
+    this._rootModelNode.model = this;
     this.bindNode(this.rootModelNode, this.rootNode);
 
     // This is essential, we change the root so we need to make sure the selection uses the new root.
@@ -253,6 +254,7 @@ export default class Model {
   ) {
     if (snapshot) {
       this._rootModelNode = snapshot.rootModelNode;
+      this._rootModelNode.model = this;
       this._selection = snapshot.modelSelection;
 
       if (writeBack) {

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -163,7 +163,7 @@ export default class Model {
    * @param modelNode
    * @param domNode
    */
-  bindNode(modelNode: ModelNode, domNode: Node) {
+  bindNode(modelNode: ModelNode, domNode: Node): void {
     this.nodeMap.delete(domNode);
     modelNode.boundNode = domNode;
     this.nodeMap.set(domNode, modelNode);

--- a/addon/model/mutators/immediate-model-mutator.ts
+++ b/addon/model/mutators/immediate-model-mutator.ts
@@ -281,9 +281,7 @@ export default class ImmediateModelMutator extends ModelMutator<ModelRange> {
     if (!oldNode) throw new Error('no element in range');
     const newNode = oldNode.clone();
     newNode.setAttribute(key, value);
-    console.log(oldNode);
     const oldNodeRange = ModelRange.fromAroundNode(oldNode);
-    console.log(oldNodeRange);
     const op = new InsertOperation(this.eventbus, oldNodeRange, newNode);
     op.execute();
     return newNode;

--- a/addon/model/node-view.ts
+++ b/addon/model/node-view.ts
@@ -1,3 +1,12 @@
+import {
+  isTextOrElement,
+  TextOrElement,
+} from '@lblod/ember-rdfa-editor/model/util/types';
+import {
+  isElement,
+  isTextNode,
+} from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+
 export default interface NodeView {
   viewRoot: Node;
   contentRoot: Node;
@@ -8,7 +17,15 @@ export interface ElementView extends NodeView {
   contentRoot: HTMLElement;
 }
 
+export function isElementView(view: NodeView): view is ElementView {
+  return isElement(view.viewRoot) && isElement(view.contentRoot);
+}
+
 export interface TextView extends NodeView {
-  viewRoot: Node;
+  viewRoot: TextOrElement;
   contentRoot: Text;
+}
+
+export function isTextView(view: NodeView): view is TextView {
+  return isTextOrElement(view.viewRoot) && isTextNode(view.contentRoot);
 }

--- a/addon/model/node-view.ts
+++ b/addon/model/node-view.ts
@@ -1,0 +1,14 @@
+export default interface NodeView {
+  viewRoot: Node;
+  contentRoot: Node;
+}
+
+export interface ElementView extends NodeView {
+  viewRoot: HTMLElement;
+  contentRoot: HTMLElement;
+}
+
+export interface TextView extends NodeView {
+  viewRoot: Node;
+  contentRoot: Text;
+}

--- a/addon/model/operations/operation-algorithms.ts
+++ b/addon/model/operations/operation-algorithms.ts
@@ -100,6 +100,20 @@ export default class OperationAlgorithms {
 
   static splitText(position: ModelPosition, keepright = false) {
     position.split(keepright);
+    const before = position.nodeBefore();
+    const after = position.nodeAfter();
+    if (before) {
+      before.setDirty('content');
+      if (keepright) {
+        before.setDirty('node');
+      }
+    }
+    if (after) {
+      after.setDirty('content');
+      if (!keepright) {
+        after.setDirty('node');
+      }
+    }
     return position;
   }
 

--- a/addon/model/operations/operation-algorithms.ts
+++ b/addon/model/operations/operation-algorithms.ts
@@ -79,16 +79,6 @@ export default class OperationAlgorithms {
         );
       }
     } else {
-      // range.start.split();
-      // range.end.split(true);
-      // const before = range.start.nodeBefore();
-      // const after = range.end.nodeAfter();
-      // if (before) {
-      //   _markCheckNodes.push(before);
-      // }
-      // if (after) {
-      //   _markCheckNodes.push(after);
-      // }
       overwrittenNodes = OperationAlgorithms.remove(range);
 
       range.start.parent.insertChildrenAtOffset(

--- a/addon/model/readers/html-element-reader.ts
+++ b/addon/model/readers/html-element-reader.ts
@@ -20,7 +20,7 @@ export default class HtmlElementReader
       const parsedChildren = nodeReader.read(child, context);
       result.appendChildren(...parsedChildren);
     }
-    context.bindNode(result, from);
+    context.registerNodeView(result, { viewRoot: from, contentRoot: from });
     return [result];
   }
 }

--- a/addon/model/readers/html-list-reader.ts
+++ b/addon/model/readers/html-list-reader.ts
@@ -40,7 +40,7 @@ export default class HtmlListReader
       return [];
     }
     copyAttributes(from, wrapper);
-    context.bindNode(wrapper, from);
+    context.registerNodeView(wrapper, { viewRoot: from, contentRoot: from });
     return [wrapper];
   }
 }

--- a/addon/model/readers/html-node-reader.ts
+++ b/addon/model/readers/html-node-reader.ts
@@ -64,7 +64,6 @@ export default class HtmlNodeReader
     } else {
       result = [];
     }
-    // result.forEach(node => node.clearDirty())
 
     return result;
   }

--- a/addon/model/readers/html-node-reader.ts
+++ b/addon/model/readers/html-node-reader.ts
@@ -35,6 +35,7 @@ export default class HtmlNodeReader
 
       const marks = context.matchMark(from);
       if (marks.size) {
+        context.markViewRootStack.push(from);
         SetUtils.addMany(context.activeMarks, ...marks);
         const reader = new HtmlNodeReader();
         result = [];
@@ -46,6 +47,7 @@ export default class HtmlNodeReader
           }
         }
         SetUtils.deleteMany(context.activeMarks, ...marks);
+        context.markViewRootStack.pop();
       } else {
         let reader: ElementReader;
         const ctor = HtmlNodeReader.elementConfig.get(tag);

--- a/addon/model/readers/html-node-reader.ts
+++ b/addon/model/readers/html-node-reader.ts
@@ -64,7 +64,7 @@ export default class HtmlNodeReader
     } else {
       result = [];
     }
-    result.forEach(node => node.clearDirty())
+    // result.forEach(node => node.clearDirty())
 
     return result;
   }

--- a/addon/model/readers/html-node-reader.ts
+++ b/addon/model/readers/html-node-reader.ts
@@ -64,6 +64,7 @@ export default class HtmlNodeReader
     } else {
       result = [];
     }
+    result.forEach(node => node.clearDirty())
 
     return result;
   }

--- a/addon/model/readers/html-reader.ts
+++ b/addon/model/readers/html-reader.ts
@@ -6,6 +6,7 @@ import { calculateRdfaPrefixes } from '../util/rdfa-utils';
 import { SpecAttributes } from '@lblod/ember-rdfa-editor/model/marks-registry';
 import ModelText from '@lblod/ember-rdfa-editor/model/model-text';
 import { AttributeSpec, MarkSpec } from '@lblod/ember-rdfa-editor/model/mark';
+import NodeView from '@lblod/ember-rdfa-editor/model/node-view';
 
 export class HtmlReaderContext {
   private readonly _textAttributes: Map<string, string>;
@@ -13,6 +14,7 @@ export class HtmlReaderContext {
   private _rdfaPrefixes: Map<string, string>;
   private _shouldConvertWhitespace: boolean;
   activeMarks: Set<SpecAttributes> = new Set<SpecAttributes>();
+  markViewRootStack: Node[] = [];
 
   constructor(
     model: Model,
@@ -29,8 +31,8 @@ export class HtmlReaderContext {
     return this._model;
   }
 
-  bindNode(modelNode: ModelNode, domNode: Node) {
-    this.model.bindNode(modelNode, domNode);
+  registerNodeView(modelNode: ModelNode, view: NodeView) {
+    this.model.registerNodeView(modelNode, view);
   }
 
   get shouldConvertWhitespace() {

--- a/addon/model/readers/html-table-reader.ts
+++ b/addon/model/readers/html-table-reader.ts
@@ -15,7 +15,7 @@ export default class HtmlTableReader
       const parsedChildren = nodeReader.read(child, context);
       table.appendChildren(...parsedChildren);
     }
-    context.bindNode(table, from);
+    context.registerNodeView(table, { viewRoot: from, contentRoot: from });
     return [table];
   }
 }

--- a/addon/model/readers/html-text-reader.ts
+++ b/addon/model/readers/html-text-reader.ts
@@ -27,7 +27,14 @@ export default class HtmlTextReader
     context.activeMarks.forEach(({ spec, attributes }) =>
       context.addMark(result, spec, attributes)
     );
-    context.bindNode(result, from);
+    if (context.markViewRootStack.length) {
+      context.registerNodeView(result, {
+        viewRoot: context.markViewRootStack[0],
+        contentRoot: from,
+      });
+    } else {
+      context.registerNodeView(result, { viewRoot: from, contentRoot: from });
+    }
     return [result];
   }
 }

--- a/addon/model/readers/selection-reader.ts
+++ b/addon/model/readers/selection-reader.ts
@@ -117,7 +117,18 @@ export default class SelectionReader
     if (isTextNode(container) && ModelNode.isModelText(modelNode)) {
       return ModelPosition.fromInTextNode(modelNode, domOffset);
     } else if (isElement(container) && ModelNode.isModelElement(modelNode)) {
-      return ModelPosition.fromBeforeNode(modelNode.children[domOffset]);
+      if (modelNode.children.length) {
+        return ModelPosition.fromInElement(
+          modelNode,
+          modelNode.indexToOffset(domOffset)
+        );
+      } else {
+        if (domOffset === 0) {
+          return ModelPosition.fromInElement(modelNode, 0);
+        } else {
+          throw new NotImplementedError();
+        }
+      }
     } else {
       throw new NotImplementedError('impossible selection');
     }

--- a/addon/model/readers/selection-reader.ts
+++ b/addon/model/readers/selection-reader.ts
@@ -124,7 +124,16 @@ export default class SelectionReader
         );
       } else {
         if (domOffset === 0) {
-          return ModelPosition.fromInElement(modelNode, 0);
+          // Setting a cursor inside an element without height leads to invisible
+          // cursor, so work around it
+          // note I haven't been able to even reproduce this case
+          if (!modelNode.parent) {
+            // in case the node is root, there's not much we can do
+            return ModelPosition.fromInNode(modelNode, 0);
+          } else {
+            // otherwise default to setting it in front of the element
+            return ModelPosition.fromBeforeNode(modelNode);
+          }
         } else {
           throw new NotImplementedError();
         }

--- a/addon/model/readers/xml-element-reader.ts
+++ b/addon/model/readers/xml-element-reader.ts
@@ -3,6 +3,7 @@ import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
 import XmlNodeReader from '@lblod/ember-rdfa-editor/model/readers/xml-node-reader';
 import { XmlNodeRegistry } from '@lblod/ember-rdfa-editor/model/readers/xml-reader';
 import ModelText from '@lblod/ember-rdfa-editor/model/model-text';
+import { DirtyType } from '@lblod/ember-rdfa-editor/model/model-node';
 
 export default class XmlElementReader
   implements Reader<Element, ModelElement, void>
@@ -37,6 +38,9 @@ export default class XmlElementReader
         rslt.addChild(child);
       }
     }
+    const dirtyFlags = from.attributes.getNamedItem('__dirty');
+    const dirtyConfig = (dirtyFlags?.value.split(',') || []) as DirtyType[];
+    rslt.setDirty(...dirtyConfig);
     return rslt;
   }
 }

--- a/addon/model/readers/xml-node-reader.ts
+++ b/addon/model/readers/xml-node-reader.ts
@@ -1,4 +1,6 @@
-import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
+import ModelNode, {
+  DirtyType,
+} from '@lblod/ember-rdfa-editor/model/model-node';
 import Reader from '@lblod/ember-rdfa-editor/model/readers/reader';
 import XmlElementReader from '@lblod/ember-rdfa-editor/model/readers/xml-element-reader';
 import XmlTextReader from '@lblod/ember-rdfa-editor/model/readers/xml-text-reader';
@@ -25,16 +27,23 @@ export default class XmlNodeReader
   }
 
   read(from: Node): ModelNode | null {
+    let result;
     if (isElement(from)) {
       if (from.tagName === 'text') {
-        return this.textReader.read(from);
+        result = this.textReader.read(from);
       } else if (from.tagName === 'table') {
-        return this.tableReader.read(from as Element);
+        result = this.tableReader.read(from as Element);
+      } else {
+        result = this.elementReader.read(from as Element);
       }
-
-      return this.elementReader.read(from as Element);
+      const dirtyFlags = from.attributes.getNamedItem('__dirty');
+      if (dirtyFlags?.value) {
+        const dirtyConfig = dirtyFlags.value.split(',') as DirtyType[];
+        result.setDirty(...dirtyConfig);
+      }
     } else {
-      return null;
+      result = null;
     }
+    return result;
   }
 }

--- a/addon/model/readers/xml-node-reader.ts
+++ b/addon/model/readers/xml-node-reader.ts
@@ -1,6 +1,4 @@
-import ModelNode, {
-  DirtyType,
-} from '@lblod/ember-rdfa-editor/model/model-node';
+import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
 import Reader from '@lblod/ember-rdfa-editor/model/readers/reader';
 import XmlElementReader from '@lblod/ember-rdfa-editor/model/readers/xml-element-reader';
 import XmlTextReader from '@lblod/ember-rdfa-editor/model/readers/xml-text-reader';

--- a/addon/model/readers/xml-node-reader.ts
+++ b/addon/model/readers/xml-node-reader.ts
@@ -36,11 +36,6 @@ export default class XmlNodeReader
       } else {
         result = this.elementReader.read(from as Element);
       }
-      const dirtyFlags = from.attributes.getNamedItem('__dirty');
-      if (dirtyFlags?.value) {
-        const dirtyConfig = dirtyFlags.value.split(',') as DirtyType[];
-        result.setDirty(...dirtyConfig);
-      }
     } else {
       result = null;
     }

--- a/addon/model/readers/xml-text-reader.ts
+++ b/addon/model/readers/xml-text-reader.ts
@@ -4,6 +4,7 @@ import { XmlNodeRegistry } from '@lblod/ember-rdfa-editor/model/readers/xml-read
 import { compatTextAttributeMap } from '@lblod/ember-rdfa-editor/model/util/constants';
 import { Mark } from '@lblod/ember-rdfa-editor/model/mark';
 import { TextAttribute } from '@lblod/ember-rdfa-editor/commands/text-properties/set-text-property-command';
+import { DirtyType } from '@lblod/ember-rdfa-editor/model/model-node';
 
 export default class XmlTextReader implements Reader<Element, ModelText, void> {
   constructor(private registry: XmlNodeRegistry<ModelText>) {}
@@ -31,6 +32,9 @@ export default class XmlTextReader implements Reader<Element, ModelText, void> {
         rslt.setAttribute(attribute.name, attribute.value);
       }
     }
+    const dirtyFlags = from.attributes.getNamedItem('__dirty');
+    const dirtyConfig = (dirtyFlags?.value.split(',') || []) as DirtyType[];
+    rslt.setDirty(...dirtyConfig);
     return rslt;
   }
 }

--- a/addon/model/util/model-node-utils.ts
+++ b/addon/model/util/model-node-utils.ts
@@ -12,6 +12,7 @@ export default class ModelNodeUtils {
   static DEFAULT_IGNORED_ATTRS: Set<string> = new Set([
     '__dummy_test_attr',
     '__id',
+    '__dirty',
     'data-editor-position-level',
     'data-editor-rdfa-position-level',
   ]);

--- a/addon/model/util/set-utils.ts
+++ b/addon/model/util/set-utils.ts
@@ -1,4 +1,16 @@
 export default class SetUtils {
+  static areSetsSame<I>(setA: Set<I>, setB: Set<I>): boolean {
+    if (setA.size !== setB.size) {
+      return false;
+    }
+    for (const elem of setA) {
+      if (!setB.has(elem)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * Calculates A / B in set arithmetic
    */

--- a/addon/model/util/types.ts
+++ b/addon/model/util/types.ts
@@ -34,3 +34,13 @@ export interface FilterAndPredicate<T extends ModelNode> {
 }
 
 export type RdfaEditorInitializer = (rdfaEditor: RdfaDocument) => void;
+export type TextOrElement = Text | HTMLElement;
+
+export function isTextOrElement(
+  node: Node | null | undefined
+): node is TextOrElement {
+  return (
+    !!node &&
+    (node.nodeType === Node.TEXT_NODE || node.nodeType === node.ELEMENT_NODE)
+  );
+}

--- a/addon/model/writers/html-element-writer.ts
+++ b/addon/model/writers/html-element-writer.ts
@@ -1,13 +1,14 @@
 import Writer from '@lblod/ember-rdfa-editor/model/writers/writer';
 import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
 import Model from '@lblod/ember-rdfa-editor/model/model';
+import { ElementView } from '@lblod/ember-rdfa-editor/model/node-view';
 
 export default class HtmlElementWriter
-  implements Writer<ModelElement, HTMLElement>
+  implements Writer<ModelElement, ElementView>
 {
   constructor(private model: Model) {}
 
-  write(modelNode: ModelElement): HTMLElement {
+  write(modelNode: ModelElement): ElementView {
     const result = document.createElement(modelNode.type);
 
     // This will disable the selection of multiple cells on table.
@@ -18,12 +19,11 @@ export default class HtmlElementWriter
     if (modelNode.type === 'td' || modelNode.type === 'th') {
       result.contentEditable = 'true';
     }
-    this.model.registerNodeView(modelNode, result);
 
     for (const item of modelNode.attributeMap.entries()) {
       result.setAttribute(item[0], item[1]);
     }
 
-    return result;
+    return { viewRoot: result, contentRoot: result };
   }
 }

--- a/addon/model/writers/html-element-writer.ts
+++ b/addon/model/writers/html-element-writer.ts
@@ -18,7 +18,7 @@ export default class HtmlElementWriter
     if (modelNode.type === 'td' || modelNode.type === 'th') {
       result.contentEditable = 'true';
     }
-    this.model.bindNode(modelNode, result);
+    this.model.registerNodeView(modelNode, result);
 
     for (const item of modelNode.attributeMap.entries()) {
       result.setAttribute(item[0], item[1]);

--- a/addon/model/writers/html-export-writer.ts
+++ b/addon/model/writers/html-export-writer.ts
@@ -1,13 +1,12 @@
 import Writer from '@lblod/ember-rdfa-editor/model/writers/writer';
 import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
 import Model from '@lblod/ember-rdfa-editor/model/model';
-import HtmlTextWriter from '@lblod/ember-rdfa-editor/model/writers/html-text-writer';
 import { WriterError } from '@lblod/ember-rdfa-editor/utils/errors';
 import UnpollutedHtmlElementWriter from './unpolluted-html-element-writer';
 import UnpollutedHtmlTextWriter from './unpolluted-html-text-writer';
 
 export default class HTMLExportWriter implements Writer<ModelNode, Node> {
-  private htmlTextWriter: HtmlTextWriter;
+  private htmlTextWriter: UnpollutedHtmlTextWriter;
   private htmlElementWriter: UnpollutedHtmlElementWriter;
 
   constructor(private model: Model) {

--- a/addon/model/writers/html-text-writer.ts
+++ b/addon/model/writers/html-text-writer.ts
@@ -6,12 +6,12 @@ import ModelText from '@lblod/ember-rdfa-editor/model/model-text';
  * Writer responsible for converting {@link ModelText} nodes into HTML subtrees
  * This takes care of converting the textattributes into HTML elements
  */
-export default class HtmlTextWriter implements Writer<ModelText, Node | null> {
+export default class HtmlTextWriter implements Writer<ModelText, Node> {
   constructor(protected model: Model) {}
 
-  write(modelNode: ModelText): Node | null {
+  write(modelNode: ModelText): Node {
     if (modelNode.length === 0) {
-      return null;
+      return new Text();
     }
 
     let current: Node = new Text(modelNode.content);

--- a/addon/model/writers/html-text-writer.ts
+++ b/addon/model/writers/html-text-writer.ts
@@ -1,27 +1,36 @@
 import Writer from '@lblod/ember-rdfa-editor/model/writers/writer';
 import Model from '@lblod/ember-rdfa-editor/model/model';
 import ModelText from '@lblod/ember-rdfa-editor/model/model-text';
+import { TextView } from '@lblod/ember-rdfa-editor/model/node-view';
+import {
+  isTextOrElement,
+  TextOrElement,
+} from '@lblod/ember-rdfa-editor/model/util/types';
+import { NotImplementedError } from '@lblod/ember-rdfa-editor/utils/errors';
 
 /**
  * Writer responsible for converting {@link ModelText} nodes into HTML subtrees
  * This takes care of converting the textattributes into HTML elements
  */
-export default class HtmlTextWriter implements Writer<ModelText, Node> {
+export default class HtmlTextWriter implements Writer<ModelText, TextView> {
   constructor(protected model: Model) {}
 
-  write(modelNode: ModelText): Node {
-    if (modelNode.length === 0) {
-      return new Text();
-    }
-
-    let current: Node = new Text(modelNode.content);
-    this.model.registerNodeView(modelNode, current);
+  write(modelNode: ModelText): TextView {
+    const contentRoot: Text = new Text(modelNode.content);
+    let current: TextOrElement = contentRoot;
 
     for (const entry of [...modelNode.marks].sort((a, b) =>
       a.priority >= b.priority ? 1 : -1
     )) {
-      current = entry.write(current);
+      const rendered = entry.write(current);
+      if (isTextOrElement(rendered)) {
+        current = rendered;
+      } else {
+        throw new NotImplementedError(
+          'Mark is trying to render as something other than an element or a text node'
+        );
+      }
     }
-    return current;
+    return { contentRoot, viewRoot: current };
   }
 }

--- a/addon/model/writers/html-text-writer.ts
+++ b/addon/model/writers/html-text-writer.ts
@@ -15,7 +15,7 @@ export default class HtmlTextWriter implements Writer<ModelText, Node> {
     }
 
     let current: Node = new Text(modelNode.content);
-    this.model.bindNode(modelNode, current);
+    this.model.registerNodeView(modelNode, current);
 
     for (const entry of [...modelNode.marks].sort((a, b) =>
       a.priority >= b.priority ? 1 : -1

--- a/addon/model/writers/html-writer.ts
+++ b/addon/model/writers/html-writer.ts
@@ -19,10 +19,10 @@ export default class HtmlWriter {
   }
 
   write(modelNode: ModelNode): Node {
-    let boundNode: TextOrElement = modelNode.boundNode as TextOrElement;
+    let boundNode: TextOrElement = modelNode.viewRoot as TextOrElement;
 
     if (!boundNode) {
-      if (!modelNode.parent?.boundNode) {
+      if (!modelNode.parent?.viewRoot) {
         throw new ModelError('Impossible state');
       }
       boundNode = this.parseTree(modelNode);

--- a/addon/model/writers/html-writer.ts
+++ b/addon/model/writers/html-writer.ts
@@ -77,7 +77,7 @@ export default class HtmlWriter {
     return this.model.modelToView(modelNode);
   }
 
-  private createElementView(modelElement: ModelElement): NodeView {
+  private createElementView(modelElement: ModelElement): ElementView {
     const view = this.htmlElementWriter.write(modelElement);
     this.model.registerNodeView(modelElement, view);
     return view;
@@ -88,9 +88,8 @@ export default class HtmlWriter {
     view: ElementView
   ): NodeView {
     if (modelElement.isDirty('node')) {
-      const newView = this.htmlElementWriter.write(modelElement);
+      const newView = this.createElementView(modelElement);
       this.swapElement(view.viewRoot, newView.viewRoot);
-      this.model.registerNodeView(modelElement, newView);
       return newView;
     }
     return view;

--- a/addon/model/writers/html-writer.ts
+++ b/addon/model/writers/html-writer.ts
@@ -26,7 +26,7 @@ export default class HtmlWriter {
         throw new ModelError('Impossible state');
       }
       boundNode = this.parseTree(modelNode);
-      this.model.bindNode(modelNode, boundNode);
+      this.model.registerNodeView(modelNode, boundNode);
       modelNode.clearDirty();
       return boundNode;
     } else {
@@ -35,7 +35,7 @@ export default class HtmlWriter {
         if (modelNode.isDirty('node')) {
           result = this.htmlElementWriter.write(modelNode);
           this.swapElement(boundNode as HTMLElement, result);
-          this.model.bindNode(modelNode, result);
+          this.model.registerNodeView(modelNode, result);
           boundNode = result;
         }
         const domChildren = modelNode.children.map((child) =>
@@ -52,7 +52,7 @@ export default class HtmlWriter {
         if (modelNode.isDirty('node') || modelNode.isDirty('mark')) {
           const domNode = this.htmlTextWriter.write(modelNode) as Text;
           (boundNode as Text).replaceWith(domNode);
-          this.model.bindNode(modelNode, domNode);
+          this.model.registerNodeView(modelNode, domNode);
           result = domNode;
         } else if (modelNode.isDirty('content')) {
           (boundNode as Text).replaceData(

--- a/addon/model/writers/html-writer.ts
+++ b/addon/model/writers/html-writer.ts
@@ -4,7 +4,7 @@ import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
 import { ModelError, WriterError } from '@lblod/ember-rdfa-editor/utils/errors';
 import HtmlElementWriter from '@lblod/ember-rdfa-editor/model/writers/html-element-writer';
 
-type TextOrElement = Text | HTMLElement;
+export type TextOrElement = Text | HTMLElement;
 
 /**
  * Top-level {@link Writer} for HTML documents.
@@ -18,7 +18,7 @@ export default class HtmlWriter {
     this.htmlElementWriter = new HtmlElementWriter(model);
   }
 
-  write(modelNode: ModelNode, parseOnly = false): Node {
+  write(modelNode: ModelNode): Node {
     let boundNode: TextOrElement = modelNode.boundNode as TextOrElement;
 
     if (!boundNode) {
@@ -49,10 +49,9 @@ export default class HtmlWriter {
         return result;
       } else if (ModelNode.isModelText(modelNode)) {
         let result = boundNode;
-        if (modelNode.isDirty('node')) {
-          const domNode = this.htmlTextWriter.write(modelNode);
+        if (modelNode.isDirty('node') || modelNode.isDirty('mark')) {
+          const domNode = this.htmlTextWriter.write(modelNode) as Text;
           (boundNode as Text).replaceWith(domNode);
-          console.log('text replace');
           this.model.bindNode(modelNode, domNode);
           result = domNode;
         } else if (modelNode.isDirty('content')) {
@@ -61,7 +60,6 @@ export default class HtmlWriter {
             (boundNode as Text).length,
             modelNode.content
           );
-          console.log('text edit');
         }
         modelNode.clearDirty();
         return result;
@@ -85,12 +83,9 @@ export default class HtmlWriter {
     }
   }
 
-  getDomnodeFor(modelNode: ModelNode): Node {}
-
   swapElement(node: HTMLElement, replacement: HTMLElement) {
     const children = node.childNodes;
     replacement.append(...children);
     node.replaceWith(replacement);
-    console.log('domNode swap');
   }
 }

--- a/addon/model/writers/selection-writer.ts
+++ b/addon/model/writers/selection-writer.ts
@@ -46,28 +46,28 @@ export default class SelectionWriter implements Writer<ModelSelection, void> {
     const nodeBefore = position.nodeBefore();
     if (!nodeAfter) {
       return {
-        anchor: position.parent.boundNode!,
-        offset: position.parent.boundNode!.childNodes.length,
+        anchor: position.parent.viewRoot!,
+        offset: position.parent.viewRoot!.childNodes.length,
       };
     }
     if (ModelElement.isModelText(nodeAfter)) {
       return {
-        anchor: nodeAfter.boundNode!,
+        anchor: nodeAfter.viewRoot!,
         offset: position.parentOffset - nodeAfter.getOffset(),
       };
     } else if (ModelElement.isModelText(nodeBefore)) {
       // we prefer text node anchors, so we look both ways
       return {
-        anchor: nodeBefore.boundNode!,
+        anchor: nodeBefore.viewRoot!,
         offset: position.parentOffset - nodeBefore.getOffset(),
       };
     } else if (ModelElement.isModelElement(nodeAfter)) {
-      const domAnchor = position.parent.boundNode!;
+      const domAnchor = position.parent.viewRoot!;
       const domIndex = ArrayUtils.indexOf(
-        nodeAfter.boundNode!,
+        nodeAfter.viewRoot!,
         (domAnchor as HTMLElement).childNodes
       )!;
-      return { anchor: position.parent.boundNode!, offset: domIndex };
+      return { anchor: position.parent.viewRoot!, offset: domIndex };
     } else {
       throw new ModelError('Unsupported node type');
     }

--- a/addon/model/writers/selection-writer.ts
+++ b/addon/model/writers/selection-writer.ts
@@ -6,6 +6,8 @@ import ModelPosition from '@lblod/ember-rdfa-editor/model/model-position';
 import { ModelError } from '@lblod/ember-rdfa-editor/utils/errors';
 import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
 import ArrayUtils from '@lblod/ember-rdfa-editor/model/util/array-utils';
+import Model from '@lblod/ember-rdfa-editor/model/model';
+import ModelText from '@lblod/ember-rdfa-editor/model/model-text';
 
 /**
  * Writer to convert a {@link ModelSelection} to a {@link Selection}
@@ -13,6 +15,12 @@ import ArrayUtils from '@lblod/ember-rdfa-editor/model/util/array-utils';
  * create a {@link Selection}
  */
 export default class SelectionWriter implements Writer<ModelSelection, void> {
+  private _model: Model;
+
+  constructor(model: Model) {
+    this._model = model;
+  }
+
   write(modelSelection: ModelSelection): void {
     const domSelection = getWindowSelection();
 
@@ -45,31 +53,53 @@ export default class SelectionWriter implements Writer<ModelSelection, void> {
     const nodeAfter = position.nodeAfter();
     const nodeBefore = position.nodeBefore();
     if (!nodeAfter) {
+      const nodeView = this._model.modelToView(position.parent);
+      if (!nodeView) {
+        throw new ModelError(
+          'Writing selection of modelNode which is not in dom'
+        );
+      }
       return {
-        anchor: position.parent.viewRoot!,
-        offset: position.parent.viewRoot!.childNodes.length,
+        anchor: nodeView.contentRoot,
+        offset: nodeView.contentRoot.childNodes.length,
       };
     }
+    let textAnchor: ModelText | null = null;
     if (ModelElement.isModelText(nodeAfter)) {
-      return {
-        anchor: nodeAfter.viewRoot!,
-        offset: position.parentOffset - nodeAfter.getOffset(),
-      };
+      textAnchor = nodeAfter;
     } else if (ModelElement.isModelText(nodeBefore)) {
-      // we prefer text node anchors, so we look both ways
+      textAnchor = nodeBefore;
+    }
+    if (textAnchor) {
+      const nodeView = this._model.modelToView(textAnchor);
+      if (!nodeView) {
+        throw new ModelError(
+          'Writing selection of modelNode which is not in dom'
+        );
+      }
       return {
-        anchor: nodeBefore.viewRoot!,
-        offset: position.parentOffset - nodeBefore.getOffset(),
+        anchor: nodeView.contentRoot,
+        offset: position.parentOffset - textAnchor.getOffset(),
       };
-    } else if (ModelElement.isModelElement(nodeAfter)) {
-      const domAnchor = position.parent.viewRoot!;
-      const domIndex = ArrayUtils.indexOf(
-        nodeAfter.viewRoot!,
-        (domAnchor as HTMLElement).childNodes
-      )!;
-      return { anchor: position.parent.viewRoot!, offset: domIndex };
     } else {
-      throw new ModelError('Unsupported node type');
+      if (ModelElement.isModelElement(nodeAfter)) {
+        const parentView = this._model.modelToView(position.parent);
+        const nodeView = this._model.modelToView(nodeAfter);
+        if (!nodeView || !parentView) {
+          throw new ModelError(
+            'Writing selection of modelNode which is not in dom'
+          );
+        }
+
+        const domAnchor = parentView.contentRoot;
+        const domIndex = ArrayUtils.indexOf(
+          nodeView.contentRoot,
+          (domAnchor as HTMLElement).childNodes
+        )!;
+        return { anchor: parentView.contentRoot, offset: domIndex };
+      } else {
+        throw new ModelError('Unsupported node type');
+      }
     }
   }
 }

--- a/addon/model/writers/unpolluted-html-text-writer.ts
+++ b/addon/model/writers/unpolluted-html-text-writer.ts
@@ -1,16 +1,21 @@
 import HtmlTextWriter from '@lblod/ember-rdfa-editor/model/writers/html-text-writer';
 import { preWrapToNormalWhiteSpace } from '@lblod/ember-rdfa-editor/utils/whitespace-collapsing';
 import ModelText from '../model-text';
+import Model from '@lblod/ember-rdfa-editor/model/model';
 
 /**
  * Writer responsible for converting {@link ModelText} nodes into HTML subtrees
  * This takes care of converting the textattributes into HTML elements
  */
-export default class UnpollutedHtmlTextWriter extends HtmlTextWriter {
+export default class UnpollutedHtmlTextWriter {
+  constructor(private model: Model) {}
+
+  private textWriter = new HtmlTextWriter(this.model);
+
   write(modelNode: ModelText): Node {
     const clone = modelNode.clone();
     clone.content = preWrapToNormalWhiteSpace(modelNode.content);
-    const current = super.write(clone);
+    const current = this.textWriter.write(clone).viewRoot;
     return current;
   }
 }

--- a/addon/model/writers/unpolluted-html-text-writer.ts
+++ b/addon/model/writers/unpolluted-html-text-writer.ts
@@ -7,7 +7,7 @@ import ModelText from '../model-text';
  * This takes care of converting the textattributes into HTML elements
  */
 export default class UnpollutedHtmlTextWriter extends HtmlTextWriter {
-  write(modelNode: ModelText): Node | null {
+  write(modelNode: ModelText): Node {
     const clone = modelNode.clone();
     clone.content = preWrapToNormalWhiteSpace(modelNode.content);
     const current = super.write(clone);

--- a/addon/model/writers/xml-node-writer.ts
+++ b/addon/model/writers/xml-node-writer.ts
@@ -8,14 +8,20 @@ export default class XmlNodeWriter implements Writer<ModelNode, Node> {
   constructor(private document: XMLDocument) {}
 
   write(modelNode: ModelNode): Node {
+    let result: Element;
     if (ModelNode.isModelElement(modelNode)) {
       const writer = new XmlElementWriter(this.document);
-      return writer.write(modelNode);
+      result = writer.write(modelNode);
     } else if (ModelNode.isModelText(modelNode)) {
       const writer = new XmlTextWriter(this.document);
-      return writer.write(modelNode);
+      result = writer.write(modelNode);
     } else {
       throw new NotImplementedError();
     }
+    if (modelNode.dirtiness.size) {
+      const dirtyness = Array.from(modelNode.dirtiness).join(',');
+      result.setAttribute('__dirty', dirtyness);
+    }
+    return result;
   }
 }

--- a/addon/model/writers/xml-text-writer.ts
+++ b/addon/model/writers/xml-text-writer.ts
@@ -2,8 +2,7 @@ import Writer from '@lblod/ember-rdfa-editor/model/writers/writer';
 import ModelText from '@lblod/ember-rdfa-editor/model/model-text';
 
 export default class XmlTextWriter implements Writer<ModelText, Element> {
-  constructor(private document: XMLDocument) {
-  }
+  constructor(private document: XMLDocument) {}
 
   write(text: ModelText): Element {
     const result = this.document.createElement('text');

--- a/addon/model/writers/xml-text-writer.ts
+++ b/addon/model/writers/xml-text-writer.ts
@@ -2,7 +2,8 @@ import Writer from '@lblod/ember-rdfa-editor/model/writers/writer';
 import ModelText from '@lblod/ember-rdfa-editor/model/model-text';
 
 export default class XmlTextWriter implements Writer<ModelText, Element> {
-  constructor(private document: XMLDocument) {}
+  constructor(private document: XMLDocument) {
+  }
 
   write(text: ModelText): Element {
     const result = this.document.createElement('text');
@@ -11,6 +12,13 @@ export default class XmlTextWriter implements Writer<ModelText, Element> {
 
     for (const [key, value] of text.attributeMap.entries()) {
       result.setAttribute(key, value);
+    }
+    if (text.marks.size) {
+      const markNames = [];
+      for (const mark of text.marks) {
+        markNames.push(mark.name);
+      }
+      result.setAttribute('__marks', markNames.join(','));
     }
 
     return result;

--- a/addon/utils/plugins/table/tab-input-plugin.ts
+++ b/addon/utils/plugins/table/tab-input-plugin.ts
@@ -65,7 +65,7 @@ export default class TableTabInputPlugin implements TabInputPlugin {
     manipulation: TabHandlerManipulation,
     editor: PernetRawEditor
   ) {
-    const table = editor.model.getModelNodeFor(manipulation.node) as ModelTable;
+    const table = editor.model.viewToModel(manipulation.node) as ModelTable;
     const firstCell = table.getCell(0, 0);
     if (firstCell) {
       editor.selection.collapseIn(firstCell);
@@ -77,7 +77,7 @@ export default class TableTabInputPlugin implements TabInputPlugin {
     manipulation: TabHandlerManipulation,
     editor: PernetRawEditor
   ) {
-    const table = editor.model.getModelNodeFor(manipulation.node) as ModelTable;
+    const table = editor.model.viewToModel(manipulation.node) as ModelTable;
     const { x, y } = table.getDimensions();
     const lastCell = table.getCell(x - 1, y - 1);
     if (lastCell) {

--- a/tests/unit/commands/insert-html-command-test.ts
+++ b/tests/unit/commands/insert-html-command-test.ts
@@ -116,6 +116,7 @@ module('Unit | commands | insert-html-command-test', (hooks) => {
     ctx.model.fillRoot(initial);
     const range = ModelRange.fromInElement(ctx.model.rootModelNode, 1, 3);
     command.execute(htmlToInsert, range);
+    console.log(ctx.model.rootModelNode.toXml());
 
     assert.true(ctx.model.rootModelNode.sameAs(expected));
   });

--- a/tests/unit/commands/insert-html-command-test.ts
+++ b/tests/unit/commands/insert-html-command-test.ts
@@ -116,7 +116,6 @@ module('Unit | commands | insert-html-command-test', (hooks) => {
     ctx.model.fillRoot(initial);
     const range = ModelRange.fromInElement(ctx.model.rootModelNode, 1, 3);
     command.execute(htmlToInsert, range);
-    console.log(ctx.model.rootModelNode.toXml());
 
     assert.true(ctx.model.rootModelNode.sameAs(expected));
   });

--- a/tests/unit/model/marks-test.ts
+++ b/tests/unit/model/marks-test.ts
@@ -47,7 +47,7 @@ module('Unit | model | marks-test', (hooks) => {
     const model = new Model(sinon.createStubInstance(HTMLElement));
     model.registerMark(boldMarkSpec);
     const writer = new HtmlWriter(model);
-    const result = writer.write(textNode);
+    const result = writer.write(textNode).viewRoot;
     assert.true(isElement(result));
     assert.strictEqual(tagName(result), 'strong');
     assert.strictEqual(result.childNodes.length, 1);
@@ -62,7 +62,7 @@ module('Unit | model | marks-test', (hooks) => {
     model.registerMark(boldMarkSpec);
     model.registerMark(italicMarkSpec);
     const writer = new HtmlWriter(model);
-    const result = writer.write(textNode);
+    const result = writer.write(textNode).viewRoot;
     assert.true(isElement(result));
     assert.strictEqual(tagName(result), 'em');
     assert.strictEqual(result.childNodes.length, 1);

--- a/tests/unit/model/model-node-test.ts
+++ b/tests/unit/model/model-node-test.ts
@@ -336,7 +336,7 @@ module('Unit | model | model-node', (hooks) => {
           </ul>
         </div>
       `;
-      assert.false(model1.sameAs(model2, true));
+      assert.false(model1.sameAs(model2, { ignoredAttributes: new Set() }));
     });
   });
 });

--- a/tests/unit/model/operations/insert-operation-test.ts
+++ b/tests/unit/model/operations/insert-operation-test.ts
@@ -20,7 +20,8 @@ module('Unit | model | operations | insert-operation-test', () => {
       </modelRoot>
     `;
 
-    const { root: nodeToInsert } = vdom`<text>abc</text>`;
+    const { root: nodeToInsert } = vdom`
+      <text>abc</text>`;
 
     const op = new InsertOperation(
       undefined,
@@ -28,7 +29,7 @@ module('Unit | model | operations | insert-operation-test', () => {
       nodeToInsert
     );
     op.execute();
-    assert.true(initial.sameAs(expected, {ignoreDirtiness: false}));
+    assert.true(initial.sameAs(expected, { ignoreDirtiness: false }));
   });
   test('inserts element into empty root', (assert) => {
     // language=XML
@@ -60,36 +61,65 @@ module('Unit | model | operations | insert-operation-test', () => {
     assert.true(initial.sameAs(expected, { ignoreDirtiness: false }));
   });
   test('inserts into root when collapsed', (assert) => {
-    const root = new ModelElement('div');
-    const s0 = new ModelElement('span');
-    root.addChild(s0);
-
-    const nodeToInsert = new ModelText('abc');
+    //language=XML
+    const {
+      root: initial,
+      elements: { rangeAnchor },
+    } = vdom`
+      <modelRoot __id="rangeAnchor">
+        <span/>
+      </modelRoot>
+    `;
+    //language=XML
+    const { root: nodeToInsert } = vdom`
+      <text>abc</text>`;
 
     const op = new InsertOperation(
       undefined,
-      ModelRange.fromPaths(root, [0], [0]),
+      ModelRange.fromInNode(rangeAnchor, 0, 0),
       nodeToInsert
     );
+    //language=XML
+    const { root: expected } = vdom`
+      <modelRoot __dirty="content">
+        <text __dirty="node,content">abc</text>
+        <span/>
+      </modelRoot>
+    `;
     op.execute();
-    assert.strictEqual(root.length, 2);
-    assert.strictEqual(root.firstChild, nodeToInsert);
+    assert.true(expected.sameAs(initial, { ignoreDirtiness: false }));
   });
   test('inserts into root when collapsed2', (assert) => {
     const root = new ModelElement('div');
     const s0 = new ModelElement('span');
     root.addChild(s0);
+    //language=XML
+    const {
+      root: initial,
+      elements: { rangeAnchor },
+    } = vdom`
+      <modelRoot __id="rangeAnchor">
+        <span/>
+      </modelRoot>
+    `;
 
-    const nodeToInsert = new ModelText('abc');
+    //language=XML
+    const { root: nodeToInsert } = vdom`
+      <text>abc</text>`;
+    const { root: expected } = vdom`
+      <modelRoot __dirty="content">
+        <span/>
+        <text __dirty="content,node">abc</text>
+      </modelRoot>
+    `;
 
     const op = new InsertOperation(
       undefined,
-      ModelRange.fromPaths(root, [1], [1]),
+      ModelRange.fromInNode(rangeAnchor, 1, 1),
       nodeToInsert
     );
     op.execute();
-    assert.strictEqual(root.length, 2);
-    assert.strictEqual(root.lastChild, nodeToInsert);
+    assert.true(expected.sameAs(initial, { ignoreDirtiness: false }));
   });
   test('replaces when not collapsed', (assert) => {
     const root = new ModelElement('div');
@@ -145,11 +175,11 @@ module('Unit | model | operations | insert-operation-test', () => {
 
     // language=XML
     const { root: expected } = vdom`
-      <modelRoot>
-        <div>
-          <text>te</text>
+      <modelRoot __dirty="content">
+        <div __dirty="content">
+          <text __dirty="content">te</text>
         </div>
-        <text>st</text>
+        <text __dirty="content">st</text>
       </modelRoot>
     `;
     const start = ModelPosition.fromInTextNode(rangeStart, 2);
@@ -158,8 +188,9 @@ module('Unit | model | operations | insert-operation-test', () => {
     const op = new InsertOperation(undefined, range);
 
     const resultRange = op.execute();
+    console.log(expected.toXml());
 
-    assert.true(expected.sameAs(initial));
+    assert.true(expected.sameAs(initial, { ignoreDirtiness: false }));
     assert.true(
       resultRange.sameAs(
         ModelRange.fromPaths(initial as ModelElement, [1], [1])

--- a/tests/unit/model/operations/insert-operation-test.ts
+++ b/tests/unit/model/operations/insert-operation-test.ts
@@ -138,10 +138,41 @@ module('Unit | model | operations | insert-operation-test', () => {
     assert.strictEqual(root.firstChild, nodeToInsert);
   });
   test('replaces complex range', (assert) => {
-    const { root, s0, s2, s3, t00, t22 } = buildStructure1();
+    const {
+      root: initial,
+      textNodes: { t00, t22 },
+    } = vdom`
+      <modelRoot>
+        <span>
+          <text __id="t00">t00</text>
+          <text>t01</text>
+          <text>t02</text>
+        </span>
+        <span>
+          <text>t10</text>
+          <text>t11</text>
+          <text>t12</text>
+        </span>
+        <span>
+          <text>t20</text>
+          <text>t21</text>
+          <text __id="t22">t22</text>
+        </span>
+        <span/>
+      </modelRoot>
+    `;
+    const { root: nodeToInsert } = vdom`
+      <text>abc</text>`;
 
-    const nodeToInsert = new ModelText('abc');
-
+    const { root: expected } = vdom`
+      <modelRoot __dirty="content">
+        <span __dirty="content">
+          <text __dirty="node,content">abc</text>
+        </span>
+        <span __dirty="content"/>
+        <span/>
+      </modelRoot>
+    `;
     const p1 = ModelPosition.fromInTextNode(t00, 0);
     const p2 = ModelPosition.fromInTextNode(t22, 3);
     const op = new InsertOperation(
@@ -150,14 +181,7 @@ module('Unit | model | operations | insert-operation-test', () => {
       nodeToInsert
     );
     op.execute();
-    assert.strictEqual(root.length, 3);
-    assert.strictEqual(root.children[0], s0);
-    assert.strictEqual(root.children[1], s2);
-    assert.strictEqual(root.children[2], s3);
-    assert.strictEqual(s0.length, 1);
-    assert.strictEqual(s0.children[0], nodeToInsert);
-    assert.strictEqual(s2.length, 0);
-    assert.strictEqual(s3.length, 0);
+    assert.true(expected.sameAs(initial, { ignoreDirtiness: false }));
   });
   test('removes items when no nodes to insert are provided', (assert) => {
     // language=XML
@@ -223,15 +247,15 @@ module('Unit | model | operations | insert-operation-test', () => {
 
     // language=XML
     const { root: expected } = vdom`
-      <modelRoot>
-        <div>
-          <text>ab</text>
-          <text>ins0</text>
-          <text>ins1</text>
+      <modelRoot __dirty="content">
+        <div __dirty="content">
+          <text __dirty="content">ab</text>
+          <text __dirty="node,content">ins0</text>
+          <text __dirty="node,content">ins1</text>
         </div>
-        <div>
-          <span>
-            <text>op</text>
+        <div __dirty="content">
+          <span __dirty="content">
+            <text __dirty="content">op</text>
           </span>
         </div>
       </modelRoot>
@@ -246,7 +270,7 @@ module('Unit | model | operations | insert-operation-test', () => {
       new ModelText('ins1')
     );
     const resultRange = op.execute();
-    assert.true(initial.sameAs(expected));
+    assert.true(initial.sameAs(expected, { ignoreDirtiness: false }));
     assert.true(
       resultRange.sameAs(
         ModelRange.fromPaths(initial as ModelElement, [0, 2], [0, 10])
@@ -254,31 +278,3 @@ module('Unit | model | operations | insert-operation-test', () => {
     );
   });
 });
-
-function buildStructure1() {
-  const root = new ModelElement('div');
-
-  const s0 = new ModelElement('span');
-  const t00 = new ModelText('t00');
-  const t01 = new ModelText('t01');
-  const t02 = new ModelText('t02');
-
-  const s1 = new ModelElement('span');
-  const t10 = new ModelText('t10');
-  const t11 = new ModelText('t11');
-  const t12 = new ModelText('t12');
-
-  const s2 = new ModelElement('span');
-  const t20 = new ModelText('t20');
-  const t21 = new ModelText('t21');
-  const t22 = new ModelText('t22');
-
-  const s3 = new ModelElement('span');
-
-  root.appendChildren(s0, s1, s2, s3);
-  s0.appendChildren(t00, t01, t02);
-  s1.appendChildren(t10, t11, t12);
-  s2.appendChildren(t20, t21, t22);
-
-  return { root, s0, s1, s2, s3, t00, t01, t02, t10, t11, t12, t20, t21, t22 };
-}

--- a/tests/unit/model/operations/insert-operation-test.ts
+++ b/tests/unit/model/operations/insert-operation-test.ts
@@ -5,6 +5,9 @@ import ModelText from '@lblod/ember-rdfa-editor/model/model-text';
 import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
 import ModelPosition from '@lblod/ember-rdfa-editor/model/model-position';
 import { vdom } from '@lblod/ember-rdfa-editor/model/util/xml-utils';
+import { XmlReaderResult } from '@lblod/ember-rdfa-editor/model/readers/xml-reader';
+import GenTreeWalker from '@lblod/ember-rdfa-editor/model/util/gen-tree-walker';
+import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
 
 module('Unit | model | operations | insert-operation-test', () => {
   test('inserts into empty root', (assert) => {
@@ -20,8 +23,8 @@ module('Unit | model | operations | insert-operation-test', () => {
       </modelRoot>
     `;
 
-    const { root: nodeToInsert } = vdom`
-      <text>abc</text>`;
+    const { root: nodeToInsert } = asNew(vdom`
+      <text __dirty="content,node">abc</text>`);
 
     const op = new InsertOperation(
       undefined,
@@ -47,10 +50,10 @@ module('Unit | model | operations | insert-operation-test', () => {
     `;
 
     // language=XML
-    const { root: nodeToInsert } = vdom`
+    const { root: nodeToInsert } = asNew(vdom`
       <div>
         <text>abc</text>
-      </div>`;
+      </div>`);
 
     const op = new InsertOperation(
       undefined,
@@ -71,8 +74,8 @@ module('Unit | model | operations | insert-operation-test', () => {
       </modelRoot>
     `;
     //language=XML
-    const { root: nodeToInsert } = vdom`
-      <text>abc</text>`;
+    const { root: nodeToInsert } = asNew(vdom`
+      <text>abc</text>`);
 
     const op = new InsertOperation(
       undefined,
@@ -104,8 +107,8 @@ module('Unit | model | operations | insert-operation-test', () => {
     `;
 
     //language=XML
-    const { root: nodeToInsert } = vdom`
-      <text>abc</text>`;
+    const { root: nodeToInsert } = asNew(vdom`
+      <text>abc</text>`);
     const { root: expected } = vdom`
       <modelRoot __dirty="content">
         <span/>
@@ -161,8 +164,8 @@ module('Unit | model | operations | insert-operation-test', () => {
         <span/>
       </modelRoot>
     `;
-    const { root: nodeToInsert } = vdom`
-      <text>abc</text>`;
+    const { root: nodeToInsert } = asNew(vdom`
+      <text>abc</text>`);
 
     const { root: expected } = vdom`
       <modelRoot __dirty="content">
@@ -199,8 +202,8 @@ module('Unit | model | operations | insert-operation-test', () => {
 
     // language=XML
     const { root: expected } = vdom`
-      <modelRoot __dirty="content">
-        <div __dirty="content">
+      <modelRoot>
+        <div>
           <text __dirty="content">te</text>
         </div>
         <text __dirty="content">st</text>
@@ -212,7 +215,7 @@ module('Unit | model | operations | insert-operation-test', () => {
     const op = new InsertOperation(undefined, range);
 
     const resultRange = op.execute();
-    console.log(expected.toXml());
+    console.log(initial.toXml())
 
     assert.true(expected.sameAs(initial, { ignoreDirtiness: false }));
     assert.true(
@@ -254,7 +257,7 @@ module('Unit | model | operations | insert-operation-test', () => {
           <text __dirty="node,content">ins1</text>
         </div>
         <div __dirty="content">
-          <span __dirty="content">
+          <span>
             <text __dirty="content">op</text>
           </span>
         </div>
@@ -278,3 +281,11 @@ module('Unit | model | operations | insert-operation-test', () => {
     );
   });
 });
+
+function asNew(result: XmlReaderResult) {
+  const walker = GenTreeWalker.fromSubTree<ModelNode>({ root: result.root });
+  for (const node of walker.nodes()) {
+    node.setDirty('node', 'content');
+  }
+  return result;
+}

--- a/tests/unit/model/operations/insert-operation-test.ts
+++ b/tests/unit/model/operations/insert-operation-test.ts
@@ -15,8 +15,8 @@ module('Unit | model | operations | insert-operation-test', () => {
 
     // language=XML
     const { root: expected } = vdom`
-      <modelRoot>
-        <text>abc</text>
+      <modelRoot __dirty="content">
+        <text __dirty="content,node">abc</text>
       </modelRoot>
     `;
 
@@ -28,7 +28,7 @@ module('Unit | model | operations | insert-operation-test', () => {
       nodeToInsert
     );
     op.execute();
-    assert.true(initial.sameAs(expected));
+    assert.true(initial.sameAs(expected, {ignoreDirtiness: false}));
   });
   test('inserts element into empty root', (assert) => {
     // language=XML
@@ -38,9 +38,9 @@ module('Unit | model | operations | insert-operation-test', () => {
 
     // language=XML
     const { root: expected } = vdom`
-      <modelRoot>
-        <div>
-          <text>abc</text>
+      <modelRoot __dirty="content">
+        <div __dirty="content,node">
+          <text __dirty="content,node">abc</text>
         </div>
       </modelRoot>
     `;
@@ -57,7 +57,7 @@ module('Unit | model | operations | insert-operation-test', () => {
       nodeToInsert
     );
     op.execute();
-    assert.true(initial.sameAs(expected));
+    assert.true(initial.sameAs(expected, { ignoreDirtiness: false }));
   });
   test('inserts into root when collapsed', (assert) => {
     const root = new ModelElement('div');

--- a/tests/unit/model/operations/insert-operation-test.ts
+++ b/tests/unit/model/operations/insert-operation-test.ts
@@ -215,7 +215,7 @@ module('Unit | model | operations | insert-operation-test', () => {
     const op = new InsertOperation(undefined, range);
 
     const resultRange = op.execute();
-    console.log(initial.toXml())
+    console.log(initial.toXml());
 
     assert.true(expected.sameAs(initial, { ignoreDirtiness: false }));
     assert.true(

--- a/tests/unit/model/operations/insert-operation-test.ts
+++ b/tests/unit/model/operations/insert-operation-test.ts
@@ -215,7 +215,6 @@ module('Unit | model | operations | insert-operation-test', () => {
     const op = new InsertOperation(undefined, range);
 
     const resultRange = op.execute();
-    console.log(initial.toXml());
 
     assert.true(expected.sameAs(initial, { ignoreDirtiness: false }));
     assert.true(

--- a/tests/unit/model/operations/move-operation-test.ts
+++ b/tests/unit/model/operations/move-operation-test.ts
@@ -22,8 +22,8 @@ module('Unit | model | operations | move-operation-test', () => {
 
     // language=XML
     const { root: expected } = vdom`
-      <modelRoot>
-        <div>
+      <modelRoot __dirty="content">
+        <div __dirty="content">
           <text>abcd</text>
         </div>
       </modelRoot>
@@ -34,7 +34,7 @@ module('Unit | model | operations | move-operation-test', () => {
     const op = new MoveOperation(undefined, srcRange, targetPos);
     const resultRange = op.execute();
 
-    assert.true(initial.sameAs(expected));
+    assert.true(initial.sameAs(expected, { ignoreDirtiness: false }));
     assert.true(
       resultRange.sameAs(
         ModelRange.fromPaths(initial as ModelElement, [0, 0], [0, 4])

--- a/tests/unit/model/operations/operation-algorithms-test.ts
+++ b/tests/unit/model/operations/operation-algorithms-test.ts
@@ -39,7 +39,6 @@ module('Unit | model | operations | operation-algorithms-test', () => {
     const start = ModelPosition.fromInElement(rangeStart, 0);
     const end = ModelPosition.fromInTextNode(rangeEnd, 1);
     OperationAlgorithms.remove(new ModelRange(start, end));
-    console.log(initial.toXml());
 
     assert.true(initial.sameAs(expected));
   });

--- a/tests/unit/model/operations/operation-algorithms-test.ts
+++ b/tests/unit/model/operations/operation-algorithms-test.ts
@@ -39,7 +39,7 @@ module('Unit | model | operations | operation-algorithms-test', () => {
     const start = ModelPosition.fromInElement(rangeStart, 0);
     const end = ModelPosition.fromInTextNode(rangeEnd, 1);
     OperationAlgorithms.remove(new ModelRange(start, end));
-    console.log(initial.toXml())
+    console.log(initial.toXml());
 
     assert.true(initial.sameAs(expected));
   });

--- a/tests/unit/model/operations/operation-algorithms-test.ts
+++ b/tests/unit/model/operations/operation-algorithms-test.ts
@@ -39,6 +39,7 @@ module('Unit | model | operations | operation-algorithms-test', () => {
     const start = ModelPosition.fromInElement(rangeStart, 0);
     const end = ModelPosition.fromInTextNode(rangeEnd, 1);
     OperationAlgorithms.remove(new ModelRange(start, end));
+    console.log(initial.toXml())
 
     assert.true(initial.sameAs(expected));
   });

--- a/tests/unit/model/twoway-conversion-test.ts
+++ b/tests/unit/model/twoway-conversion-test.ts
@@ -18,14 +18,19 @@ module('Unit | model | twoway-conversion', (hooks) => {
   });
   test('converting simple tree back and forth gives same tree', (assert) => {
     const p = document.createElement('p');
-    p.innerHTML = `<p><ul><li> some text <div style="background-color:green"><a href="#">an <em data-__set-by="rdfa-editor"> italic |- </em> link</a></div></li></ul></p>`;
+    // the inner p will get broken up by the dom as per the html standard
+    // this happens before the model reads it
+    // https://developer.mozilla.org/en-us/docs/Web/HTML/Element/p
+    const innerContent = `<p></p><ul><li> some text <div style="background-color:green"><a href="#">an <em data-__set-by="rdfa-editor"> italic |- </em> link</a></div></li></ul><p></p>`;
+    p.innerHTML = innerContent;
     const read = reader.read(p);
     if (!read) {
       throw new AssertionError();
     }
-    const written = writer.write(read[0]) as HTMLElement;
+    console.log(read[0].toXml());
+    const written = writer.write(read[0]).viewRoot as HTMLElement;
 
-    assert.strictEqual(written.outerHTML, p.outerHTML);
+    assert.strictEqual(written.innerHTML, innerContent);
   });
   test('<i> gets converted to <em>', (assert) => {
     const p = document.createElement('p');
@@ -34,7 +39,7 @@ module('Unit | model | twoway-conversion', (hooks) => {
     if (!read) {
       throw new AssertionError();
     }
-    const written = writer.write(read[0]) as HTMLElement;
+    const written = writer.write(read[0]).viewRoot as HTMLElement;
     // the inner p will get broken up by the dom as per the html standard
     // this happens before the model reads it
     // https://developer.mozilla.org/en-us/docs/Web/HTML/Element/p

--- a/tests/unit/model/twoway-conversion-test.ts
+++ b/tests/unit/model/twoway-conversion-test.ts
@@ -27,7 +27,6 @@ module('Unit | model | twoway-conversion', (hooks) => {
     if (!read) {
       throw new AssertionError();
     }
-    console.log(read[0].toXml());
     const written = writer.write(read[0]).viewRoot as HTMLElement;
 
     assert.strictEqual(written.innerHTML, innerContent);

--- a/tests/unit/model/writers/selection-writer-test.ts
+++ b/tests/unit/model/writers/selection-writer-test.ts
@@ -25,7 +25,7 @@ module('Unit | model | writers | selection-writer', (hooks) => {
     const writer = new SelectionWriter();
     const domRange = writer.writeDomRange(model.selection.lastRange!);
 
-    assert.strictEqual(domRange.startContainer, text.boundNode);
+    assert.strictEqual(domRange.startContainer, text.viewRoot);
     assert.strictEqual(domRange.startOffset, 0);
     assert.strictEqual(domRange.endContainer, model.rootNode);
     assert.strictEqual(domRange.endOffset, 1);

--- a/tests/unit/model/writers/selection-writer-test.ts
+++ b/tests/unit/model/writers/selection-writer-test.ts
@@ -22,10 +22,13 @@ module('Unit | model | writers | selection-writer', (hooks) => {
     model.selection.selectRange(new ModelRange(start, end));
 
     model.write();
-    const writer = new SelectionWriter();
+    const writer = new SelectionWriter(model);
     const domRange = writer.writeDomRange(model.selection.lastRange!);
 
-    assert.strictEqual(domRange.startContainer, text.viewRoot);
+    assert.strictEqual(
+      domRange.startContainer,
+      model.modelToView(text)?.viewRoot
+    );
     assert.strictEqual(domRange.startOffset, 0);
     assert.strictEqual(domRange.endContainer, model.rootNode);
     assert.strictEqual(domRange.endOffset, 1);


### PR DESCRIPTION
PLEASE TEST A LOT

This is a complete rewrite of the reading/writing logic, both of the content _and_ the selection.

### How it works:

Every node now keeps track of its own 'dirty' state. This is a set of strings with 3 possible values:
- "node": something in the node itself has changed (in practice, mainly attribute changes, or when it's a new node)
- "content": for elements, a change has been made to it's children array (aka children added or removed, changes in children are handled by a "node" dirtyness on the child). For textnodes, its textcontent has changed
- "mark": only relevant for textnodes, a change in its marks (mainly future proofing, has the same effect as a "node" dirtiness at the moment, but that's a coincidence). 

(Recall, it's a set, so nodes can have any combination of these active at the same time)

#### assumptions:
changes to nodes are done using their public methods. This is not 100% enforced, for example the `children` array is publicly readable, and because this is JS it is therefore also mutable. Though, directly messing with these kinds of things has been undefined behavior for a while already, and usage of the node API is only permitted within Operation logic, so unlikely to have any impact.

The html-writer then smartly updates the dom based on these dirtiness values. 
**This means that the writer is no longer a pure functional interface!**
Having the writer make instant changes to the dom avoids the need to traverse twice.


### Side-effects of this PR

#### NodeViews

While working on the writing logic, the way that Marks were handled became a gigantic nuisance to debug. After some fruitless prodding, I decided to rework it. This has led to the introduction of the concept of a `NodeView`. 
Previously, ModelNodes were tied to a single DOMNode, called the `boundNode`. This coupling was necessary for converting selections back and forth. 
With marks however, a new problem was introduced: a textnode could now be rendered as a small tree of elements, instead of a plain Text node. With incremental writing, it became necessary to couple the ModelText node both to the dom Text node, as well as the root of the subtree defined by its marks.

NodeViews are the generic form of this coupling. At the moment it is simply an object with the following interface:
```ts
interface NodeView {
  viewRoot: Node,
  contentRoot: Node
}
```

The viewRoot represents the root of the DOM subtree defined by this modelNode. For a textnode, this is the root subtree created by its marks. This is what was previously called the `boundNode`
The contentRoot is then where the _content_ of the node (literally `content` for textnodes, and `children` for elements) will be rendered.

Currently, viewRoot and contentRoot are identical for ModelElements and only differ for ModelText nodes _if_ they have Marks.
But it's easy to see the value of this separation when we think about non-trivial rendering for special elements.

This change had consequences for all readers and writers, and especially for the selection reader/writer. Luckily, it was actually a beneficial change. Rather than the awkward heuristics of `findPositionForTextPropertyNode` (a relic from the pre-marks era) we now have a clear distinction between selections "in the content root" and "outside the content root". The former being a selection we can meaningfully transform, and the latter simply mapping to either before or after the modelnode, based on some heuristics.

Note, as usual when it appears I've done something smart, this is heavily inspired by ProseMirror.

Another detail: rather than storing the nodeView as a property on the node itself, I've decided to maintain a two-way WeakMap in the Model. Since at least a one-way WeakMap had to be maintained already, this was a much cleaner solution. 
It also makes the Nodes _almost_ a **true** model in the MVC sense. The only remnant of view-specific logic (and it's debatable whether it is view-specific) is the dirtiness flags. It's likely those will move away from nodes when immutable nodes are introduced, since at that point any node-update logic will live outside the node as well, leading to an even cleaner MVC structure. This is not a short-term goal though.


#### Other

- cloning of a markset was broken. (This will also be split off as a separate PR since it's an urgent fix)
- the debouncing hack in the TextInputHandler is no longer necessary since performance is vastly improved on chrome, so it is removed.




Closes https://binnenland.atlassian.net/browse/GN-3304