### PR TITLE
Fix/lump node plugin selection

### DIFF
--- a/addon/commands/node-properties/remove-property-command.ts
+++ b/addon/commands/node-properties/remove-property-command.ts
@@ -12,8 +12,8 @@ export default class RemovePropertyCommand extends Command {
 
   @logExecute
   execute(element: ModelElement, property: string) {
-    this.model.change((mutator) => {
-      mutator.removeProperty(element, property);
+    this.model.change(() => {
+      element.removeAttribute(property);
     });
   }
 }

--- a/addon/commands/node-properties/set-property-command.ts
+++ b/addon/commands/node-properties/set-property-command.ts
@@ -12,8 +12,8 @@ export default class SetPropertyCommand extends Command {
 
   @logExecute
   execute(property: string, value: string, element: ModelElement) {
-    this.model.change((mutator) => {
-      mutator.setProperty(element, property, value);
+    this.model.change(() => {
+      element.setAttribute(property, value);
     });
   }
 }

--- a/addon/plugins/lump-node/lump-node.ts
+++ b/addon/plugins/lump-node/lump-node.ts
@@ -32,7 +32,9 @@ export default class LumpNodePlugin implements EditorPlugin {
         this.lumpNodePreviouslyBeforeCursor &&
         !this.lastPosition?.equals(newPosition) &&
         this.lumpNodePreviouslyBeforeCursor.connected &&
-        this.lumpNodePreviouslyBeforeCursor.attributeMap.has('remove-property')
+        this.lumpNodePreviouslyBeforeCursor.attributeMap.has(
+          'data-flagged-remove'
+        )
       ) {
         this.controller?.executeCommand(
           'remove-property',

--- a/addon/plugins/lump-node/lump-node.ts
+++ b/addon/plugins/lump-node/lump-node.ts
@@ -27,12 +27,12 @@ export default class LumpNodePlugin implements EditorPlugin {
     console.log(selection);
     if (selection?.isCollapsed) {
       const lumpNode = lumpNodeBeforeCursor(selection);
-      console.log('LUMP', lumpNode);
       const newPosition = selection.lastRange?.start;
       if (
         this.lumpNodePreviouslyBeforeCursor &&
         !this.lastPosition?.equals(newPosition) &&
-        this.lumpNodePreviouslyBeforeCursor.connected
+        this.lumpNodePreviouslyBeforeCursor.connected &&
+        this.lumpNodePreviouslyBeforeCursor.attributeMap.has('remove-property')
       ) {
         this.controller?.executeCommand(
           'remove-property',

--- a/addon/utils/plugins/lump-node/backspace-delete-plugin.ts
+++ b/addon/utils/plugins/lump-node/backspace-delete-plugin.ts
@@ -31,9 +31,12 @@ export class LumpNodeBackspaceDeleteInputPlugin
         return {
           allow: true,
           executor: () => {
-            editor.model.change(() => {
-              lumpNode.setAttribute('data-flagged-remove', 'complete');
-            });
+            editor.executeCommand(
+              'set-property',
+              'data-flagged-remove',
+              'complete',
+              lumpNode
+            );
           },
         };
       }


### PR DESCRIPTION
This modifies the set-property and remove-property commands to modify the modelnode and not replace it with a new one.
In the lump node plugin, we only remove the 'data-flagged-remove'-property if the modelnode has it.