### PR TITLE
Fix textsearch on quads defined outside the root element

### DIFF
--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -191,6 +191,9 @@ export default class ModelRange {
   }
 
   static fromAroundNode(node: ModelNode) {
+    if (!node.parent) {
+      throw new IllegalArgumentError('Cannot create a range around the root');
+    }
     const start = ModelPosition.fromBeforeNode(node);
     const end = ModelPosition.fromAfterNode(node);
     return new ModelRange(start, end);

--- a/addon/model/util/datastore/datastore.ts
+++ b/addon/model/util/datastore/datastore.ts
@@ -483,7 +483,14 @@ export class EditorStore implements Datastore {
       mapping = this.asObjectNodeMapping();
     }
     for (const node of mapping.nodes()) {
-      const searchRange = ModelRange.fromAroundNode(node);
+      let searchRange;
+      // we test if the node is root, which will be the case when the
+      // rdfa knowledge is defined above the document root.
+      if (node.parent) {
+        searchRange = ModelRange.fromAroundNode(node);
+      } else {
+        searchRange = ModelRange.fromInNode(node);
+      }
       results.push(...matchText(searchRange, regex));
     }
     return results;


### PR DESCRIPTION
It was simply creating impossible ranges :man_facepalming: 