### PR TITLE
More consice removing of RDFa type

### DIFF
--- a/addon/commands/node-properties/remove-type-command.ts
+++ b/addon/commands/node-properties/remove-type-command.ts
@@ -14,16 +14,11 @@ export default class RemoveTypeCommand extends Command {
   @logExecute
   execute(type: string, element: ModelElement) {
     const oldTypeof = element.getAttribute('typeof');
-    let typesArray = oldTypeof?.split(' ');
-    if (!typesArray) typesArray = [];
-    let newType = '';
-    for (const typeString of typesArray) {
-      if (type === typeString) continue;
-      newType += typeString + ' ';
-    }
+    const typesArray = oldTypeof ? oldTypeof.split(' ') : [];
+    const newTypeof = typesArray.filter((t) => t !== type).join(' ');
     let newNode;
     this.model.change((mutator) => {
-      newNode = mutator.setProperty(element, 'typeof', newType);
+      newNode = mutator.setProperty(element, 'typeof', newTypeof);
       this.model.selectRange(ModelRange.fromInElement(newNode, 0, 0));
     });
     return newNode;


### PR DESCRIPTION
This version of the remove-type command does not create extra spaces on removing a type from the attribute of a DOM element. This is linked to the problems we found in https://github.com/lblod/besluit-publicatie-publish-service/pull/8 where extra spaces in RDFa attributes (although legal) caused the RDFa parser to create triples with empty subjects.