### PR TITLE
Fix collapsed selections not detecting marks correctly

### DIFF
--- a/addon/commands/add-mark-to-range-command.ts
+++ b/addon/commands/add-mark-to-range-command.ts
@@ -22,7 +22,8 @@ export default class AddMarkToRangeCommand extends Command<
     const spec = this.model.marksRegistry.lookupMark(markName);
     if (spec) {
       this.model.change((mutator) => {
-        mutator.addMark(range, spec, markAttributes);
+        const resultRange = mutator.addMark(range, spec, markAttributes);
+        this.model.selectRange(resultRange);
       });
     } else {
       throw new ModelError(`Unrecognized mark: ${markName}`);

--- a/addon/commands/add-mark-to-selection-command.ts
+++ b/addon/commands/add-mark-to-selection-command.ts
@@ -1,0 +1,34 @@
+import Command from '@lblod/ember-rdfa-editor/commands/command';
+import Model from '@lblod/ember-rdfa-editor/model/model';
+import {
+  AttributeSpec,
+  Mark,
+  Serializable,
+} from '@lblod/ember-rdfa-editor/model/mark';
+import { ModelError } from '@lblod/ember-rdfa-editor/utils/errors';
+
+export default class AddMarkToSelectionCommand extends Command<
+  [string, Record<string, Serializable>],
+  void
+> {
+  name = 'add-mark-to-selection';
+
+  constructor(model: Model) {
+    super(model);
+  }
+
+  execute(
+    markName: string,
+    markAttributes: Record<string, Serializable> = {}
+  ): void {
+    const spec = this.model.marksRegistry.lookupMark(markName);
+    if (spec) {
+      this.model.selection.addMark(
+        new Mark<AttributeSpec>(spec, markAttributes)
+      );
+      this.model.rootNode.focus();
+    } else {
+      throw new ModelError(`Unrecognized mark: ${markName}`);
+    }
+  }
+}

--- a/addon/commands/add-mark-to-selection-command.ts
+++ b/addon/commands/add-mark-to-selection-command.ts
@@ -5,7 +5,11 @@ import {
   Mark,
   Serializable,
 } from '@lblod/ember-rdfa-editor/model/mark';
-import { ModelError } from '@lblod/ember-rdfa-editor/utils/errors';
+import {
+  MisbehavedSelectionError,
+  ModelError,
+} from '@lblod/ember-rdfa-editor/utils/errors';
+import ModelSelection from '@lblod/ember-rdfa-editor/model/model-selection';
 
 export default class AddMarkToSelectionCommand extends Command<
   [string, Record<string, Serializable>],
@@ -21,12 +25,26 @@ export default class AddMarkToSelectionCommand extends Command<
     markName: string,
     markAttributes: Record<string, Serializable> = {}
   ): void {
+    const selection = this.model.selection;
     const spec = this.model.marksRegistry.lookupMark(markName);
     if (spec) {
-      this.model.selection.addMark(
-        new Mark<AttributeSpec>(spec, markAttributes)
-      );
-      this.model.rootNode.focus();
+      if (selection.isCollapsed) {
+        selection.addMark(new Mark<AttributeSpec>(spec, markAttributes));
+        this.model.rootNode.focus();
+        this.model.emitSelectionChanged();
+      } else {
+        if (!ModelSelection.isWellBehaved(selection)) {
+          throw new MisbehavedSelectionError();
+        }
+        this.model.change((mutator) => {
+          const resultRange = mutator.addMark(
+            selection.lastRange,
+            spec,
+            markAttributes
+          );
+          this.model.selectRange(resultRange);
+        });
+      }
     } else {
       throw new ModelError(`Unrecognized mark: ${markName}`);
     }

--- a/addon/commands/remove-mark-command.ts
+++ b/addon/commands/remove-mark-command.ts
@@ -12,16 +12,19 @@ export default class RemoveMarkCommand extends Command<[Mark], boolean> {
 
   execute(mark: Mark): boolean {
     const node = mark.node;
-    if (!node.hasMark(mark)) {
-      return false;
+    if (node) {
+      if (!node.hasMark(mark)) {
+        return false;
+      }
+      this.model.change((mutator) => {
+        mutator.removeMark(
+          ModelRange.fromAroundNode(node),
+          mark.spec,
+          mark.attributes
+        );
+      });
+      return true;
     }
-    this.model.change((mutator) => {
-      mutator.removeMark(
-        ModelRange.fromAroundNode(node),
-        mark.spec,
-        mark.attributes
-      );
-    });
-    return true;
+    return false;
   }
 }

--- a/addon/commands/remove-mark-from-selection-command.ts
+++ b/addon/commands/remove-mark-from-selection-command.ts
@@ -1,0 +1,18 @@
+import Command from '@lblod/ember-rdfa-editor/commands/command';
+import Model from '@lblod/ember-rdfa-editor/model/model';
+
+export default class RemoveMarkFromSelectionCommand extends Command<
+  [string],
+  void
+> {
+  name = 'remove-mark-from-selection';
+
+  constructor(model: Model) {
+    super(model);
+  }
+
+  execute(name: string): void {
+    this.model.selection.removeMarkByName(name);
+    this.model.rootNode.focus();
+  }
+}

--- a/addon/components/rdfa/editor-toolbar.ts
+++ b/addon/components/rdfa/editor-toolbar.ts
@@ -125,16 +125,12 @@ export default class EditorToolbar extends Component<Args> {
   setMark(value: boolean, markName: string, attributes = {}) {
     if (value) {
       this.args.controller.executeCommand(
-        'add-mark-to-range',
-        this.selection?.lastRange,
+        'add-mark-to-selection',
         markName,
         attributes
       );
     } else {
-      this.args.controller.executeCommand('remove-marks-from-ranges', {
-        ranges: this.selection?.ranges,
-        markConfigs: [{ name: markName, attributes }],
-      });
+      this.args.controller.executeCommand('remove-mark-from-selection', markName, attributes);
     }
   }
 

--- a/addon/components/rdfa/editor-toolbar.ts
+++ b/addon/components/rdfa/editor-toolbar.ts
@@ -130,7 +130,11 @@ export default class EditorToolbar extends Component<Args> {
         attributes
       );
     } else {
-      this.args.controller.executeCommand('remove-mark-from-selection', markName, attributes);
+      this.args.controller.executeCommand(
+        'remove-mark-from-selection',
+        markName,
+        attributes
+      );
     }
   }
 

--- a/addon/editor/input-handlers/bold-italic-underline-handler.ts
+++ b/addon/editor/input-handlers/bold-italic-underline-handler.ts
@@ -1,6 +1,4 @@
 import { InputHandler } from './input-handler';
-import ModelSelection from '@lblod/ember-rdfa-editor/model/model-selection';
-import { PropertyState } from '@lblod/ember-rdfa-editor/model/util/types';
 import PernetRawEditor from '@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor';
 import { isKeyDownEvent } from '@lblod/ember-rdfa-editor/editor/input-handlers/event-helpers';
 
@@ -19,10 +17,6 @@ export default class BoldItalicUnderlineHandler extends InputHandler {
 
   constructor({ rawEditor }: { rawEditor: PernetRawEditor }) {
     super(rawEditor);
-    document.addEventListener(
-      'richSelectionUpdated',
-      this.updateProperties.bind(this)
-    );
   }
 
   isHandlerFor(event: Event) {
@@ -33,29 +27,31 @@ export default class BoldItalicUnderlineHandler extends InputHandler {
     );
   }
 
-  updateProperties(event: CustomEvent<ModelSelection>) {
-    this.isBold = event.detail.bold === PropertyState.enabled;
-    this.isItalic = event.detail.italic === PropertyState.enabled;
-    this.isUnderline = event.detail.underline === PropertyState.enabled;
-    this.isStrikethrough = event.detail.strikethrough === PropertyState.enabled;
-  }
-
   handleEvent(event: KeyboardEvent) {
-    let property;
+    const selection = this.rawEditor.model.selection;
+    let markName;
     switch (event.key) {
       case 'b':
-        property = this.isBold ? 'remove-bold' : 'make-bold';
+        markName = 'bold';
         break;
       case 'u':
-        property = this.isUnderline ? 'remove-underline' : 'make-underline';
+        markName = 'underline';
         break;
       case 'i':
-        property = this.isItalic ? 'remove-italic' : 'make-italic';
+        markName = 'italic';
         break;
     }
 
-    if (property) {
-      this.rawEditor.executeCommand(property);
+    if (markName) {
+      if (selection.hasMark(markName)) {
+        this.rawEditor.executeCommand(
+          'remove-mark-from-selection',
+          markName,
+          {}
+        );
+      } else {
+        this.rawEditor.executeCommand('add-mark-to-selection', markName, {});
+      }
       return { allowBrowserDefault: false, allowPropagation: false };
     } else {
       return { allowBrowserDefault: true, allowPropagation: true };

--- a/addon/model/mark.ts
+++ b/addon/model/mark.ts
@@ -20,9 +20,9 @@ export interface MarkSpec<A extends AttributeSpec = AttributeSpec> {
 export class Mark<A extends AttributeSpec = AttributeSpec> {
   private readonly _spec: MarkSpec<A>;
   private readonly _attributes: A;
-  private readonly _node: ModelText;
+  private readonly _node?: ModelText;
 
-  constructor(spec: MarkSpec<A>, attributes: A, node: ModelText) {
+  constructor(spec: MarkSpec<A>, attributes: A, node?: ModelText) {
     this._spec = spec;
     this._attributes = attributes;
     this._node = node;
@@ -36,7 +36,7 @@ export class Mark<A extends AttributeSpec = AttributeSpec> {
     return this._spec.name;
   }
 
-  get node(): ModelText {
+  get node(): ModelText | undefined {
     return this._node;
   }
 

--- a/addon/model/marks-registry.ts
+++ b/addon/model/marks-registry.ts
@@ -162,7 +162,7 @@ export default class MarksRegistry {
     const mark = node.marks.lookupHash(markName);
     if (mark) {
       const marks = this.markStore.get(mark.attributes.setBy ?? CORE_OWNER);
-      if (marks) {
+      if (marks && mark.node) {
         marks.delete(mark.node);
       }
     }

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -314,7 +314,7 @@ export default class ModelRange {
         {
           type: 'rangeIsInside',
           textNodeStickyness: {
-            start: 'left',
+            start: 'both',
             end: 'left',
           },
         },

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -312,16 +312,18 @@ export default class ModelRange {
     const nodes = [
       ...this.contextNodes(
         {
-          type: 'rangeIsInside',
+          type: 'rangeTouches',
           textNodeStickyness: {
             start: 'both',
             end: 'left',
           },
+          includeEndTags: false,
         },
         toFilterSkipFalse(ModelNode.isModelText)
       ),
     ] as ModelText[];
     if (nodes.length) {
+      console.log(nodes);
       let result = nodes[0].marks.clone();
       for (const node of nodes.slice(1)) {
         result = result.intersection(node.marks);

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -314,8 +314,8 @@ export default class ModelRange {
         {
           type: 'rangeIsInside',
           textNodeStickyness: {
-            start: 'both',
-            end: 'both',
+            start: 'left',
+            end: 'left',
           },
         },
         toFilterSkipFalse(ModelNode.isModelText)

--- a/addon/model/model-selection.ts
+++ b/addon/model/model-selection.ts
@@ -14,6 +14,7 @@ import { nodeIsElementOfType } from '@lblod/ember-rdfa-editor/model/util/predica
 import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
 import { compatTextAttributeMap } from '@lblod/ember-rdfa-editor/model/util/constants';
 import { TextAttribute } from '@lblod/ember-rdfa-editor/commands/text-properties/set-text-property-command';
+import { Mark, MarkSet } from '@lblod/ember-rdfa-editor/model/mark';
 
 /**
  * Utility interface describing a selection with an non-null anchor and focus
@@ -35,6 +36,7 @@ export default class ModelSelection {
 
   private _ranges: ModelRange[];
   private _isRightToLeft: boolean;
+  private _activeMarks: MarkSet;
 
   /**
    * Utility type guard to check if a selection has and anchor and a focus, as without them
@@ -50,6 +52,7 @@ export default class ModelSelection {
   constructor() {
     this._ranges = [];
     this._isRightToLeft = false;
+    this._activeMarks = new MarkSet();
   }
 
   /**
@@ -113,6 +116,26 @@ export default class ModelSelection {
 
   set isRightToLeft(value: boolean) {
     this._isRightToLeft = value;
+  }
+
+  get activeMarks(): MarkSet {
+    return this._activeMarks;
+  }
+
+  set activeMarks(value: MarkSet) {
+    this._activeMarks = value.clone();
+  }
+
+  addMark(mark: Mark) {
+    this.activeMarks.add(mark);
+  }
+
+  removeMarkByName(markName: string) {
+    for (const mark of this.activeMarks) {
+      if (mark.name === markName) {
+        this.activeMarks.delete(mark);
+      }
+    }
   }
 
   /**
@@ -280,17 +303,7 @@ export default class ModelSelection {
   }
 
   hasMark(markName: string): boolean {
-    if (ModelSelection.isWellBehaved(this)) {
-      const range = this.lastRange;
-      if (range) {
-        for (const mark of range.getMarks()) {
-          if (mark.name === markName) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
+    return this.activeMarks.hasMarkName(markName);
   }
 
   /**

--- a/addon/model/model-selection.ts
+++ b/addon/model/model-selection.ts
@@ -157,6 +157,7 @@ export default class ModelSelection {
   selectRange(range: ModelRange, rightToLeft = false) {
     this.clearRanges();
     this.addRange(range);
+    this.activeMarks = range.getMarks();
     this._isRightToLeft = rightToLeft;
   }
 

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -116,6 +116,15 @@ export default class Model {
 
   readSelection(domSelection: Selection = getWindowSelection()) {
     this._selection = this.selectionReader.read(domSelection);
+    this.emitSelectionChanged();
+    const modelSelectionUpdatedEvent = new CustomEvent<ModelSelection>(
+      'richSelectionUpdated',
+      { detail: this.selection }
+    );
+    document.dispatchEvent(modelSelectionUpdatedEvent);
+  }
+
+  emitSelectionChanged() {
     if (this._eventBus) {
       this._eventBus.emit(
         new SelectionChangedEvent({
@@ -128,11 +137,6 @@ export default class Model {
         'Selection changed without EventBus present, no event will be fired'
       );
     }
-    const modelSelectionUpdatedEvent = new CustomEvent<ModelSelection>(
-      'richSelectionUpdated',
-      { detail: this.selection }
-    );
-    document.dispatchEvent(modelSelectionUpdatedEvent);
   }
 
   /**

--- a/addon/model/mutators/immediate-model-mutator.ts
+++ b/addon/model/mutators/immediate-model-mutator.ts
@@ -6,7 +6,11 @@ import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
 import ModelPosition from '@lblod/ember-rdfa-editor/model/model-position';
 import SplitOperation from '@lblod/ember-rdfa-editor/model/operations/split-operation';
 import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
-import {AttributeSpec, MarkSet, MarkSpec} from '@lblod/ember-rdfa-editor/model/mark';
+import {
+  AttributeSpec,
+  MarkSet,
+  MarkSpec,
+} from '@lblod/ember-rdfa-editor/model/mark';
 import MarkOperation from '@lblod/ember-rdfa-editor/model/operations/mark-operation';
 import EventBus from '@lblod/ember-rdfa-editor/utils/event-bus';
 import RangeMapper, {

--- a/addon/model/mutators/immediate-model-mutator.ts
+++ b/addon/model/mutators/immediate-model-mutator.ts
@@ -6,7 +6,7 @@ import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
 import ModelPosition from '@lblod/ember-rdfa-editor/model/model-position';
 import SplitOperation from '@lblod/ember-rdfa-editor/model/operations/split-operation';
 import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
-import { AttributeSpec, MarkSpec } from '@lblod/ember-rdfa-editor/model/mark';
+import {AttributeSpec, MarkSet, MarkSpec} from '@lblod/ember-rdfa-editor/model/mark';
 import MarkOperation from '@lblod/ember-rdfa-editor/model/operations/mark-operation';
 import EventBus from '@lblod/ember-rdfa-editor/utils/event-bus';
 import RangeMapper, {
@@ -56,8 +56,8 @@ export default class ImmediateModelMutator extends ModelMutator<ModelRange> {
     return defaultRange;
   }
 
-  insertText(range: ModelRange, text: string): ModelRange {
-    const op = new InsertTextOperation(this.eventbus, range, text);
+  insertText(range: ModelRange, text: string, marks: MarkSet): ModelRange {
+    const op = new InsertTextOperation(this.eventbus, range, text, marks);
     return this.executeOperation(op);
   }
 

--- a/addon/model/operations/insert-text-operation.ts
+++ b/addon/model/operations/insert-text-operation.ts
@@ -8,13 +8,21 @@ import { CORE_OWNER } from '@lblod/ember-rdfa-editor/model/util/constants';
 import ModelText from '@lblod/ember-rdfa-editor/model/model-text';
 import OperationAlgorithms from '@lblod/ember-rdfa-editor/model/operations/operation-algorithms';
 import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
+import { MarkSet } from '@lblod/ember-rdfa-editor/model/mark';
 
 export default class InsertTextOperation extends Operation {
   private _text: string;
+  private _marks: MarkSet;
 
-  constructor(eventbus: EventBus | undefined, range: ModelRange, text: string) {
+  constructor(
+    eventbus: EventBus | undefined,
+    range: ModelRange,
+    text: string,
+    marks: MarkSet
+  ) {
     super(eventbus, range);
     this._text = text;
+    this._marks = marks;
   }
 
   get text(): string {
@@ -25,9 +33,17 @@ export default class InsertTextOperation extends Operation {
     this._text = value;
   }
 
+  get marks(): MarkSet {
+    return this._marks;
+  }
+
+  set marks(value: MarkSet) {
+    this._marks = value;
+  }
+
   execute(): OperationResult {
     let newText = new ModelText(this.text);
-    for (const mark of this.range.getMarks()) {
+    for (const mark of this.marks) {
       newText.addMark(mark.clone());
     }
     const { mapper, overwrittenNodes, _markCheckNodes } =

--- a/addon/model/operations/mark-operation.ts
+++ b/addon/model/operations/mark-operation.ts
@@ -104,12 +104,7 @@ export default class MarkOperation extends Operation {
       this.range.start.parent.addChild(node, insertionIndex);
 
       //put the cursor inside that node
-      const cursorPath = node.getOffsetPath();
-      const newRange = ModelRange.fromPaths(
-        this.range.root,
-        cursorPath,
-        cursorPath
-      );
+      const newRange = ModelRange.fromInNode(node, 1, 1);
       this.emit(
         new ContentChangedEvent({
           owner: CORE_OWNER,

--- a/addon/model/readers/selection-reader.ts
+++ b/addon/model/readers/selection-reader.ts
@@ -12,6 +12,7 @@ import {
   NotImplementedError,
 } from '@lblod/ember-rdfa-editor/utils/errors';
 import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
+import { MarkSet } from '@lblod/ember-rdfa-editor/model/mark';
 
 type Bias = 'left' | 'right' | 'center';
 
@@ -31,15 +32,20 @@ export default class SelectionReader
     const ranges = [];
     const result = new ModelSelection();
 
+    let commonMarks: MarkSet | null = null;
     for (let i = 0; i < from.rangeCount; i++) {
       const range = from.getRangeAt(i);
       const modelRange = this.readDomRange(range);
       if (modelRange) {
+        commonMarks = commonMarks
+          ? commonMarks.intersection(modelRange.getMarks())
+          : modelRange.getMarks();
         ranges.push(modelRange);
       }
     }
     result.ranges = ranges;
     result.isRightToLeft = SelectionReader.isReverseSelection(from);
+    result.activeMarks = commonMarks || new MarkSet();
 
     return result;
   }

--- a/addon/model/util/gen-tree-walker.ts
+++ b/addon/model/util/gen-tree-walker.ts
@@ -164,6 +164,7 @@ export default class GenTreeWalker<T extends Walkable = Walkable> {
           root: startNode,
           descend,
           reverse,
+          filter,
           visitParentUpwards,
           onEnterNode,
           onLeaveNode,

--- a/addon/utils/ce/model-selection-tracker.ts
+++ b/addon/utils/ce/model-selection-tracker.ts
@@ -1,8 +1,19 @@
 import Model from '@lblod/ember-rdfa-editor/model/model';
 import { getWindowSelection } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 
+interface DomSelection {
+  anchorNode: Node | null;
+
+  focusNode: Node | null;
+
+  anchorOffset: number;
+
+  focusOffset: number;
+}
+
 export default class ModelSelectionTracker {
   model: Model;
+  previousSelection: DomSelection | null = null;
 
   constructor(model: Model) {
     this.model = model;
@@ -18,6 +29,9 @@ export default class ModelSelectionTracker {
 
   updateSelection = () => {
     const currentSelection = getWindowSelection();
+    if (this.isSameAsPrevious(currentSelection)) {
+      return;
+    }
     if (
       !this.model.rootNode.contains(currentSelection.anchorNode) ||
       !this.model.rootNode.contains(currentSelection.focusNode) ||
@@ -27,6 +41,24 @@ export default class ModelSelectionTracker {
     ) {
       return;
     }
+    this.previousSelection = {
+      anchorOffset: currentSelection.anchorOffset,
+      focusNode: currentSelection.focusNode,
+      anchorNode: currentSelection.anchorNode,
+      focusOffset: currentSelection.focusOffset,
+    };
     this.model.readSelection();
   };
+
+  isSameAsPrevious(selection: Selection) {
+    if (!this.previousSelection) {
+      return false;
+    }
+    return (
+      selection.anchorNode === this.previousSelection.anchorNode &&
+      selection.focusNode === this.previousSelection.focusNode &&
+      selection.anchorOffset === this.previousSelection.anchorOffset &&
+      selection.focusOffset === this.previousSelection.focusOffset
+    );
+  }
 }

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -65,8 +65,8 @@ import RemoveMarksFromRangesCommand from '@lblod/ember-rdfa-editor/commands/remo
 import RemoveMarkCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-command';
 import MatchTextCommand from '@lblod/ember-rdfa-editor/commands/match-text-command';
 import RemoveMarkFromRangeCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-from-range-command';
-import AddMarkToSelectionCommand from "@lblod/ember-rdfa-editor/commands/add-mark-to-selection-command";
-import RemoveMarkFromSelectionCommand from "@lblod/ember-rdfa-editor/commands/remove-mark-from-selection-command";
+import AddMarkToSelectionCommand from '@lblod/ember-rdfa-editor/commands/add-mark-to-selection-command';
+import RemoveMarkFromSelectionCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-from-selection-command';
 
 export interface RawEditorProperties {
   baseIRI: string;

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -65,6 +65,8 @@ import RemoveMarksFromRangesCommand from '@lblod/ember-rdfa-editor/commands/remo
 import RemoveMarkCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-command';
 import MatchTextCommand from '@lblod/ember-rdfa-editor/commands/match-text-command';
 import RemoveMarkFromRangeCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-from-range-command';
+import AddMarkToSelectionCommand from "@lblod/ember-rdfa-editor/commands/add-mark-to-selection-command";
+import RemoveMarkFromSelectionCommand from "@lblod/ember-rdfa-editor/commands/remove-mark-from-selection-command";
 
 export interface RawEditorProperties {
   baseIRI: string;
@@ -193,6 +195,8 @@ export default class RawEditor {
     this.registerCommand(new RemoveMarksFromRangesCommand(this.model));
     this.registerCommand(new RemoveMarkCommand(this.model));
     this.registerCommand(new MatchTextCommand(this.model));
+    this.registerCommand(new AddMarkToSelectionCommand(this.model));
+    this.registerCommand(new RemoveMarkFromSelectionCommand(this.model));
     this.registerMark(highlightMarkSpec);
   }
 

--- a/tests/unit/model/mutators/immediate-model-mutator-test.ts
+++ b/tests/unit/model/mutators/immediate-model-mutator-test.ts
@@ -6,6 +6,7 @@ import ModelTestContext from 'dummy/tests/utilities/model-test-context';
 import { setupTest } from 'ember-qunit';
 import ModelElement from '@lblod/ember-rdfa-editor/model/model-element';
 import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
+import { MarkSet } from '@lblod/ember-rdfa-editor/model/mark';
 
 module('Unit | model | mutators | immediate-model-mutator-test', (hooks) => {
   const ctx = new ModelTestContext();
@@ -631,7 +632,7 @@ module('Unit | model | mutators | immediate-model-mutator-test', (hooks) => {
 
         const mut = new ImmediateModelMutator();
         const range = ModelRange.fromInElement(initial as ModelElement, 0, 0);
-        const resultRange = mut.insertText(range, 'abc');
+        const resultRange = mut.insertText(range, 'abc', new MarkSet());
         assert.true(initial.sameAs(expected), QUnit.dump.parse(initial));
         assert.true(
           resultRange.sameAs(
@@ -656,7 +657,7 @@ module('Unit | model | mutators | immediate-model-mutator-test', (hooks) => {
 
         const mut = new ImmediateModelMutator();
         const range = ModelRange.fromInElement(initial as ModelElement, 0, 0);
-        const resultRange = mut.insertText(range, '');
+        const resultRange = mut.insertText(range, '', new MarkSet());
         assert.true(initial.sameAs(expected));
         assert.true(
           resultRange.sameAs(
@@ -682,7 +683,7 @@ module('Unit | model | mutators | immediate-model-mutator-test', (hooks) => {
 
         const mut = new ImmediateModelMutator();
         const range = ModelRange.fromInElement(initial as ModelElement, 2, 2);
-        const resultRange = mut.insertText(range, 'cd');
+        const resultRange = mut.insertText(range, 'cd', new MarkSet());
 
         assert.true(initial.sameAs(expected));
         assert.true(


### PR DESCRIPTION
What was happening was that the range.getMarks logic was taking the mark information from both sides of a collapsed selection, which in most normal cases wouldnt be the same. It then does an intersection on the marksets for all found nodes, so in the case where you just clicked lets say the bold button, it would create the node, and intersect left (the new node) and right, coming up with an empty set.

This combined with the new text-insertion logic that actually takes the mark status of the selection into account (this was not the case before) it kept inserting non-marked characters when typing.

Solution was actually already implemented in the range.contextNodes method, where it was already possible to determine in which direction to look for adjacent textnodes, it was just set to both instead of left only (this replicates google docs behavior in how it treats the "markedness" of a collapsed selection.