### PR TITLE
add embroider test scenarios to ember try

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
   return {
@@ -48,6 +49,8 @@ module.exports = async function () {
         },
         allowedToFail: true,
       },
+      embroiderSafe(),
+      embroiderOptimized(),
     ],
   };
 };

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -49,8 +49,8 @@ module.exports = async function () {
         },
         allowedToFail: true,
       },
-      embroiderSafe(),
-      embroiderOptimized(),
+      embroiderSafe({ allowedToFail: true }),
+      embroiderOptimized({ allowedToFail: true }),
     ],
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -45,6 +45,6 @@ module.exports = function (defaults) {
     This build file does *not* influence how the addon or the app using it
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
-
-  return app.toTree();
+  const { maybeEmbroider } = require('@embroider/test-setup');
+  return maybeEmbroider(app);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2350,6 +2350,16 @@
         }
       }
     },
+    "@embroider/test-setup": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-1.5.0.tgz",
+      "integrity": "sha512-4C0dgVswxfA/lBCD8FUWADQhjeO8AJ2KmRkvItOPSwPlAA1QI7gOD28DuiAnCAK18muIFq7P++gvl1qBNid6lg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      }
+    },
     "@embroider/util": {
       "version": "0.47.2",
       "resolved": "https://registry.npmjs.org/@embroider/util/-/util-0.47.2.tgz",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@codemirror/lang-html": "^0.19.4",
     "@codemirror/lang-xml": "^0.19.2",
     "@ember/test-helpers": "^2.6.0",
+    "@embroider/test-setup": "^1.5.0",
     "@glimmer/component": "^1.0.3",
     "@rdfjs/types": "^1.0.1",
     "@types/common-tags": "^1.8.0",
@@ -144,13 +145,13 @@
     "release-it-lerna-changelog": "^4.0.1",
     "sass": "^1.26.3",
     "sinon": "^12.0.1",
+    "stream-browserify": "^3.0.0",
     "svg-symbols": "^1.0.5",
     "tracked-built-ins": "^1.1.1",
     "typescript": "^4.3.4",
     "webpack": "^5.55.1",
     "xml-formatter": "^2.4.0",
-    "yuidoc-ember-theme": "^2.0.1",
-    "stream-browserify": "^3.0.0"
+    "yuidoc-ember-theme": "^2.0.1"
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^1.0.0",


### PR DESCRIPTION
According to the embroider readme:
> The best thing for all addons authors to do right now is to achieve the "Embroider Safe" support level. Follow the instructions in the @embroider/test-setup README to add the embroider-safe scenario to your ember-try config.