### PR TITLE
improve whitespace collapsing

### DIFF
--- a/addon/model/readers/html-text-reader.ts
+++ b/addon/model/readers/html-text-reader.ts
@@ -16,7 +16,7 @@ export default class HtmlTextReader
 
     let trimmed = from.textContent;
     if (context.shouldConvertWhitespace) {
-      trimmed = normalToPreWrapWhiteSpace(trimmed);
+      trimmed = normalToPreWrapWhiteSpace(from);
     }
 
     if (trimmed.length == 0) {

--- a/addon/model/util/constants.ts
+++ b/addon/model/util/constants.ts
@@ -8,13 +8,13 @@ import { TextAttribute } from '@lblod/ember-rdfa-editor/commands/text-properties
 
 // based on https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content
 // we've added a, del, ins to the list since we assume they only contain phrasing content in the editor
+// we've removed br from the list to be inline with editor behaviour, which treats it as a block
 export const PHRASING_CONTENT = [
   'a',
   'abbr',
   'audio',
   'b',
   'bdo',
-  'br',
   'button',
   'canvas',
   'cite',

--- a/addon/model/util/constants.ts
+++ b/addon/model/util/constants.ts
@@ -6,7 +6,61 @@ import { underlineMarkSpec } from '@lblod/ember-rdfa-editor/plugins/basic-styles
 import { strikethroughMarkSpec } from '@lblod/ember-rdfa-editor/plugins/basic-styles/marks/strikethrough';
 import { TextAttribute } from '@lblod/ember-rdfa-editor/commands/text-properties/set-text-property-command';
 
-export const NON_BLOCK_NODES = new Set(['b', 'strong', 'i', 'em', 'span', 'a']);
+// based on https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content
+// we've added a, del, ins to the list since we assume they only contain phrasing content in the editor
+export const PHRASING_CONTENT = [
+  'a',
+  'abbr',
+  'audio',
+  'b',
+  'bdo',
+  'br',
+  'button',
+  'canvas',
+  'cite',
+  'code',
+  'command',
+  'data',
+  'datalist',
+  'del',
+  'dfn',
+  'em',
+  'embed',
+  'i',
+  'iframe',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'keygen',
+  'label',
+  'mark',
+  'math',
+  'meter',
+  'noscript',
+  'object',
+  'output',
+  'picture',
+  'progress',
+  'q',
+  'ruby',
+  'samp',
+  'script',
+  'select',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'svg',
+  'textarea',
+  'time',
+  'u',
+  'var',
+  'video',
+  'wbr',
+];
+export const NON_BLOCK_NODES = new Set(PHRASING_CONTENT);
 export const LIST_TYPES = new Set(['li', 'ul', 'ol']);
 export const LIST_CONTAINERS = new Set(['ul', 'ol']);
 export const TABLE_TYPES = new Set([

--- a/tests/unit/utils/whitespace-collapsing-test.ts
+++ b/tests/unit/utils/whitespace-collapsing-test.ts
@@ -31,13 +31,13 @@ module('Unit | utils | whitespace-collapsing | pre-wrap-to-normal ', () => {
 
 module('Unit | utils | whitespace-collapsing | normal-to-pre-wrap', () => {
   test('properly collapses spaces', function (assert) {
-    const inputText = '            my title';
+    const inputText = document.createTextNode('            my title');
     const result = normalToPreWrapWhiteSpace(inputText);
     assert.strictEqual(result, 'my title');
   });
 
   test('removes linebreaks', function (assert) {
-    const inputText = 'line one\nline two\nline 3';
+    const inputText = document.createTextNode('line one\nline two\nline 3');
     const result = normalToPreWrapWhiteSpace(inputText);
     assert.strictEqual(result, 'line one line two line 3');
   });


### PR DESCRIPTION
should address most common cases. I tested with the following:
```
<p> space before me</p>
<p>space before me</p>
<p>space <em> <strong>before </strong>me</em></p>
<p>space<em><strong> before</strong> me</em></p>
<p>space<em> before me</em> and me</p>
<p>space<em> before me </em>and me</p>
```