### PR TITLE
Allow plugins to send arguments to their components

### DIFF
--- a/addon/components/rdfa/rdfa-editor.hbs
+++ b/addon/components/rdfa/rdfa-editor.hbs
@@ -25,6 +25,7 @@
           widget.componentName
           controller=widget.controller
           plugin=widget.plugin
+          widgetArgs=widget.widgetArgs
         }}
       {{/each}}
     </Rdfa::EditorToolbar>
@@ -64,6 +65,7 @@
                 widget.componentName
                 controller=widget.controller
                 plugin=widget.plugin
+                widgetArgs=widget.widgetArgs
               }}
             {{/each}}
           </Rdfa::PluginWrapper>
@@ -75,6 +77,7 @@
                 widget.componentName
                 controller=widget.controller
                 plugin=widget.plugin
+                widgetArgs=widget.widgetArgs
               }}
             </li>
           {{/each}}

--- a/addon/model/controller.ts
+++ b/addon/model/controller.ts
@@ -32,7 +32,11 @@ export type WidgetLocation = 'toolbar' | 'sidebar' | 'insertSidebar';
 export interface WidgetSpec {
   componentName: string;
   desiredLocation: WidgetLocation;
-  plugin: EditorPlugin;
+  /**
+   * @deprecated use widgetArgs instead
+   * */
+  plugin?: EditorPlugin;
+  widgetArgs?: unknown;
 }
 
 export type InternalWidgetSpec = WidgetSpec & {


### PR DESCRIPTION
Introduce an extra option in the widgetSpec interface.
When registering a component, plugins can pass whatever information they like to
the components like so:

``` typescript
controller.registerWidget({
  componentName: "my-component",
  desiredLocation: "toolbar",
  widgetArgs: {
    hello: "world",
    // if you want the whole plugin instance to be available
    plugin: this,
  }
})
```

the component will recieve the widgetArgs object as one of its arguments.