### PR TITLE
Replace ix by itertools

### DIFF
--- a/addon/model/util/array-utils.ts
+++ b/addon/model/util/array-utils.ts
@@ -1,4 +1,4 @@
-import { from, last } from 'ix/iterable';
+import { filter, takeLastOr } from 'iter-tools';
 
 export default class ArrayUtils {
   static findCommonSlice<T>(array1: T[], array2: T[]): T[] {
@@ -13,7 +13,7 @@ export default class ArrayUtils {
    * Like Array.find, but starts searching from the end
    */
   static findLast<T>(array: T[], predicate: (item: T) => boolean): T | null {
-    return last(from(array), { predicate }) || null;
+    return takeLastOr(null, filter(predicate, array));
   }
 
   static pushOrCreate<T>(array: T[][], position: number, item: T) {

--- a/addon/model/util/datastore/result-set.ts
+++ b/addon/model/util/datastore/result-set.ts
@@ -1,11 +1,12 @@
-import { isEmpty, from, IterableX, single } from 'ix/iterable';
-import { map } from 'ix/iterable/operators';
+import { isEmpty, map } from 'iter-tools';
+import { Iterable } from 'iter-tools';
+import { single } from '../iterator-utils';
 
 export class ResultSet<I> implements Iterable<I> {
-  private engine: IterableX<I>;
+  private engine: Iterable<I>;
 
   constructor(iterable: Iterable<I>) {
-    this.engine = from(iterable);
+    this.engine = iterable;
   }
 
   single(): I | undefined {
@@ -13,7 +14,7 @@ export class ResultSet<I> implements Iterable<I> {
   }
 
   map<T>(mappingFunc: (item: I) => T): ResultSet<T> {
-    return new ResultSet<T>(this.engine.pipe(map(mappingFunc)));
+    return new ResultSet<T>(map(mappingFunc, this.engine));
   }
 
   isEmpty(): boolean {

--- a/addon/model/util/datastore/term-mapping.ts
+++ b/addon/model/util/datastore/term-mapping.ts
@@ -5,8 +5,6 @@ import {
   PrefixMapping,
 } from '@lblod/ember-rdfa-editor/model/util/concise-term-string';
 import { first, isEmpty, flatMap, map, filter, execPipe } from 'iter-tools';
-// import { first, from, isEmpty, single } from 'ix/iterable';
-// import { filter, flatMap, map } from 'ix/iterable/operators';
 import { TermSpec } from '@lblod/ember-rdfa-editor/model/util/datastore/term-spec';
 import { single } from '../iterator-utils';
 

--- a/addon/model/util/datastore/term-mapping.ts
+++ b/addon/model/util/datastore/term-mapping.ts
@@ -4,9 +4,11 @@ import {
   conciseToRdfjs,
   PrefixMapping,
 } from '@lblod/ember-rdfa-editor/model/util/concise-term-string';
-import { first, from, isEmpty, single } from 'ix/iterable';
-import { filter, flatMap, map } from 'ix/iterable/operators';
+import { first, isEmpty, flatMap, map, filter, execPipe } from 'iter-tools';
+// import { first, from, isEmpty, single } from 'ix/iterable';
+// import { filter, flatMap, map } from 'ix/iterable/operators';
 import { TermSpec } from '@lblod/ember-rdfa-editor/model/util/datastore/term-spec';
+import { single } from '../iterator-utils';
 
 /**
  * Utility class to represent a collection of terms with their
@@ -42,25 +44,25 @@ export class TermMapping<T extends RDF.Term>
   single(): { term: T; nodes: ModelNode[] } | null {
     return (
       single(
-        from(this.termMap.entries()).pipe(
-          map((entry) => ({
+        map(
+          (entry) => ({
             term: entry[0],
             nodes: entry[1],
-          }))
+          }),
+          this.termMap.entries()
         )
       ) || null
     );
   }
 
   [Symbol.iterator]() {
-    return from(this.termMap.entries())
-      .pipe(
-        map((entry) => ({
-          term: entry[0],
-          nodes: entry[1],
-        }))
-      )
-      [Symbol.iterator]();
+    return map(
+      (entry) => ({
+        term: entry[0],
+        nodes: entry[1],
+      }),
+      this.termMap.entries()
+    )[Symbol.iterator]();
   }
 
   /**
@@ -73,7 +75,8 @@ export class TermMapping<T extends RDF.Term>
     ) as T;
     return (
       first(
-        from(this.termMap.entries()).pipe(
+        execPipe(
+          this.termMap.entries(),
           filter((entry) => entry[0].equals(convertedTerm)),
           map((entry) => entry[1])
         )
@@ -88,17 +91,18 @@ export class TermMapping<T extends RDF.Term>
   map<R>(
     mappingFunc: (entry: { term: T; nodes: ModelNode[] }) => R
   ): Iterable<R> {
-    return from(this.termMap.entries()).pipe(
+    return execPipe(
+      this.termMap.entries(),
       map((entry) => ({ term: entry[0], nodes: entry[1] })),
       map(mappingFunc)
     );
   }
 
   nodes(): Iterable<ModelNode> {
-    return from(this.termMap.entries()).pipe(flatMap((entry) => entry[1]));
+    return flatMap((entry) => entry[1], this.termMap.entries());
   }
 
   isEmpty(): boolean {
-    return isEmpty(from(this.termMap.entries()));
+    return isEmpty(this.termMap.entries());
   }
 }

--- a/addon/model/util/iterator-utils.ts
+++ b/addon/model/util/iterator-utils.ts
@@ -1,0 +1,16 @@
+export function single<T>(
+  iterable: Iterable<T>,
+  predicate: (item: T) => boolean = () => true
+): T | undefined {
+  let matchCount = 0;
+  let result = undefined;
+  for (const item of iterable) {
+    if (predicate(item)) {
+      if (matchCount === 1)
+        throw new Error('Iterable contains more than one item');
+      matchCount++;
+      result = item;
+    }
+  }
+  return result;
+}

--- a/addon/utils/plugins/lists/tab-input-plugin.ts
+++ b/addon/utils/plugins/lists/tab-input-plugin.ts
@@ -10,8 +10,7 @@ import { INVISIBLE_SPACE } from '@lblod/ember-rdfa-editor/model/util/constants';
 import ModelNodeUtils from '@lblod/ember-rdfa-editor/model/util/model-node-utils';
 import { Direction } from '@lblod/ember-rdfa-editor/model/util/types';
 import RawEditor from '@lblod/ember-rdfa-editor/utils/ce/raw-editor';
-import { from, isEmpty, last, first } from 'ix/iterable';
-import { filter } from 'ix/iterable/operators';
+import { isEmpty, takeLast, first, filter } from 'iter-tools';
 import { ImpossibleModelStateError } from '../../errors';
 
 /**
@@ -61,12 +60,9 @@ export default class ListTabInputPlugin implements TabInputPlugin {
       if (!list) {
         throw new ImpossibleModelStateError('Li element cannot be root');
       }
-      const lis = from(list.children).pipe(
-        filter(ModelNodeUtils.isListElement)
-      );
-
+      const lis = filter(ModelNodeUtils.isListElement, list.children);
       const firstLi = first(lis);
-      const lastLi = last(lis);
+      const lastLi = takeLast(lis);
 
       if (
         selection.lastRange?.start.sameAs(
@@ -147,7 +143,7 @@ export default class ListTabInputPlugin implements TabInputPlugin {
     direction: Direction,
     editor: RawEditor
   ): void => {
-    const lis = from(list.children).pipe(filter(ModelNodeUtils.isListElement));
+    const lis = filter(ModelNodeUtils.isListElement, list.children);
 
     // This branch creates a new LI, but not really sure if we want that.
     if (isEmpty(lis)) {
@@ -158,7 +154,7 @@ export default class ListTabInputPlugin implements TabInputPlugin {
         const li = first(lis)!;
         pos = ModelPosition.fromInNode(li, 0);
       } else {
-        const li = last(lis)!;
+        const li = takeLast(lis)!;
         pos = ModelPosition.fromInNode(li, li.getMaxOffset());
       }
       setCursorAtPos(pos, editor);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4167,7 +4167,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -4224,7 +4224,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -4440,7 +4440,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-support": {
           "version": "0.4.18",
@@ -17023,6 +17023,14 @@
         "textextensions": "1 || 2"
       }
     },
+    "iter-tools": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/iter-tools/-/iter-tools-7.4.0.tgz",
+      "integrity": "sha512-twcHD87GOpbnfFmOtEQMcZuJzBCViNaYx4//70KkkjFcQTkKcUfcuni5G5dfO4Uyb80KIsWnVGZ4vvkpmYCNQQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1"
+      }
+    },
     "iterate-iterator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
@@ -17037,22 +17045,6 @@
       "requires": {
         "es-get-iterator": "^1.0.2",
         "iterate-iterator": "^1.0.1"
-      }
-    },
-    "ix": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/ix/-/ix-4.5.2.tgz",
-      "integrity": "sha512-Cm0uEpZd2qU+7DVeyyBQeceafggvPD3xe6LDKUU4YnmOzAFIz0CbxwufRfxywU/5easfCX1XEYcOAkDJUuUtiw==",
-      "requires": {
-        "@types/node": "^13.7.4",
-        "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-        }
       }
     },
     "jest-worker": {
@@ -21957,7 +21949,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-truth-helpers": "^3.0.0",
     "handlebars": "^4.7.7",
     "handlebars-loader": "^1.7.2",
-    "ix": "^4.5.2",
+    "iter-tools": "^7.4.0",
     "mdn-polyfills": "^5.16.0",
     "rdf-data-factory": "^1.1.0",
     "relative-to-absolute-iri": "^1.0.6",


### PR DESCRIPTION
This PR replaces the ix package by the iter-tools package. Iter-tools is more recently maintained and works with the default Iterable class directly.