### PR TITLE
convert newlines to br elements when inserting text

### DIFF
--- a/addon/commands/insert-text-command.ts
+++ b/addon/commands/insert-text-command.ts
@@ -2,6 +2,7 @@ import Command from '@lblod/ember-rdfa-editor/commands/command';
 import Model from '@lblod/ember-rdfa-editor/model/model';
 import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
 import { MisbehavedSelectionError } from '@lblod/ember-rdfa-editor/utils/errors';
+import ModelElement from '../model/model-element';
 import { logExecute } from '../utils/logging-utils';
 
 export default class InsertTextCommand extends Command {
@@ -20,9 +21,28 @@ export default class InsertTextCommand extends Command {
       throw new MisbehavedSelectionError();
     }
 
+    const newLines = text.matchAll(/\n/g);
     this.model.change((mutator) => {
-      const resultRange = mutator.insertText(range, text);
-
+      let resultRange = range;
+      if (newLines) {
+        let previousIndex = 0;
+        for (const newLineMatch of newLines) {
+          const position = newLineMatch.index!;
+          const line = text.substring(previousIndex, position);
+          resultRange = mutator.insertText(resultRange, line);
+          resultRange.collapse(false);
+          resultRange = mutator.insertNodes(
+            resultRange,
+            new ModelElement('br')
+          );
+          resultRange.collapse(false);
+          previousIndex = position + 1;
+        }
+        const lastLine = text.substring(previousIndex, text.length);
+        resultRange = mutator.insertText(resultRange, lastLine);
+      } else {
+        resultRange = mutator.insertText(range, text);
+      }
       resultRange.collapse(false);
       this.model.selectRange(resultRange);
     });

--- a/tests/unit/commands/insert-text-command-test.ts
+++ b/tests/unit/commands/insert-text-command-test.ts
@@ -156,4 +156,33 @@ module('Unit | commands | insert-text-command-test', (hooks) => {
     }
     assert.true(rslt);
   });
+
+  test('newlines are converted to br elements', (assert) => {
+    // language=XML
+    const {
+      root: initial,
+      elements: { parent },
+    } = vdom`
+      <modelRoot>
+        <div __id="parent">
+          <text>ab</text>
+        </div>
+      </modelRoot>
+    `;
+
+    // language=XML
+    const { root: expected } = vdom`
+      <modelRoot>
+        <div>
+          <text>abc</text>
+          <br />
+          <text>de</text>
+        </div>
+      </modelRoot>
+    `;
+    ctx.model.fillRoot(initial);
+    const range = ModelRange.fromInElement(parent, 2, 2);
+    command.execute('c\nde', range);
+    assert.true(ctx.model.rootModelNode.sameAs(expected));
+  });
 });


### PR DESCRIPTION
since text inserts can contain newlines and we don't expect those in the editor, we convert them to br elements in the insert-text command. this also fixes some issues I had with pasting content from PDFs and editing that.