### PR TITLE
fixed issue where insert a list a the end of line caused the insertion of a newline

### DIFF
--- a/addon/commands/make-list-command.ts
+++ b/addon/commands/make-list-command.ts
@@ -15,6 +15,7 @@ import ModelPosition from '@lblod/ember-rdfa-editor/model/model-position';
 import { PropertyState } from '../model/util/types';
 import { logExecute } from '@lblod/ember-rdfa-editor/utils/logging-utils';
 import ModelText from '../model/model-text';
+import RangeMapper from '../model/range-mapper';
 
 /**
  * Command will convert all nodes in the selection to a list, if they are not already in a list.
@@ -45,7 +46,7 @@ export default class MakeListCommand extends Command {
       throw new MisbehavedSelectionError();
     }
 
-    const range = selection.lastRange;
+    const range = selection.lastRange.clone();
     const wasCollapsed = range.collapsed;
     const blocks = this.getBlocksFromRange(range);
 
@@ -95,8 +96,12 @@ export default class MakeListCommand extends Command {
   }
 
   private getBlocksFromRange(range: ModelRange): ModelNode[][] {
+    // Do a check if we are at the end of a text node
     // Expand range until it is bound by blocks.
     let current: ModelNode | null = range.start.nodeAfter();
+    if (!current && !range.start.nodeBefore()?.isBlock) {
+      current = range.start.nodeBefore();
+    }
     if (current) {
       range.start.parentOffset = current.getOffset();
 

--- a/addon/commands/make-list-command.ts
+++ b/addon/commands/make-list-command.ts
@@ -15,7 +15,6 @@ import ModelPosition from '@lblod/ember-rdfa-editor/model/model-position';
 import { PropertyState } from '../model/util/types';
 import { logExecute } from '@lblod/ember-rdfa-editor/utils/logging-utils';
 import ModelText from '../model/model-text';
-import RangeMapper from '../model/range-mapper';
 
 /**
  * Command will convert all nodes in the selection to a list, if they are not already in a list.

--- a/tests/unit/commands/make-list-command-test.ts
+++ b/tests/unit/commands/make-list-command-test.ts
@@ -40,14 +40,14 @@ module('Unit | commands | make-list-command', function (hooks) {
     // language=XML
     const { root: initial } = vdom`
       <modelRoot>
-        <text>${'\n'}</text>
+        <br/>
       </modelRoot>
     `;
 
     // language=XML
     const { root: expected } = vdom`
       <modelRoot>
-        <text>${'\n'}</text>
+        <br/>
         <ul>
           <li><text></text></li>
         </ul>
@@ -55,7 +55,7 @@ module('Unit | commands | make-list-command', function (hooks) {
     `;
 
     ctx.model.fillRoot(initial);
-    const range = ModelRange.fromInElement(ctx.model.rootModelNode, 1, 1);
+    const range = ModelRange.fromInElement(ctx.model.rootModelNode, 1);
     ctx.model.selectRange(range);
 
     command.execute('ul');


### PR DESCRIPTION
When converting a text node to a list item with the cursor positioned at the end of the text, an empty list item was inserted on a new line.