### PR TITLE
Provide ranges per capture group

### DIFF
--- a/addon/utils/match-text.ts
+++ b/addon/utils/match-text.ts
@@ -13,6 +13,7 @@ export interface TextMatch {
   text: string;
   /**
    * The matched text in the capture groups
+   * The first element contains the full match, in line with how the DOM spec does it
    */
   groups: Array<string | undefined>;
   /**
@@ -21,10 +22,12 @@ export interface TextMatch {
   index: number;
   /**
    * The [start, end] indices of each capture group
+   * The first element contains start and end of the full match, in line with how the DOM spec does it
    */
   indices: Array<[number, number] | undefined>;
   /**
    * The range where each capture group was found
+   * The first element contains the range encompassing the full match, in line with how the DOM spec does it
    */
   groupRanges: Array<ModelRange | undefined>;
   /**


### PR DESCRIPTION
Along with getting the range for the entire match, it is also important plugins have access to textranges for every capture group, as they may want to only operate on a group match.

## BREAKING
- to be more inline with the structure of the DOM api, the groups array now has the entire match as its first element. This is currently only used in the citation plugin, for which an accompanying pr is available: https://github.com/lblod/ember-rdfa-editor-citaten-plugin/pull/26