### PR TITLE
execute undo on VDOM

### DIFF
--- a/addon/commands/insert-xml-command.ts
+++ b/addon/commands/insert-xml-command.ts
@@ -4,8 +4,7 @@ import { parseXmlSiblings } from '@lblod/ember-rdfa-editor/model/util/xml-utils'
 import Model from '@lblod/ember-rdfa-editor/model/model';
 import { logExecute } from '@lblod/ember-rdfa-editor/utils/logging-utils';
 import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
-import ModelNode from '../model/model-node';
-import ModelElement from '../model/model-element';
+import setNodeAndChildDirty from '@lblod/ember-rdfa-editor/model/util/set-node-and-child-dirty';
 
 /**
  * Allows you to insert model nodes from an xml string.
@@ -31,17 +30,9 @@ export default class InsertXmlCommand extends Command {
       //All nodes are marked as dirty by default when inserted but not in the xml writer
       // as we need to set dirtiness statuses in the tests, in order to solve bugs related to
       // nodes not being properly inserted we set them all dirty in this function below
-      parsedModelNodes.forEach((node) => this.setNodeAndChildDirty(node));
+      parsedModelNodes.forEach((node) => setNodeAndChildDirty(node));
       const newRange = mutator.insertNodes(range, ...parsedModelNodes);
       this.model.selectRange(newRange);
     });
-  }
-  setNodeAndChildDirty(node: ModelNode) {
-    node.addDirty('content');
-    if (ModelElement.isModelElement(node)) {
-      for (const child of node.children) {
-        this.setNodeAndChildDirty(child);
-      }
-    }
   }
 }

--- a/addon/commands/undo-command.ts
+++ b/addon/commands/undo-command.ts
@@ -1,5 +1,6 @@
 import Command from '@lblod/ember-rdfa-editor/commands/command';
 import Model from '@lblod/ember-rdfa-editor/model/model';
+import { logExecute } from '../utils/logging-utils';
 
 export default class UndoCommand extends Command {
   name = 'undo';
@@ -8,6 +9,7 @@ export default class UndoCommand extends Command {
     super(model, false);
   }
 
+  @logExecute
   execute(): void {
     this.model.restoreSnapshot();
   }

--- a/addon/editor/input-handlers/backspace-handler.ts
+++ b/addon/editor/input-handlers/backspace-handler.ts
@@ -389,6 +389,7 @@ export default class BackspaceHandler extends InputHandler {
     void this.backspace().then(() => {
       this.rawEditor.updateSelectionAfterComplexInput(); // make sure currentSelection of editor is up to date with actual cursor position
       this.rawEditor.model.read();
+      this.rawEditor.model.saveSnapshot();
       this.rawEditor.eventBus.emit(
         new ContentChangedEvent({
           owner: CORE_OWNER,

--- a/addon/editor/input-handlers/fallback-input-handler.ts
+++ b/addon/editor/input-handlers/fallback-input-handler.ts
@@ -43,6 +43,7 @@ export default class FallbackInputHandler extends InputHandler {
       `Uncaptured event of type ${event.type}, restoring editor state.`
     );
     this.rawEditor.model.read();
+    this.rawEditor.model.saveSnapshot();
     return { allowPropagation: false, allowBrowserDefault: true };
   }
 }

--- a/addon/editor/input-handlers/undo-handler.ts
+++ b/addon/editor/input-handlers/undo-handler.ts
@@ -17,8 +17,7 @@ export default class UndoHandler extends InputHandler {
   }
 
   handleEvent(_: KeyboardEvent): HandlerResponse {
-    this.rawEditor.undo();
-    this.rawEditor.model.read();
+    this.rawEditor.executeCommand('undo');
     return { allowPropagation: false, allowBrowserDefault: false };
   }
 }

--- a/addon/editor/input-handlers/undo-handler.ts
+++ b/addon/editor/input-handlers/undo-handler.ts
@@ -19,6 +19,6 @@ export default class UndoHandler extends InputHandler {
   handleEvent(_: KeyboardEvent): HandlerResponse {
     this.rawEditor.undo();
     this.rawEditor.model.read();
-    return { allowPropagation: false, allowBrowserDefault: true };
+    return { allowPropagation: false, allowBrowserDefault: false };
   }
 }

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -140,8 +140,6 @@ export default class Model {
    * have a real dom available.
    */
   write(tree: ModelElement = this.rootModelNode, writeSelection = true) {
-    const modelWriteEvent = new CustomEvent('editorModelWrite');
-    document.dispatchEvent(modelWriteEvent);
     this.rootModelNode.removeDirty('node');
 
     this.writer.write(tree);

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -197,11 +197,11 @@ export default class Model {
     writeBack = true,
     saveSnapshot = true
   ) {
-    const mutator = new ImmediateModelMutator(this._eventBus);
-    callback(mutator);
     if (saveSnapshot) {
       this.saveSnapshot();
     }
+    const mutator = new ImmediateModelMutator(this._eventBus);
+    callback(mutator);
     if (writeBack) {
       this.write();
     }

--- a/addon/model/util/set-node-and-child-dirty.ts
+++ b/addon/model/util/set-node-and-child-dirty.ts
@@ -1,0 +1,11 @@
+import ModelElement from '../model-element';
+import ModelNode from '../model-node';
+
+export default function setNodeAndChildDirty(node: ModelNode) {
+  node.addDirty('content');
+  if (ModelElement.isModelElement(node)) {
+    for (const child of node.children) {
+      setNodeAndChildDirty(child);
+    }
+  }
+}

--- a/addon/utils/ce/list-helpers.ts
+++ b/addon/utils/ce/list-helpers.ts
@@ -21,7 +21,7 @@ export function indentAction(rawEditor: PernetRawEditor): void {
 
   if (filteredSuitableNodes.length) {
     const handleAction = () => {
-      rawEditor.createSnapshot();
+      rawEditor.model.saveSnapshot();
 
       const groupedLogicalBlocks = getGroupedLogicalBlocks(
         filteredSuitableNodes,
@@ -55,7 +55,7 @@ export function unindentAction(rawEditor: PernetRawEditor): void {
 
   if (filteredSuitableNodes.length) {
     const handleAction = () => {
-      rawEditor.createSnapshot();
+      rawEditor.model.saveSnapshot();
 
       const groupedLogicalBlocks = getGroupedLogicalBlocks(
         filteredSuitableNodes,

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -62,7 +62,6 @@ import {
 } from '@lblod/ember-rdfa-editor/model/mark';
 import AddMarkToRangeCommand from '@lblod/ember-rdfa-editor/commands/add-mark-to-range-command';
 import RemoveMarkFromRangeCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-from-range-command';
-import PernetRawEditor from '@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor';
 import RemoveMarkCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-command';
 import MatchTextCommand from '@lblod/ember-rdfa-editor/commands/match-text-command';
 
@@ -255,13 +254,6 @@ export default class RawEditor {
    * @param args
    */
   executeCommand(commandName: string, ...args: unknown[]) {
-    //TODO this is a hack to keep legacy undo behavior, to be removed when vdom-based undo is solidified
-    if (commandName === 'undo') {
-      if (this instanceof PernetRawEditor) {
-        this.undo();
-        return;
-      }
-    }
     try {
       const command = this.getCommand(commandName);
       if (command.canExecute(...args)) {


### PR DESCRIPTION
while reviewing #236 I noticed the undo handler is not preventing default browser behaviour at the moment, this fixes that. 
edit: Turns out fixing that involved porting this to work on the VDOM, so updated the title to reflect that
NEEDS EXTENSIVE TESTING