### PR TITLE
bump ember-truth-helpers to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5515,6 +5515,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
       "requires": {
         "babel-helper-explode-assignable-expression": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -5525,6 +5526,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -5536,6 +5538,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "^6.24.1",
         "babel-runtime": "^6.26.0",
@@ -5547,6 +5550,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-traverse": "^6.24.1",
@@ -5557,6 +5561,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -5569,6 +5574,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -5578,6 +5584,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -5587,6 +5594,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -5596,6 +5604,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "babel-types": "^6.26.0",
@@ -5606,6 +5615,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -5618,6 +5628,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
       "requires": {
         "babel-helper-optimise-call-expression": "^6.24.1",
         "babel-messages": "^6.23.0",
@@ -5664,6 +5675,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -5786,7 +5798,8 @@
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
     },
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
@@ -5796,17 +5809,20 @@
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
       "requires": {
         "babel-helper-remap-async-to-generator": "^6.24.1",
         "babel-plugin-syntax-async-functions": "^6.8.0",
@@ -5817,6 +5833,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -5825,6 +5842,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -5833,6 +5851,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "babel-template": "^6.26.0",
@@ -5845,6 +5864,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
       "requires": {
         "babel-helper-define-map": "^6.24.1",
         "babel-helper-function-name": "^6.24.1",
@@ -5861,6 +5881,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
@@ -5870,6 +5891,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -5878,6 +5900,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -5887,6 +5910,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -5895,6 +5919,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -5905,6 +5930,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -5913,6 +5939,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -5923,6 +5950,7 @@
       "version": "6.26.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "^6.24.1",
         "babel-runtime": "^6.26.0",
@@ -5934,6 +5962,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -5944,6 +5973,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -5954,6 +5984,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
       "requires": {
         "babel-helper-replace-supers": "^6.24.1",
         "babel-runtime": "^6.22.0"
@@ -5963,6 +5994,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
       "requires": {
         "babel-helper-call-delegate": "^6.24.1",
         "babel-helper-get-function-arity": "^6.24.1",
@@ -5976,6 +6008,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -5985,6 +6018,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -5993,6 +6027,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
       "requires": {
         "babel-helper-regex": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -6003,6 +6038,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -6011,6 +6047,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -6019,6 +6056,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
       "requires": {
         "babel-helper-regex": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -6028,12 +6066,14 @@
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
         },
         "regexpu-core": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+          "dev": true,
           "requires": {
             "regenerate": "^1.2.1",
             "regjsgen": "^0.2.0",
@@ -6043,12 +6083,14 @@
         "regjsgen": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+          "dev": true
         },
         "regjsparser": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+          "dev": true,
           "requires": {
             "jsesc": "~0.5.0"
           }
@@ -6059,6 +6101,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -6069,6 +6112,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
       "requires": {
         "regenerator-transform": "^0.10.0"
       },
@@ -6077,6 +6121,7 @@
           "version": "0.10.1",
           "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
           "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+          "dev": true,
           "requires": {
             "babel-runtime": "^6.18.0",
             "babel-types": "^6.19.0",
@@ -6089,6 +6134,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -6098,6 +6144,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
@@ -6107,7 +6154,8 @@
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
         }
       }
     },
@@ -6115,6 +6163,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "^6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -6152,6 +6201,7 @@
           "version": "3.2.8",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
           "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+          "dev": true,
           "requires": {
             "caniuse-lite": "^1.0.30000844",
             "electron-to-chromium": "^1.3.47"
@@ -14888,6 +14938,172 @@
         "ember-lodash": "^4.19.4",
         "ember-math-helpers": "^2.1.0",
         "ember-truth-helpers": "^2.0.0"
+      },
+      "dependencies": {
+        "amd-name-resolver": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.1"
+          }
+        },
+        "babel-plugin-debug-macros": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
+          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
+          "dev": true,
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+          "dev": true,
+          "requires": {
+            "ember-rfc176-data": "^0.3.13"
+          }
+        },
+        "broccoli-babel-transpiler": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
+          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+          "dev": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "broccoli-funnel": "^2.0.1",
+            "broccoli-merge-trees": "^2.0.0",
+            "broccoli-persistent-filter": "^1.4.3",
+            "clone": "^2.0.0",
+            "hash-for-dep": "^1.2.3",
+            "heimdalljs-logger": "^0.1.7",
+            "json-stable-stringify": "^1.0.0",
+            "rsvp": "^4.8.2",
+            "workerpool": "^2.3.0"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        },
+        "broccoli-persistent-filter": {
+          "version": "1.4.6",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
+          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
+          "dev": true,
+          "requires": {
+            "async-disk-cache": "^1.2.1",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^1.0.0",
+            "fs-tree-diff": "^0.5.2",
+            "hash-for-dep": "^1.0.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "mkdirp": "^0.5.1",
+            "promise-map-series": "^0.2.1",
+            "rimraf": "^2.6.1",
+            "rsvp": "^3.0.18",
+            "symlink-or-copy": "^1.0.1",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "rsvp": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+              "dev": true
+            }
+          }
+        },
+        "broccoli-source": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
+          "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
+          "dev": true
+        },
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        },
+        "ember-truth-helpers": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-2.1.0.tgz",
+          "integrity": "sha512-BQlU8aTNl1XHKTYZ243r66yqtR9JU7XKWQcmMA+vkqfkE/c9WWQ9hQZM8YABihCmbyxzzZsngvldokmeX5GhAw==",
+          "dev": true,
+          "requires": {
+            "ember-cli-babel": "^6.6.0"
+          },
+          "dependencies": {
+            "ember-cli-babel": {
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+              "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+              "dev": true,
+              "requires": {
+                "amd-name-resolver": "1.2.0",
+                "babel-plugin-debug-macros": "^0.2.0-beta.6",
+                "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+                "babel-polyfill": "^6.26.0",
+                "babel-preset-env": "^1.7.0",
+                "broccoli-babel-transpiler": "^6.5.0",
+                "broccoli-debug": "^0.6.4",
+                "broccoli-funnel": "^2.0.0",
+                "broccoli-source": "^1.1.0",
+                "clone": "^2.0.0",
+                "ember-cli-version-checker": "^2.1.2",
+                "semver": "^5.5.0"
+              }
+            }
+          }
+        },
+        "merge-trees": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
+          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+          "dev": true,
+          "requires": {
+            "can-symlink": "^1.0.0",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "workerpool": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.4.tgz",
+          "integrity": "sha512-c2EWrgB9IKHi1jbf4LG9sxKgHYOY+Ej5li6siEGtFecCXWG7eQOqATPEJ0rg1KFETXROEkErc1t5XiNrLG666Q==",
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "ember-decorators": {
@@ -20613,153 +20829,11 @@
       }
     },
     "ember-truth-helpers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-2.1.0.tgz",
-      "integrity": "sha512-BQlU8aTNl1XHKTYZ243r66yqtR9JU7XKWQcmMA+vkqfkE/c9WWQ9hQZM8YABihCmbyxzzZsngvldokmeX5GhAw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.0.0.tgz",
+      "integrity": "sha512-hPKG9QqruAELh0li5xaiLZtr88ioWYxWCXisAWHWE0qCP4a2hgtuMzKUPpiTCkltvKjuqpzTZCU4VhQ+IlRmew==",
       "requires": {
-        "ember-cli-babel": "^6.6.0"
-      },
-      "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "babel-plugin-ember-modules-api-polyfill": {
-          "version": "2.13.4",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
-          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
-          "requires": {
-            "ember-rfc176-data": "^0.3.13"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
-          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "requires": {
-            "babel-core": "^6.26.0",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^2.0.0",
-            "broccoli-persistent-filter": "^1.4.3",
-            "clone": "^2.0.0",
-            "hash-for-dep": "^1.2.3",
-            "heimdalljs-logger": "^0.1.7",
-            "json-stable-stringify": "^1.0.0",
-            "rsvp": "^4.8.2",
-            "workerpool": "^2.3.0"
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
-          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "merge-trees": "^1.0.1"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
-          "integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^0.5.2",
-            "hash-for-dep": "^1.0.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^3.0.18",
-            "symlink-or-copy": "^1.0.1",
-            "walk-sync": "^0.3.1"
-          },
-          "dependencies": {
-            "rsvp": {
-              "version": "3.6.2",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-              "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
-            }
-          }
-        },
-        "broccoli-source": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-          "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
-        },
-        "ember-cli-babel": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
-          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "merge-trees": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
-          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "requires": {
-            "can-symlink": "^1.0.0",
-            "fs-tree-diff": "^0.5.4",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "workerpool": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.4.tgz",
-          "integrity": "sha512-c2EWrgB9IKHi1jbf4LG9sxKgHYOY+Ej5li6siEGtFecCXWG7eQOqATPEJ0rg1KFETXROEkErc1t5XiNrLG666Q==",
-          "requires": {
-            "object-assign": "4.1.1"
-          }
-        }
+        "ember-cli-babel": "^7.22.1"
       }
     },
     "ember-try": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-get-config": "^0.5.0",
     "ember-intl": "^5.6.2",
     "ember-maybe-import-regenerator": "^1.0.0",
-    "ember-truth-helpers": "^2.0.0",
+    "ember-truth-helpers": "^3.0.0",
     "ix": "^4.5.2",
     "mdn-polyfills": "^5.16.0",
     "rdf-data-factory": "^1.1.0",


### PR DESCRIPTION
this is one of the packages with an older babel version as a dependency. 3.0 has no breaking changes that should be of concern.
See https://github.com/jmurphyau/ember-truth-helpers/blob/master/CHANGELOG.md