### PR TITLE
Fix cursor behavior in empty lists

### DIFF
--- a/addon/commands/make-list-command.ts
+++ b/addon/commands/make-list-command.ts
@@ -15,6 +15,7 @@ import ModelPosition from '@lblod/ember-rdfa-editor/model/model-position';
 import { PropertyState } from '../model/util/types';
 import { logExecute } from '@lblod/ember-rdfa-editor/utils/logging-utils';
 import ModelText from '../model/model-text';
+import { INVISIBLE_SPACE } from '../model/util/constants';
 
 /**
  * Command will convert all nodes in the selection to a list, if they are not already in a list.
@@ -79,6 +80,7 @@ export default class MakeListCommand extends Command {
           0,
           firstChild.getMaxOffset()
         );
+        resultRange.collapse();
       } else {
         const firstChild = list.firstChild as ModelElement;
         const lastChild = list.lastChild as ModelElement;
@@ -171,7 +173,7 @@ export default class MakeListCommand extends Command {
       }
     }
     if (result[0].length === 0) {
-      result[0].push(new ModelText());
+      result[0].push(new ModelText(INVISIBLE_SPACE));
     }
 
     return result;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4167,7 +4167,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
         }
       }
     },
@@ -4224,7 +4224,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
         }
       }
     },
@@ -4440,7 +4440,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
         },
         "source-map-support": {
           "version": "0.4.18",
@@ -5909,7 +5909,7 @@
         "object-assign": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "integrity": "sha512-CdsOUYIh5wIiozhJ3rLQgmUTgcyzFwZZrqhkKhODMoGtPKM+wt0h0CNIoauJWMsS9822EdzPsF/6mb4nLvPN5g==",
           "dev": true
         }
       }
@@ -21957,7 +21957,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
         }
       }
     },

--- a/tests/unit/commands/make-list-command-test.ts
+++ b/tests/unit/commands/make-list-command-test.ts
@@ -3,6 +3,7 @@ import ModelTestContext from 'dummy/tests/utilities/model-test-context';
 import MakeListCommand from '@lblod/ember-rdfa-editor/commands/make-list-command';
 import ModelRange from '@lblod/ember-rdfa-editor/model/model-range';
 import { vdom } from '@lblod/ember-rdfa-editor/model/util/xml-utils';
+import { INVISIBLE_SPACE } from '@lblod/ember-rdfa-editor/model/util/constants';
 
 module('Unit | commands | make-list-command', function (hooks) {
   const ctx = new ModelTestContext();
@@ -23,7 +24,7 @@ module('Unit | commands | make-list-command', function (hooks) {
     const { root: expected } = vdom`
       <modelRoot>
         <ul>
-          <li><text></text></li>
+          <li><text>${INVISIBLE_SPACE}</text></li>
         </ul>
       </modelRoot>
     `;
@@ -49,7 +50,7 @@ module('Unit | commands | make-list-command', function (hooks) {
       <modelRoot>
         <br/>
         <ul>
-          <li><text></text></li>
+          <li><text>${INVISIBLE_SPACE}</text></li>
         </ul>
       </modelRoot>
     `;


### PR DESCRIPTION
Repro: 

case 1: 
- make list in empty doc
- try to remove-list
result: 
error thrown in console

case 2:
- make list in empty doc
- hit enter to make another list-item
- click back into the first (still empty) list-item
- type some characters

result: 
chars appear in weird location, above first listitem. If we inspect html we see that the newly added text is a child of the `<ul>` directly (which is not allowed by the spec)