### PR TITLE
Fix broken copying behavior

### DIFF
--- a/addon/editor/input-handlers/cut-copy-handler.ts
+++ b/addon/editor/input-handlers/cut-copy-handler.ts
@@ -1,12 +1,10 @@
-import { InputHandler } from '@lblod/ember-rdfa-editor/editor/input-handlers/input-handler';
-import PernetRawEditor from '@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor';
 import { HandlerResponse } from '@lblod/ember-rdfa-editor/editor/input-handlers/handler-response';
-import HTMLExportWriter from '@lblod/ember-rdfa-editor/model/writers/html-export-writer';
+import { InputHandler } from '@lblod/ember-rdfa-editor/editor/input-handlers/input-handler';
 import ModelNode from '@lblod/ember-rdfa-editor/model/model-node';
-import ModelTreeWalker, {
-  toFilterSkipFalse,
-} from '@lblod/ember-rdfa-editor/model/util/model-tree-walker';
-import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
+import GenTreeWalker from '@lblod/ember-rdfa-editor/model/util/gen-tree-walker';
+import { toFilterSkipFalse } from '@lblod/ember-rdfa-editor/model/util/model-tree-walker';
+import HTMLExportWriter from '@lblod/ember-rdfa-editor/model/writers/html-export-writer';
+import PernetRawEditor from '@lblod/ember-rdfa-editor/utils/ce/pernet-raw-editor';
 
 export default abstract class CutCopyHandler extends InputHandler {
   abstract deleteSelection: boolean;
@@ -40,10 +38,12 @@ export default abstract class CutCopyHandler extends InputHandler {
     for (const modelNode of modelNodes) {
       if (ModelNode.isModelElement(modelNode)) {
         modelNode.parent = null;
-        const range = ModelRange.fromAroundNode(modelNode);
-        const treeWalker = new ModelTreeWalker({ filter, range });
+        const treeWalker = GenTreeWalker.fromSubTree({
+          root: modelNode,
+          filter,
+        });
 
-        for (const node of treeWalker) {
+        for (const node of treeWalker.nodes()) {
           textString += ModelNode.isModelText(node) ? node.content : '\n';
         }
       } else if (ModelNode.isModelText(modelNode)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7447,6 +7447,15 @@
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
       "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -27186,6 +27195,12 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-4.2.1.tgz",
@@ -31064,6 +31079,12 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nan": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.3.1",
@@ -36386,7 +36407,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",


### PR DESCRIPTION
Repro of original bug:
try to copy literally anything that (fully) contains an element, it'll throw en error

We were trying to create a range around an element on which we just
removed the parent. This gets detected as being the root node, so the
rangeAround method errors out since we cannot create a range around the
root.

Solved by using the gentreewalker, eliminating the need to create
the range in the first place. Swapping the lines would have also worked but I was uncomfortable with letting the treewalker decide start and end nodes on a range that was effectively invalid