### PR TITLE
Remove the appuniversum SASS includePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,9 @@ module.exports = {
       app.options.sassOptions.includePaths || [];
 
     app.options.sassOptions.includePaths.push(
-      'node_modules/@appuniversum/appuniversum',
+      // This is needed for the editor plugins dummy app styles to work.
+      // They import the ember-rdfa-editor/a-dummy file, which imports the appuniversum styles
+      // with an absolute path which only works if this includePath is added.
       'node_modules/@appuniversum/ember-appuniversum/app/styles'
     );
   },


### PR DESCRIPTION
ember-appuniversum 1.3+ no longer uses the `@appuniversum/appuniversum` package so this config fails the build if the project updated to that version (and the host app doesn't install the package itself).

The config isn't needed on older ember-appuniversum versions either since those also add the includePath already.