### PR TITLE
Fix initialization issues

### DIFF
--- a/addon/components/ce/content-editable.ts
+++ b/addon/components/ce/content-editable.ts
@@ -26,6 +26,7 @@ import {
   createLogger,
   Logger,
 } from '@lblod/ember-rdfa-editor/utils/logging-utils';
+import { EditorPlugin } from '@lblod/ember-rdfa-editor/utils/editor-plugin';
 
 interface FeatureService {
   isEnabled(key: string): boolean;
@@ -36,7 +37,11 @@ interface ContentEditableArgs {
 
   rawEditorInit(editor: RawEditor): void;
 
+  plugins: EditorPlugin[];
+
   baseIRI?: string;
+
+  stealFocus?: boolean;
 }
 
 /**
@@ -100,6 +105,9 @@ export default class ContentEditable extends Component<ContentEditableArgs> {
    */
   get inputHandlers(): InputHandler[] {
     return this.externalHandlers.concat(this.defaultHandlers);
+  }
+  get stealFocus() {
+    return this.args.stealFocus ?? true;
   }
 
   /**
@@ -166,12 +174,13 @@ export default class ContentEditable extends Component<ContentEditableArgs> {
    * @method insertedEditorElement
    */
   @action
-  insertedEditorElement(element: HTMLElement) {
-    this.rawEditor.rootNode = element;
-    this.rawEditor.updateRichNode();
-    this.rawEditor.setCurrentPosition(0);
+  async insertedEditorElement(element: HTMLElement) {
+    await this.rawEditor.initialize(element, this.args.plugins);
     if (this.args.rawEditorInit) {
       this.args.rawEditorInit(this.rawEditor);
+    }
+    if (this.stealFocus) {
+      element.focus();
     }
   }
 

--- a/addon/components/rdfa/rdfa-editor.hbs
+++ b/addon/components/rdfa/rdfa-editor.hbs
@@ -42,7 +42,9 @@
         <Ce::ContentEditable
           @class='say-editor__inner say-content'
           @rawEditorInit={{this.handleRawEditorInit}}
+          @plugins={{this.editorPlugins}}
           @baseIRI={{@baseIRI}}
+          @stealFocus={{@stealFocus}}
         />
       </div>
     </div>

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -6,7 +6,6 @@ import { tracked } from '@glimmer/tracking';
 import RdfaDocument from '../../utils/rdfa/rdfa-document';
 import RdfaDocumentController from '../../utils/rdfa/rdfa-document';
 import type IntlService from 'ember-intl/services/intl';
-import RawEditor from '@lblod/ember-rdfa-editor/utils/ce/raw-editor';
 import PernetRawEditor from '@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor';
 import { EditorPlugin } from '@lblod/ember-rdfa-editor/utils/editor-plugin';
 import ApplicationInstance from '@ember/application/instance';
@@ -19,7 +18,6 @@ import {
   Logger,
 } from '@lblod/ember-rdfa-editor/utils/logging-utils';
 import BasicStyles from '@lblod/ember-rdfa-editor/plugins/basic-styles/basic-styles';
-import { ContentChangedEvent } from '@lblod/ember-rdfa-editor/utils/editor-event';
 
 interface RdfaEditorArgs {
   /**

--- a/addon/model/model-range.ts
+++ b/addon/model/model-range.ts
@@ -326,7 +326,6 @@ export default class ModelRange {
       ),
     ] as ModelText[];
     if (nodes.length) {
-      console.log(nodes);
       let result = nodes[0].marks.clone();
       for (const node of nodes.slice(1)) {
         result = result.intersection(node.marks);

--- a/addon/model/model-selection.ts
+++ b/addon/model/model-selection.ts
@@ -49,8 +49,8 @@ export default class ModelSelection {
     return !!(selection.anchor && selection.focus);
   }
 
-  constructor() {
-    this._ranges = [];
+  constructor(ranges: ModelRange[] = []) {
+    this._ranges = ranges;
     this._isRightToLeft = false;
     this._activeMarks = new MarkSet();
   }

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -68,8 +68,6 @@ import MatchTextCommand from '@lblod/ember-rdfa-editor/commands/match-text-comma
 import RemoveMarkFromRangeCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-from-range-command';
 import AddMarkToSelectionCommand from '@lblod/ember-rdfa-editor/commands/add-mark-to-selection-command';
 import RemoveMarkFromSelectionCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-from-selection-command';
-import { ContentChangedEvent, EventWithName } from '../editor-event';
-import { CORE_OWNER } from '@lblod/ember-rdfa-editor/model/util/constants';
 import { EditorPlugin } from '../editor-plugin';
 import { createLogger, Logger } from '../logging-utils';
 


### PR DESCRIPTION
Moved all initialization logic into the editor so we have better control
when what gets triggered.
Problem was that relevant change events related to model initialization
triggered before the plugins were loaded, as well as a last remnant of
the setCaret method inserting an illegitimate invisible space

likely also fixes https://binnenland.atlassian.net/browse/GN-3412