### PR TITLE
Enabling reload of plugins

### DIFF
--- a/addon/components/ce/content-editable.hbs
+++ b/addon/components/ce/content-editable.hbs
@@ -13,6 +13,7 @@
   {{on 'input' this.handleInput}}
   {{on 'dragstart' this.dragstart}}
   {{did-insert this.insertedEditorElement}}
+  {{did-update this.initialize @plugins}}
   contenteditable='true'
   class={{@class}}
   ...attributes

--- a/addon/components/ce/content-editable.ts
+++ b/addon/components/ce/content-editable.ts
@@ -160,12 +160,20 @@ export default class ContentEditable extends Component<ContentEditableArgs> {
    */
   @action
   async insertedEditorElement(element: HTMLElement) {
-    await this.rawEditor.initialize(element, this.args.plugins);
-    if (this.args.rawEditorInit) {
-      this.args.rawEditorInit(this.rawEditor);
-    }
-    if (this.stealFocus) {
-      element.focus();
+    this.rootNode = element;
+    await this.initialize();
+  }
+
+  @action
+  async initialize() {
+    if (this.rootNode) {
+      await this.rawEditor.initialize(this.rootNode, this.args.plugins);
+      if (this.args.rawEditorInit) {
+        this.args.rawEditorInit(this.rawEditor);
+      }
+      if (this.stealFocus) {
+        this.rootNode.focus();
+      }
     }
   }
 

--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -159,6 +159,9 @@ export default class RawEditor {
 
   async initialize(rootNode: HTMLElement, plugins: ResolvedPluginConfig[]) {
     this.registeredCommands = new Map<string, Command>();
+    this.widgetMap.set('toolbar', []);
+    this.widgetMap.set('sidebar', []);
+    this.widgetMap.set('insertSidebar', []);
     if (this.modelSelectionTracker) {
       this.modelSelectionTracker.stopTracking();
     }


### PR DESCRIPTION
When the provided plugins array has changed, the editor now reloads the plugins. This is done by recalling the initalize function on the editor.