### PR TITLE
Addition of a loading indicator when the editor has not yet fully loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ testem.log
 
 # jetbrains
 .idea
+
+# vscode
+.vscode
+
+# nvm
+.nvmrc

--- a/addon/components/rdfa/rdfa-editor.hbs
+++ b/addon/components/rdfa/rdfa-editor.hbs
@@ -32,19 +32,18 @@
 
   <div class='say-container__main'>
     {{#if this.editorLoading}}
-      <AuLoader style="margin: 0 auto;"/>
+      <AuLoader />
     {{/if}}
-    
 
     <div
-      class="say-editor
+      class='say-editor
         {{if @editorOptions.showRdfa "rdfa-annotations"}}
         {{if @editorOptions.showRdfaHighlight "rdfa-annotations-highlight"}}
         {{if @editorOptions.showRdfaHover "rdfa-annotations-hover"}}
         {{if this.showRdfaBlocks "show-rdfa-blocks"}}
-        {{if this.editorLoading 'au-u-hidden-visually'}}"
+        {{if this.editorLoading "au-u-hidden-visually"}}'
     >
-      <div class="say-editor__paper">
+      <div class='say-editor__paper'>
         <Ce::ContentEditable
           @class='say-editor__inner say-content'
           @rawEditorInit={{this.handleRawEditorInit}}
@@ -53,11 +52,10 @@
       </div>
     </div>
 
-
     <div class='say-container__aside'>
       <div class='say-editor-hints'>
         {{#if this.insertSidebarWidgets.length}}
-          <Rdfa::PluginWrapper @title="Invoegen">
+          <Rdfa::PluginWrapper @title='Invoegen'>
             {{#each this.insertSidebarWidgets as |widget|}}
               {{component
                 widget.componentName

--- a/addon/components/rdfa/rdfa-editor.hbs
+++ b/addon/components/rdfa/rdfa-editor.hbs
@@ -31,14 +31,20 @@
   {{/if}}
 
   <div class='say-container__main'>
+    {{#if this.editorLoading}}
+      <AuLoader style="margin: 0 auto;"/>
+    {{/if}}
+    
+
     <div
-      class='say-editor
+      class="say-editor
         {{if @editorOptions.showRdfa "rdfa-annotations"}}
         {{if @editorOptions.showRdfaHighlight "rdfa-annotations-highlight"}}
         {{if @editorOptions.showRdfaHover "rdfa-annotations-hover"}}
-        {{if this.showRdfaBlocks "show-rdfa-blocks"}}'
+        {{if this.showRdfaBlocks "show-rdfa-blocks"}}
+        {{if this.editorLoading 'au-u-hidden-visually'}}"
     >
-      <div class='say-editor__paper'>
+      <div class="say-editor__paper">
         <Ce::ContentEditable
           @class='say-editor__inner say-content'
           @rawEditorInit={{this.handleRawEditorInit}}
@@ -46,6 +52,7 @@
         />
       </div>
     </div>
+
 
     <div class='say-container__aside'>
       <div class='say-editor-hints'>

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -100,7 +100,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
     if (this.args.rdfaEditorInit) {
       this.args.rdfaEditorInit(rdfaDocument);
     }
-    this.editorLoading = false
+    this.editorLoading = false;
   }
 
   async initializePlugins(editor: RawEditor) {

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -56,6 +56,8 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
   @tracked sidebarWidgets: InternalWidgetSpec[] = [];
   @tracked insertSidebarWidgets: InternalWidgetSpec[] = [];
   @tracked toolbarController: Controller | null = null;
+
+  @tracked editorLoading: boolean = true;
   private owner: ApplicationInstance;
   activePlugins: EditorPlugin[] = [];
   private logger: Logger;
@@ -98,6 +100,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
     if (this.args.rdfaEditorInit) {
       this.args.rdfaEditorInit(rdfaDocument);
     }
+    this.editorLoading = false
   }
 
   async initializePlugins(editor: RawEditor) {

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -57,7 +57,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
   @tracked insertSidebarWidgets: InternalWidgetSpec[] = [];
   @tracked toolbarController: Controller | null = null;
 
-  @tracked editorLoading: boolean = true;
+  @tracked editorLoading = true;
   private owner: ApplicationInstance;
   activePlugins: EditorPlugin[] = [];
   private logger: Logger;


### PR DESCRIPTION
It is possible that the ContentEditable component has already rendered while not every component or plugin has loaded. This pull requests adds a loading indicator and hides the ContentEditable component until every plugin has loaded.