### PR TITLE
Remove erroneous check to avoid duplicate selectionchange events

### DIFF
--- a/addon/model/writers/selection-writer.ts
+++ b/addon/model/writers/selection-writer.ts
@@ -26,11 +26,20 @@ export default class SelectionWriter implements Writer<ModelSelection, void> {
 
   write(modelSelection: ModelSelection, moveSelectionIntoView = false): void {
     const domSelection = getWindowSelection();
-
-    domSelection.removeAllRanges();
-    for (const range of modelSelection.ranges) {
-      domSelection.addRange(this.writeDomRange(range));
+    const relevantRange = modelSelection.lastRange;
+    if (!relevantRange) {
+      return;
     }
+
+    const { startContainer, startOffset, endContainer, endOffset } =
+      this.writeDomRange(relevantRange);
+
+    domSelection.setBaseAndExtent(
+      startContainer,
+      startOffset,
+      endContainer,
+      endOffset
+    );
     if (domSelection.anchorNode && moveSelectionIntoView) {
       if (isElement(domSelection.anchorNode)) {
         domSelection.anchorNode.scrollIntoView();

--- a/addon/utils/ce/model-selection-tracker.ts
+++ b/addon/utils/ce/model-selection-tracker.ts
@@ -2,19 +2,8 @@ import Model from '@lblod/ember-rdfa-editor/model/model';
 import { getWindowSelection } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 import { createLogger, Logger } from '../logging-utils';
 
-interface DomSelection {
-  anchorNode?: Node;
-
-  focusNode?: Node;
-
-  anchorOffset: number;
-
-  focusOffset: number;
-}
-
 export default class ModelSelectionTracker {
   model: Model;
-  previousSelection: DomSelection | null = null;
   logger: Logger;
 
   constructor(model: Model) {
@@ -32,9 +21,6 @@ export default class ModelSelectionTracker {
 
   updateSelection = () => {
     const currentSelection = getWindowSelection();
-    if (this.isSameAsPrevious(currentSelection)) {
-      return;
-    }
     if (
       !this.model.rootNode.contains(currentSelection.anchorNode) ||
       !this.model.rootNode.contains(currentSelection.focusNode) ||
@@ -44,25 +30,7 @@ export default class ModelSelectionTracker {
     ) {
       return;
     }
-    this.previousSelection = {
-      anchorOffset: currentSelection.anchorOffset,
-      focusNode: currentSelection.focusNode?.cloneNode(),
-      anchorNode: currentSelection.anchorNode?.cloneNode(),
-      focusOffset: currentSelection.focusOffset,
-    };
     this.logger('Dom selection updated, recalculating selection');
     this.model.readSelection();
   };
-
-  isSameAsPrevious(selection: Selection) {
-    if (!this.previousSelection) {
-      return false;
-    }
-    return (
-      selection.anchorNode === this.previousSelection.anchorNode &&
-      selection.focusNode === this.previousSelection.focusNode &&
-      selection.anchorOffset === this.previousSelection.anchorOffset &&
-      selection.focusOffset === this.previousSelection.focusOffset
-    );
-  }
 }

--- a/addon/utils/ce/model-selection-tracker.ts
+++ b/addon/utils/ce/model-selection-tracker.ts
@@ -1,5 +1,6 @@
 import Model from '@lblod/ember-rdfa-editor/model/model';
 import { getWindowSelection } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+import { createLogger, Logger } from '../logging-utils';
 
 interface DomSelection {
   anchorNode?: Node;
@@ -14,9 +15,11 @@ interface DomSelection {
 export default class ModelSelectionTracker {
   model: Model;
   previousSelection: DomSelection | null = null;
+  logger: Logger;
 
   constructor(model: Model) {
     this.model = model;
+    this.logger = createLogger(this.constructor.name);
   }
 
   startTracking() {
@@ -47,6 +50,7 @@ export default class ModelSelectionTracker {
       anchorNode: currentSelection.anchorNode?.cloneNode(),
       focusOffset: currentSelection.focusOffset,
     };
+    this.logger('Dom selection updated, recalculating selection');
     this.model.readSelection();
   };
 


### PR DESCRIPTION
The check was never correct, with potential false positives.
Dom selection is only based on anchornode and focusnode, and their offsets.
This means the nodes themselves can move without this being visible to us.

The reason for this check was the fact that we triggered two selectionchanges every domwrite.

I used to think this was because changing the dom content would also trigger a selectionchange,
but that's actually not true. I was simply updating the selection in two steps instead of one.

Now, this does mean we still always do 1 potentially useless selection read every selection write.
After all, we just set the selection ourselves, so why should we read it again?
It's an optimization we could make, but it's not a bad safety net should the browser disagree
with our selection update, and it's not expensive to calculate.

Note that the old check also did not prevent this.