### PR TITLE
Fix space-eating issues

### DIFF
--- a/addon/commands/insert-html-command.ts
+++ b/addon/commands/insert-html-command.ts
@@ -24,13 +24,13 @@ export default class InsertHtmlCommand extends Command {
     const parser = new DOMParser();
     const html = parser.parseFromString(htmlString, 'text/html');
     const bodyContent = html.body.childNodes;
-    const reader = new HtmlReader(this.model, true);
+    const reader = new HtmlReader(this.model);
 
     this.model.change((mutator) => {
       // dom NodeList doesn't have a map method
       const modelNodes: ModelNode[] = [];
       bodyContent.forEach((node) => {
-        const parsed = reader.read(node);
+        const parsed = reader.read(node, true);
         if (parsed) {
           modelNodes.push(...parsed);
         }

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -56,7 +56,7 @@ export default class Model {
 
   constructor(rootNode: HTMLElement, eventBus?: EventBus) {
     this._rootNode = rootNode;
-    this.reader = new HtmlReader(this, true);
+    this.reader = new HtmlReader(this);
     this.writer = new HtmlWriter(this);
     this.selectionReader = new SelectionReader(this);
     this.selectionWriter = new SelectionWriter(this);
@@ -88,9 +88,12 @@ export default class Model {
   /**
    * Read in the document and build up the model.
    */
-  read(readSelection = true) {
+  read(readSelection = true, shouldConvertWhitespace = false) {
     this.marksRegistry.clear();
-    const parsedNodes = this.reader.read(this.rootNode);
+    const parsedNodes = this.reader.read(
+      this.rootNode,
+      shouldConvertWhitespace
+    );
     if (parsedNodes.length !== 1) {
       throw new Error('Could not create a rich root');
     }

--- a/addon/model/readers/html-reader.ts
+++ b/addon/model/readers/html-reader.ts
@@ -63,19 +63,16 @@ export class HtmlReaderContext {
 /**
  * Top-level reader for HTML documents
  */
-export default class HtmlReader implements Reader<Node, ModelNode[], void> {
-  constructor(
-    private model: Model,
-    private shouldConvertWhitespace: boolean = false
-  ) {}
+export default class HtmlReader implements Reader<Node, ModelNode[], boolean> {
+  constructor(private model: Model) {}
 
-  read(from: Node): ModelNode[] {
+  read(from: Node, shouldConvertWhitespace = false): ModelNode[] {
     from.normalize();
     const prefixes = calculateRdfaPrefixes(from);
     const context = new HtmlReaderContext(
       this.model,
       prefixes,
-      this.shouldConvertWhitespace
+      shouldConvertWhitespace
     );
     const nodeReader = new HtmlNodeReader();
     return nodeReader.read(from, context);

--- a/addon/utils/ce/pernet-raw-editor.ts
+++ b/addon/utils/ce/pernet-raw-editor.ts
@@ -979,6 +979,8 @@ export default class PernetRawEditor extends RawEditor implements Editor {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
     const rslt = update.bind(this)(selection, options);
     if (this.tryOutVdom) {
+      // it's debatable whether we should convert whitespace here or not,
+      // but not doing it is the safer option since it is a destructive process.
       this.model.read();
       this.model.write();
       this.updateRichNode();

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -207,7 +207,7 @@ export default class RawEditor {
   set rootNode(rootNode: HTMLElement) {
     if (rootNode) {
       this.initialize(rootNode);
-      this.model.read();
+      this.model.read(true, true);
       this.model.selection.collapseIn(this.model.rootModelNode);
       this.model.write();
       this.updateRichNode();


### PR DESCRIPTION
The normalToPreWrapWhitespace function's purpose is to make the html you insert look the same as it looks outside the editor (aka in an environment with normal whitespace handling). This means deleting all whitespace that wouldn't be rendered elsewhere.
However this was done too often: when reading from our own document, (which is already in prewrap-mode) this would delete spaces that were really part of the content. 
Fixed by not converting when we are reading from our own document.