### PR TITLE
Introduction of a MarksManager

### DIFF
--- a/addon/commands/remove-mark-from-node-command.ts
+++ b/addon/commands/remove-mark-from-node-command.ts
@@ -3,26 +3,27 @@ import Command, {
   CommandContext,
 } from '@lblod/ember-rdfa-editor/commands/command';
 import ModelRange from '@lblod/ember-rdfa-editor/core/model/model-range';
+import ModelText from '../core/model/nodes/model-text';
 declare module '@lblod/ember-rdfa-editor' {
   export interface Commands {
-    removeMark: RemoveMarkCommand;
+    removeMarkFromNode: RemoveMarkFromNodeCommand;
   }
 }
-export interface RemoveMarkCommandArgs {
+export interface RemoveMarkFromNodeCommandArgs {
   mark: Mark;
+  node: ModelText;
 }
 
-export default class RemoveMarkCommand
-  implements Command<RemoveMarkCommandArgs, boolean>
+export default class RemoveMarkFromNodeCommand
+  implements Command<RemoveMarkFromNodeCommandArgs, boolean>
 {
   canExecute(): boolean {
     return true;
   }
   execute(
     { transaction }: CommandContext,
-    { mark }: RemoveMarkCommandArgs
+    { mark, node }: RemoveMarkFromNodeCommandArgs
   ): boolean {
-    const node = mark.node;
     if (node) {
       if (!node.hasMark(mark)) {
         return false;

--- a/addon/components/rdfa/editor-toolbar.hbs
+++ b/addon/components/rdfa/editor-toolbar.hbs
@@ -255,8 +255,11 @@
         </button>
       {{/if}}
     </div>
+    <div class='say-toolbar__group'>
+      {{yield to='middle'}}
+    </div>
   </div>
   <div class='say-toolbar__actions'>
-    {{yield}}
+    {{yield to='right'}}
   </div>
 </div>

--- a/addon/components/rdfa/rdfa-editor.hbs
+++ b/addon/components/rdfa/rdfa-editor.hbs
@@ -13,20 +13,33 @@
       @showIndentButtons='{{if @toolbarOptions.showIndentButtons "true"}}'
       @controller={{this.toolbarController}}
     >
-      {{#if @editorOptions.showToggleRdfaAnnotations}}
-        <AuToggleSwitch
-          {{on 'click' this.toggleRdfaBlocks}}
-          @label='Toon annotaties'
-        />
-      {{/if}}
-      {{#each this.toolbarWidgets as |widget|}}
-        {{component
-          widget.componentName
-          controller=widget.controller
-          plugin=widget.plugin
-          widgetArgs=widget.widgetArgs
-        }}
-      {{/each}}
+      <:middle>
+        {{#each this.toolbarMiddleWidgets as |widget|}}
+          {{component
+            widget.componentName
+            controller=widget.controller
+            plugin=widget.plugin
+            widgetArgs=widget.widgetArgs
+          }}
+        {{/each}}
+      </:middle>
+      <:right>
+        {{#if @editorOptions.showToggleRdfaAnnotations}}
+          <AuToggleSwitch
+            {{on 'click' this.toggleRdfaBlocks}}
+            @label='Toon annotaties'
+          />
+        {{/if}}
+        {{#each this.toolbarRightWidgets as |widget|}}
+          {{component
+            widget.componentName
+            controller=widget.controller
+            plugin=widget.plugin
+            widgetArgs=widget.widgetArgs
+          }}
+        {{/each}}
+      </:right>
+
     </Rdfa::EditorToolbar>
   {{/if}}
 

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -72,7 +72,8 @@ interface RdfaEditorArgs {
 export default class RdfaEditor extends Component<RdfaEditorArgs> {
   @service declare intl: IntlService;
 
-  @tracked toolbarWidgets: InternalWidgetSpec[] = [];
+  @tracked toolbarMiddleWidgets: InternalWidgetSpec[] = [];
+  @tracked toolbarRightWidgets: InternalWidgetSpec[] = [];
   @tracked sidebarWidgets: InternalWidgetSpec[] = [];
   @tracked insertSidebarWidgets: InternalWidgetSpec[] = [];
   @tracked toolbarController: Controller | null = null;
@@ -118,8 +119,10 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
   @action
   handleRawEditorInit(view: View) {
     this.controller = new ViewController('rdfaEditorComponent', view);
-    this.toolbarWidgets =
-      this.controller.currentState.widgetMap.get('toolbar') || [];
+    this.toolbarMiddleWidgets =
+      this.controller.currentState.widgetMap.get('toolbarMiddle') || [];
+    this.toolbarRightWidgets =
+      this.controller.currentState.widgetMap.get('toolbarRight') || [];
     this.sidebarWidgets =
       this.controller.currentState.widgetMap.get('sidebar') || [];
     this.insertSidebarWidgets =

--- a/addon/core/controllers/controller.ts
+++ b/addon/core/controllers/controller.ts
@@ -1,7 +1,7 @@
 import LiveMarkSet, {
   LiveMarkSetArgs,
 } from '@lblod/ember-rdfa-editor/core/model/marks/live-mark-set';
-import { Mark, MarkSpec } from '@lblod/ember-rdfa-editor/core/model/marks/mark';
+import { MarkSpec } from '@lblod/ember-rdfa-editor/core/model/marks/mark';
 import MarksRegistry from '@lblod/ember-rdfa-editor/core/model/marks/marks-registry';
 import ModelElement, {
   ElementType,
@@ -25,6 +25,7 @@ import { View } from '../view';
 import { InlineComponentSpec } from '../model/inline-components/model-inline-component';
 import ModelNode from '../model/nodes/model-node';
 import { EditorUtils } from '@lblod/ember-rdfa-editor/core/controllers/view-controller';
+import { MarkInstanceEntry } from '../model/marks/marks-manager';
 
 export type WidgetLocation = 'toolbar' | 'sidebar' | 'insertSidebar';
 
@@ -55,7 +56,7 @@ export default interface Controller {
 
   get util(): EditorUtils;
 
-  get ownMarks(): Set<Mark>;
+  get ownMarks(): Set<MarkInstanceEntry>;
 
   get modelRoot(): ModelElement;
 
@@ -65,7 +66,7 @@ export default interface Controller {
 
   get currentState(): State;
 
-  getMarksFor(owner: string): Set<Mark>;
+  getMarksFor(owner: string): Set<MarkInstanceEntry>;
 
   createLiveMarkSet(args: LiveMarkSetArgs): LiveMarkSet;
 

--- a/addon/core/controllers/controller.ts
+++ b/addon/core/controllers/controller.ts
@@ -27,7 +27,11 @@ import ModelNode from '../model/nodes/model-node';
 import { EditorUtils } from '@lblod/ember-rdfa-editor/core/controllers/view-controller';
 import { MarkInstanceEntry } from '../model/marks/marks-manager';
 
-export type WidgetLocation = 'toolbar' | 'sidebar' | 'insertSidebar';
+export type WidgetLocation =
+  | 'toolbarMiddle'
+  | 'toolbarRight'
+  | 'sidebar'
+  | 'insertSidebar';
 
 export interface WidgetSpec {
   componentName: string;

--- a/addon/core/controllers/view-controller.ts
+++ b/addon/core/controllers/view-controller.ts
@@ -9,7 +9,7 @@ import GenTreeWalker, {
   TreeWalkerFactory,
 } from '@lblod/ember-rdfa-editor/utils/gen-tree-walker';
 import Datastore from '@lblod/ember-rdfa-editor/utils/datastore/datastore';
-import { Mark, MarkSpec } from '@lblod/ember-rdfa-editor/core/model/marks/mark';
+import { MarkSpec } from '@lblod/ember-rdfa-editor/core/model/marks/mark';
 import { AttributeSpec } from '@lblod/ember-rdfa-editor/utils/render-spec';
 import ModelElement, {
   ElementType,
@@ -33,6 +33,7 @@ import Controller, {
   WidgetSpec,
 } from '@lblod/ember-rdfa-editor/core/controllers/controller';
 import { toFilterSkipFalse } from '@lblod/ember-rdfa-editor/utils/model-tree-walker';
+import { MarkInstanceEntry } from '../model/marks/marks-manager';
 
 export interface EditorUtils {
   toFilterSkipFalse: typeof toFilterSkipFalse;
@@ -75,7 +76,7 @@ export class ViewController implements Controller {
     throw new Error('Method not implemented.');
   }
 
-  get ownMarks(): Set<Mark<AttributeSpec>> {
+  get ownMarks(): Set<MarkInstanceEntry> {
     return this.getMarksFor(this.name);
   }
 
@@ -135,8 +136,8 @@ export class ViewController implements Controller {
     // this._rawEditor.registerComponent(component);
   }
 
-  getMarksFor(owner: string): Set<Mark<AttributeSpec>> {
-    return this.marksRegistry.getMarksByOwner(owner);
+  getMarksFor(owner: string): Set<MarkInstanceEntry> {
+    return this.currentState.marksManager.getMarksByOwner(owner);
   }
 
   registerWidget(spec: WidgetSpec): void {

--- a/addon/core/controllers/view-controller.ts
+++ b/addon/core/controllers/view-controller.ts
@@ -136,7 +136,7 @@ export class ViewController implements Controller {
   }
 
   getMarksFor(owner: string): Set<Mark<AttributeSpec>> {
-    return this.marksRegistry.getMarksFor(owner);
+    return this.marksRegistry.getMarksByOwner(owner);
   }
 
   registerWidget(spec: WidgetSpec): void {

--- a/addon/core/model/marks/mark.ts
+++ b/addon/core/model/marks/mark.ts
@@ -1,6 +1,5 @@
 import HashSet from '@lblod/ember-rdfa-editor/utils/hash-set';
 import { isElement } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
-import ModelText from '@lblod/ember-rdfa-editor/core/model/nodes/model-text';
 import { CORE_OWNER } from '@lblod/ember-rdfa-editor/utils/constants';
 import renderFromSpec, {
   AttributeSpec,
@@ -24,12 +23,12 @@ export interface MarkSpec<A extends AttributeSpec = AttributeSpec> {
 export class Mark<A extends AttributeSpec = AttributeSpec> {
   private readonly _spec: MarkSpec<A>;
   private readonly _attributes: A;
-  private readonly _node?: ModelText;
+  // private _node?: ModelText;
 
-  constructor(spec: MarkSpec<A>, attributes: A, node?: ModelText) {
+  constructor(spec: MarkSpec<A>, attributes: A) {
     this._spec = spec;
     this._attributes = attributes;
-    this._node = node;
+    // this._node = node;
   }
 
   get attributes(): A {
@@ -40,9 +39,13 @@ export class Mark<A extends AttributeSpec = AttributeSpec> {
     return this._spec.name;
   }
 
-  get node(): ModelText | undefined {
-    return this._node;
-  }
+  // get node(): ModelText | undefined {
+  //   return this._node;
+  // }
+
+  // set node(value: ModelText | undefined) {
+  //   this._node = value;
+  // }
 
   get priority(): number {
     return this._spec.priority;
@@ -59,7 +62,7 @@ export class Mark<A extends AttributeSpec = AttributeSpec> {
   }
 
   clone(): Mark<A> {
-    return new Mark<A>(this._spec, this.attributes, this.node);
+    return new Mark<A>(this._spec, this.attributes);
   }
 }
 

--- a/addon/core/model/marks/marks-manager.ts
+++ b/addon/core/model/marks/marks-manager.ts
@@ -1,0 +1,67 @@
+import { CORE_OWNER } from '@lblod/ember-rdfa-editor/utils/constants';
+import GenTreeWalker from '@lblod/ember-rdfa-editor/utils/gen-tree-walker';
+import MapUtils from '@lblod/ember-rdfa-editor/utils/map-utils';
+import { toFilterSkipFalse } from '@lblod/ember-rdfa-editor/utils/model-tree-walker';
+import ModelElement from '../nodes/model-element';
+import ModelNode from '../nodes/model-node';
+import ModelText from '../nodes/model-text';
+import { Mark } from './mark';
+
+export type MarksManagerArgs = {
+  store?: Map<string, Set<Mark>>;
+  ownerMapping?: Map<string, Set<Mark>>;
+};
+
+export default class MarksManager {
+  /**
+   * A map of mark owners onto the currently active marks created by the owner
+   * @private
+   */
+  private markOwnerMapping: Map<string, Set<Mark>>;
+
+  /**
+   * A map of unique mark types onto the currently active marks of that type
+   * @private
+   */
+  private markStore: Map<string, Set<Mark>>;
+
+  constructor(args?: MarksManagerArgs) {
+    this.markStore = args?.store || new Map<string, Set<Mark>>();
+    this.markOwnerMapping = args?.ownerMapping || new Map<string, Set<Mark>>();
+  }
+
+  getMarksByOwner(owner: string): Set<Mark> {
+    return this.markOwnerMapping.get(owner) || new Set();
+  }
+
+  getMarksByMarkName(name: string): Set<Mark> {
+    return this.markStore.get(name) || new Set();
+  }
+
+  static fromDocument(document: ModelElement) {
+    const markStore = new Map<string, Set<Mark>>();
+    const markOwnerMapping = new Map<string, Set<Mark>>();
+    const textModels: GenTreeWalker<ModelText> = GenTreeWalker.fromSubTree({
+      root: document,
+      filter: toFilterSkipFalse((node: ModelNode) =>
+        ModelNode.isModelText(node)
+      ),
+    }) as GenTreeWalker<ModelText>;
+
+    for (const textModel of textModels.nodes()) {
+      for (const mark of textModel.marks) {
+        MapUtils.setOrAdd(markStore, mark.name, mark);
+        MapUtils.setOrAdd(
+          markOwnerMapping,
+          mark.attributes.setBy || CORE_OWNER,
+          mark
+        );
+      }
+    }
+
+    return new MarksManager({
+      store: markStore,
+      ownerMapping: markOwnerMapping,
+    });
+  }
+}

--- a/addon/core/model/marks/marks-registry.ts
+++ b/addon/core/model/marks/marks-registry.ts
@@ -14,6 +14,9 @@ import ModelNode from '@lblod/ember-rdfa-editor/core/model/nodes/model-node';
 import GenTreeWalker from '@lblod/ember-rdfa-editor/utils/gen-tree-walker';
 import { toFilterSkipFalse } from '@lblod/ember-rdfa-editor/utils/model-tree-walker';
 import { AttributeSpec } from '../../../utils/render-spec';
+import Controller from '@ember/controller';
+import Transaction from '../../state/transaction';
+import { Step } from '../../state/steps/step';
 
 export interface SpecAttributes {
   spec: MarkSpec;
@@ -21,17 +24,6 @@ export interface SpecAttributes {
 }
 
 export default class MarksRegistry {
-  private _eventBus?: EventBus;
-
-  constructor(eventBus?: EventBus) {
-    this._eventBus = eventBus;
-    if (this._eventBus) {
-      this._eventBus.on('contentChanged', this.updateMarks, {
-        priority: 'internal',
-      });
-    }
-  }
-
   /**
    * A map of all unique markNames in the document
    * onto the nodes that have them currently active
@@ -56,20 +48,19 @@ export default class MarksRegistry {
    */
   private registeredMarks: Map<string, MarkSpec> = new Map<string, MarkSpec>();
 
-  updateMarks = (event: ContentChangedEvent) => {
-    const { payload } = event;
-    if (payload.type === 'insert') {
-      const { overwrittenNodes, insertedNodes, _markCheckNodes } = payload;
-      this.updateMarksForNodes(insertedNodes);
-      this.updateMarksForNodes(_markCheckNodes);
-      this.removeMarksForNodes(overwrittenNodes);
-    } else if (payload.type === 'move') {
-      const { insertedNodes, _markCheckNodes } = payload;
-      this.updateMarksForNodes(insertedNodes);
-      this.updateMarksForNodes(_markCheckNodes);
-    } else if (payload.type === 'unknown') {
-      this.updateMarksForNodes(payload.rootModelNode.children);
-    }
+  updateMarks = ({
+    insertedNodes,
+    overwrittenNodes,
+    markCheckNodes,
+  }: {
+    insertedNodes: ModelNode[];
+    overwrittenNodes: ModelNode[];
+    markCheckNodes: ModelNode[];
+  }) => {
+    console.log('UPDATE MARKS');
+    this.updateMarksForNodes(insertedNodes);
+    this.updateMarksForNodes(markCheckNodes);
+    this.removeMarksForNodes(overwrittenNodes);
   };
 
   private updateMarksForNodes(nodes: ModelNode[]) {

--- a/addon/core/model/marks/marks-registry.ts
+++ b/addon/core/model/marks/marks-registry.ts
@@ -1,5 +1,4 @@
 import {
-  Mark,
   MarkSpec,
   TagMatch,
 } from '@lblod/ember-rdfa-editor/core/model/marks/mark';
@@ -15,15 +14,6 @@ export interface SpecAttributes {
 }
 
 export default class MarksRegistry {
-  /**
-   * A map of mark owners onto the currently active marks created by the owner
-   * @private
-   */
-  private markOwnerMapping: Map<string, Set<Mark>> = new Map<
-    string,
-    Set<Mark>
-  >();
-
   /**
    * A map of html element tagnames onto the markspecs that
    * match on them.
@@ -77,9 +67,5 @@ export default class MarksRegistry {
     for (const matcher of mark.matchers) {
       MapUtils.setOrPush(this.markMatchMap, matcher.tag, mark);
     }
-  }
-
-  getMarksByOwner(owner: string): Set<Mark> {
-    return this.markOwnerMapping.get(owner) || new Set();
   }
 }

--- a/addon/core/model/marks/marks-registry.ts
+++ b/addon/core/model/marks/marks-registry.ts
@@ -5,12 +5,8 @@ import {
 } from '@lblod/ember-rdfa-editor/core/model/marks/mark';
 import MapUtils from '@lblod/ember-rdfa-editor/utils/map-utils';
 import { isElement, tagName } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
-import ModelText from '@lblod/ember-rdfa-editor/core/model/nodes/model-text';
 import { CORE_OWNER } from '@lblod/ember-rdfa-editor/utils/constants';
 import HashSet from '@lblod/ember-rdfa-editor/utils/hash-set';
-import ModelNode from '@lblod/ember-rdfa-editor/core/model/nodes/model-node';
-import GenTreeWalker from '@lblod/ember-rdfa-editor/utils/gen-tree-walker';
-import { toFilterSkipFalse } from '@lblod/ember-rdfa-editor/utils/model-tree-walker';
 import { AttributeSpec } from '../../../utils/render-spec';
 
 export interface SpecAttributes {
@@ -20,22 +16,12 @@ export interface SpecAttributes {
 
 export default class MarksRegistry {
   /**
-   * A map of mark owners onto the nodes
-   * that have a mark set by them currently active
+   * A map of mark owners onto the currently active marks created by the owner
    * @private
    */
-  private markOwnerMapping: Map<string, Set<ModelText>> = new Map<
+  private markOwnerMapping: Map<string, Set<Mark>> = new Map<
     string,
-    Set<ModelText>
-  >();
-
-  /**
-   * A map of unique mark types onto the text nodes that have an active mark applied of that type
-   * @private
-   */
-  private markStore: Map<string, Set<ModelText>> = new Map<
-    string,
-    Set<ModelText>
+    Set<Mark>
   >();
 
   /**
@@ -52,57 +38,6 @@ export default class MarksRegistry {
    * @private
    */
   private registeredMarks: Map<string, MarkSpec> = new Map<string, MarkSpec>();
-
-  updateMarks = ({
-    insertedNodes,
-    overwrittenNodes,
-    markCheckNodes,
-  }: {
-    insertedNodes: ModelNode[];
-    overwrittenNodes: ModelNode[];
-    markCheckNodes: ModelNode[];
-  }) => {
-    this.updateMarksForNodes(insertedNodes);
-    this.updateMarksForNodes(markCheckNodes);
-    this.removeMarksForNodes(overwrittenNodes);
-  };
-
-  private updateMarksForNodes(nodes: ModelNode[]) {
-    for (const node of nodes) {
-      const walker = GenTreeWalker.fromSubTree({
-        root: node,
-        filter: toFilterSkipFalse<ModelNode>(ModelNode.isModelText),
-      });
-      for (const textNode of walker.nodes() as Generator<ModelText>) {
-        for (const mark of textNode.marks) {
-          const owner = mark.attributes.setBy || CORE_OWNER;
-          MapUtils.setOrAdd(this.markOwnerMapping, owner, textNode);
-
-          const type = mark.name;
-          MapUtils.setOrAdd(this.markStore, type, textNode);
-        }
-      }
-    }
-  }
-
-  private removeMarksForNodes(nodes: ModelNode[]) {
-    for (const node of nodes) {
-      const walker = GenTreeWalker.fromSubTree({
-        root: node,
-        filter: toFilterSkipFalse<ModelNode>(ModelNode.isModelText),
-      });
-      for (const textNode of walker.nodes() as Generator<ModelText>) {
-        for (const mark of textNode.marks) {
-          const owner = mark.attributes.setBy || CORE_OWNER;
-          const ownerNodes = this.markOwnerMapping.get(owner);
-          ownerNodes?.delete(textNode);
-
-          const markNodes = this.markStore.get(mark.name);
-          markNodes?.delete(textNode);
-        }
-      }
-    }
-  }
 
   matchMarkSpec(node: Node): Set<SpecAttributes> {
     const setBy = isElement(node)
@@ -133,34 +68,6 @@ export default class MarksRegistry {
     return result;
   }
 
-  addMark<A extends AttributeSpec>(
-    node: ModelText,
-    spec: MarkSpec<A>,
-    attributes: A
-  ) {
-    const mark = new Mark(spec, attributes, node);
-    node.addMark(mark);
-    MapUtils.setOrAdd(
-      this.markOwnerMapping,
-      attributes.setBy ?? CORE_OWNER,
-      mark.node
-    );
-
-    MapUtils.setOrAdd(this.markStore, mark.name, mark.node);
-  }
-
-  // TODO: see if we still use this
-  // removeMarkByName(node: ModelText, markName: string) {
-  //   node.removeMarkByName(markName);
-  //   const mark = node.marks.lookupHash(markName);
-  //   if (mark) {
-  //     const marks = this.markStore.get(mark.attributes.setBy ?? CORE_OWNER);
-  //     if (marks && mark.node) {
-  //       marks.delete(mark.node);
-  //     }
-  //   }
-  // }
-
   lookupMark(name: string): MarkSpec | null {
     return this.registeredMarks.get(name) || null;
   }
@@ -173,36 +80,6 @@ export default class MarksRegistry {
   }
 
   getMarksByOwner(owner: string): Set<Mark> {
-    const nodes = this.markOwnerMapping.get(owner);
-    const result = new Set<Mark>();
-    if (nodes) {
-      for (const node of nodes) {
-        for (const mark of node.marks) {
-          if (mark.attributes.setBy === owner) {
-            result.add(mark);
-          }
-        }
-      }
-    }
-    return result;
-  }
-
-  getMarksByMarkName(name: string): Set<Mark> {
-    const nodes = this.markStore.get(name);
-    const result = new Set<Mark>();
-    if (nodes) {
-      for (const node of nodes) {
-        for (const mark of node.marks) {
-          if (mark.name === name) {
-            result.add(mark);
-          }
-        }
-      }
-    }
-    return result;
-  }
-
-  clear() {
-    this.markOwnerMapping.clear();
+    return this.markOwnerMapping.get(owner) || new Set();
   }
 }

--- a/addon/core/model/marks/marks-registry.ts
+++ b/addon/core/model/marks/marks-registry.ts
@@ -8,15 +8,10 @@ import { isElement, tagName } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 import ModelText from '@lblod/ember-rdfa-editor/core/model/nodes/model-text';
 import { CORE_OWNER } from '@lblod/ember-rdfa-editor/utils/constants';
 import HashSet from '@lblod/ember-rdfa-editor/utils/hash-set';
-import EventBus from '@lblod/ember-rdfa-editor/utils/event-bus';
-import { ContentChangedEvent } from '@lblod/ember-rdfa-editor/utils/editor-event';
 import ModelNode from '@lblod/ember-rdfa-editor/core/model/nodes/model-node';
 import GenTreeWalker from '@lblod/ember-rdfa-editor/utils/gen-tree-walker';
 import { toFilterSkipFalse } from '@lblod/ember-rdfa-editor/utils/model-tree-walker';
 import { AttributeSpec } from '../../../utils/render-spec';
-import Controller from '@ember/controller';
-import Transaction from '../../state/transaction';
-import { Step } from '../../state/steps/step';
 
 export interface SpecAttributes {
   spec: MarkSpec;
@@ -57,7 +52,6 @@ export default class MarksRegistry {
     overwrittenNodes: ModelNode[];
     markCheckNodes: ModelNode[];
   }) => {
-    console.log('UPDATE MARKS');
     this.updateMarksForNodes(insertedNodes);
     this.updateMarksForNodes(markCheckNodes);
     this.removeMarksForNodes(overwrittenNodes);

--- a/addon/core/model/nodes/model-text.ts
+++ b/addon/core/model/nodes/model-text.ts
@@ -80,7 +80,6 @@ export default class ModelText extends ModelNode {
     result.modelNodeType = this.modelNodeType;
     result.content = this.content;
     result.marks = this.marks.clone();
-
     return result;
   }
 

--- a/addon/core/model/operations/insert-operation.ts
+++ b/addon/core/model/operations/insert-operation.ts
@@ -61,6 +61,9 @@ export default class InsertOperation extends Operation {
     return {
       defaultRange,
       mapper: resultMapper,
+      insertedNodes: this.nodes,
+      overwrittenNodes,
+      markCheckNodes: _markCheckNodes,
     };
   }
 }

--- a/addon/core/model/operations/insert-text-operation.ts
+++ b/addon/core/model/operations/insert-text-operation.ts
@@ -82,6 +82,12 @@ export default class InsertTextOperation extends Operation {
         },
       })
     );
-    return { mapper, defaultRange };
+    return {
+      mapper,
+      defaultRange,
+      insertedNodes: [newText],
+      overwrittenNodes,
+      markCheckNodes: _markCheckNodes,
+    };
   }
 }

--- a/addon/core/model/operations/mark-operation.ts
+++ b/addon/core/model/operations/mark-operation.ts
@@ -70,7 +70,7 @@ export default class MarkOperation extends Operation {
     action: MarkAction
   ) {
     if (action === 'add') {
-      node.addMark(new Mark(spec, attributes, node));
+      node.addMark(new Mark(spec, attributes));
     } else {
       node.removeMarkByName(`${spec.name}-${attributes.setBy || CORE_OWNER}`);
     }

--- a/addon/core/model/operations/mark-operation.ts
+++ b/addon/core/model/operations/mark-operation.ts
@@ -112,7 +112,13 @@ export default class MarkOperation extends Operation {
           },
         })
       );
-      return { defaultRange: newRange, mapper: new RangeMapper() };
+      return {
+        defaultRange: newRange,
+        mapper: new RangeMapper(),
+        overwrittenNodes: [],
+        insertedNodes: [node],
+        markCheckNodes: [node],
+      };
     } else {
       OperationAlgorithms.splitText(this.range.start);
       OperationAlgorithms.splitText(this.range.end);
@@ -153,7 +159,13 @@ export default class MarkOperation extends Operation {
           },
         })
       );
-      return { defaultRange: this.range, mapper: new RangeMapper() };
+      return {
+        defaultRange: this.range,
+        mapper: new RangeMapper(),
+        overwrittenNodes: [],
+        insertedNodes: [],
+        markCheckNodes: _markCheckNodes,
+      };
     }
   }
 }

--- a/addon/core/model/operations/move-operation.ts
+++ b/addon/core/model/operations/move-operation.ts
@@ -58,7 +58,13 @@ export default class MoveOperation extends Operation {
           },
         })
       );
-      return { defaultRange: newRange, mapper };
+      return {
+        defaultRange: newRange,
+        mapper,
+        insertedNodes: movedNodes,
+        overwrittenNodes: [],
+        markCheckNodes: _markCheckNodes,
+      };
     } else {
       const newRange = new ModelRange(this.targetPosition, this.targetPosition);
       this.emit(
@@ -74,7 +80,13 @@ export default class MoveOperation extends Operation {
           },
         })
       );
-      return { defaultRange: newRange, mapper };
+      return {
+        defaultRange: newRange,
+        mapper,
+        insertedNodes: [],
+        overwrittenNodes: [],
+        markCheckNodes: _markCheckNodes,
+      };
     }
   }
 }

--- a/addon/core/model/operations/operation.ts
+++ b/addon/core/model/operations/operation.ts
@@ -7,11 +7,15 @@ import {
   Logger,
 } from '@lblod/ember-rdfa-editor/utils/logging-utils';
 import ModelRange from '../model-range';
+import ModelNode from '../nodes/model-node';
 import RangeMapper from '../range-mapper';
 
 export interface OperationResult {
   mapper: RangeMapper;
   defaultRange: ModelRange;
+  insertedNodes: ModelNode[];
+  overwrittenNodes: ModelNode[];
+  markCheckNodes: ModelNode[];
 }
 
 export default abstract class Operation {

--- a/addon/core/model/operations/remove-operation.ts
+++ b/addon/core/model/operations/remove-operation.ts
@@ -51,6 +51,9 @@ export default class RemoveOperation extends Operation {
     return {
       defaultRange,
       mapper: resultMapper,
+      insertedNodes: [],
+      overwrittenNodes,
+      markCheckNodes: _markCheckNodes,
     };
   }
 }

--- a/addon/core/model/operations/split-operation.ts
+++ b/addon/core/model/operations/split-operation.ts
@@ -44,7 +44,13 @@ export default class SplitOperation extends Operation {
           },
         })
       );
-      return { defaultRange: newRange, mapper };
+      return {
+        defaultRange: newRange,
+        mapper,
+        overwrittenNodes: [],
+        insertedNodes: [],
+        markCheckNodes: nodeAfter ? [nodeAfter] : [],
+      };
     } else {
       // this is very fragile and depends heavily on execution order.
       // be careful making changes here
@@ -77,7 +83,13 @@ export default class SplitOperation extends Operation {
         })
       );
 
-      return { defaultRange: newRange, mapper: finalMapper };
+      return {
+        defaultRange: newRange,
+        mapper: finalMapper,
+        overwrittenNodes: [],
+        insertedNodes: [],
+        markCheckNodes: _markCheckNodes,
+      };
     }
   }
 

--- a/addon/core/model/readers/html-reader.ts
+++ b/addon/core/model/readers/html-reader.ts
@@ -1,14 +1,11 @@
-import { MarkSpec } from '@lblod/ember-rdfa-editor/core/model/marks/mark';
 import MarksRegistry, {
   SpecAttributes,
 } from '@lblod/ember-rdfa-editor/core/model/marks/marks-registry';
 import ModelNode from '@lblod/ember-rdfa-editor/core/model/nodes/model-node';
-import ModelText from '@lblod/ember-rdfa-editor/core/model/nodes/model-text';
 import readHtmlNode from '@lblod/ember-rdfa-editor/core/model/readers/html-node-reader';
 import InlineComponentsRegistry from '../inline-components/inline-components-registry';
 import { ModelInlineComponent } from '../inline-components/model-inline-component';
 import { calculateRdfaPrefixes } from '../../../utils/rdfa-utils';
-import { AttributeSpec } from '../../../utils/render-spec';
 
 export interface HtmlReaderContextArgs {
   rdfaPrefixes?: Map<string, string>;
@@ -61,13 +58,13 @@ export class HtmlReaderContext {
     return this.inlineComponentsRegistry.matchInlineComponentSpec(node);
   }
 
-  addMark<A extends AttributeSpec>(
-    node: ModelText,
-    spec: MarkSpec<A>,
-    attributes: A
-  ) {
-    return this.marksRegistry.addMark(node, spec, attributes);
-  }
+  // addMark<A extends AttributeSpec>(
+  //   node: ModelText,
+  //   spec: MarkSpec<A>,
+  //   attributes: A
+  // ) {
+  //   return this.marksRegistry.addMark(node, spec, attributes);
+  // }
 
   addComponentInstance(
     element: HTMLElement,

--- a/addon/core/model/readers/html-reader.ts
+++ b/addon/core/model/readers/html-reader.ts
@@ -58,14 +58,6 @@ export class HtmlReaderContext {
     return this.inlineComponentsRegistry.matchInlineComponentSpec(node);
   }
 
-  // addMark<A extends AttributeSpec>(
-  //   node: ModelText,
-  //   spec: MarkSpec<A>,
-  //   attributes: A
-  // ) {
-  //   return this.marksRegistry.addMark(node, spec, attributes);
-  // }
-
   addComponentInstance(
     element: HTMLElement,
     componentName: string,

--- a/addon/core/model/readers/html-text-reader.ts
+++ b/addon/core/model/readers/html-text-reader.ts
@@ -1,5 +1,6 @@
 import ModelText from '@lblod/ember-rdfa-editor/core/model/nodes/model-text';
 import { normalToPreWrapWhiteSpace } from '@lblod/ember-rdfa-editor/utils/whitespace-collapsing';
+import { Mark } from '../marks/mark';
 import { HtmlReaderContext } from './html-reader';
 
 /**
@@ -24,8 +25,8 @@ export default function readHtmlText(
   }
 
   const result = new ModelText(trimmed);
-  context.activeMarks.forEach(({ spec, attributes }) =>
-    context.addMark(result, spec, attributes)
-  );
+  context.activeMarks.forEach(({ spec, attributes }) => {
+    result.addMark(new Mark(spec, attributes));
+  });
   return [result];
 }

--- a/addon/core/model/readers/xml-text-reader.ts
+++ b/addon/core/model/readers/xml-text-reader.ts
@@ -23,7 +23,7 @@ export default class XmlTextReader implements Reader<Element, ModelText, void> {
           if (specAttribute) {
             console.warn('ADDING MARK WITHOUT PASSING REGISTRY');
             rslt.addMark(
-              new Mark(specAttribute.spec, specAttribute.attributes, rslt)
+              new Mark(specAttribute.spec, specAttribute.attributes)
             );
           }
         }

--- a/addon/core/state/index.ts
+++ b/addon/core/state/index.ts
@@ -61,6 +61,7 @@ import {
   HtmlReaderContext,
   readHtml,
 } from '@lblod/ember-rdfa-editor/core/model/readers/html-reader';
+import MarksManager from '../model/marks/marks-manager';
 
 export interface StateArgs {
   document: ModelElement;
@@ -70,6 +71,7 @@ export interface StateArgs {
   transactionDispatchListeners: TransactionDispatchListener[];
   commands: Partial<Commands>;
   marksRegistry: MarksRegistry;
+  marksManager: MarksManager;
   inlineComponentsRegistry: InlineComponentsRegistry;
   previousState?: State | null;
   datastore: Datastore;
@@ -101,6 +103,7 @@ export default interface State {
   plugins: InitializedPlugin[];
   commands: Partial<Commands>;
   marksRegistry: MarksRegistry;
+  marksManager: MarksManager;
   inlineComponentsRegistry: InlineComponentsRegistry;
   previousState: State | null;
   widgetMap: Map<WidgetLocation, InternalWidgetSpec[]>;
@@ -126,6 +129,7 @@ export class SayState implements State {
   commands: Partial<Commands>;
   datastore: Datastore;
   marksRegistry: MarksRegistry;
+  marksManager: MarksManager;
   inlineComponentsRegistry: InlineComponentsRegistry;
   eventBus: EventBus;
   transactionStepListeners: TransactionStepListener[];
@@ -158,6 +162,7 @@ export class SayState implements State {
     this.plugins = args.plugins;
     this.commands = args.commands;
     this.marksRegistry = args.marksRegistry;
+    this.marksManager = args.marksManager;
     this.inlineComponentsRegistry = args.inlineComponentsRegistry;
     this.previousState = previousState;
     this.marksRegistry.registerMark(boldMarkSpec);
@@ -249,6 +254,7 @@ export function emptyState(eventBus = new EventBus()): State {
     commands: defaultCommands(),
     config: new Map<string, string | null>(),
     marksRegistry: new MarksRegistry(),
+    marksManager: new MarksManager(),
     inlineComponentsRegistry: new InlineComponentsRegistry(),
     widgetMap: new Map<WidgetLocation, InternalWidgetSpec[]>(),
     datastore: EditorStore.empty(),
@@ -267,6 +273,7 @@ export function cloneState(state: State): State {
   return new SayState({
     document: documentClone,
     marksRegistry: state.marksRegistry,
+    marksManager: state.marksManager,
     inlineComponentsRegistry: state.inlineComponentsRegistry.clone(
       state.document,
       documentClone
@@ -316,6 +323,7 @@ export function createState({
     commands,
     config,
     marksRegistry,
+    marksManager: MarksManager.fromDocument(document),
     inlineComponentsRegistry,
     widgetMap,
     eventBus,

--- a/addon/core/state/index.ts
+++ b/addon/core/state/index.ts
@@ -27,7 +27,6 @@ import ReadSelectionCommand from '../../commands/read-selection-command';
 import RemoveCommand from '../../commands/remove-command';
 import RemoveComponentCommand from '../../commands/remove-component-command';
 import RemoveListCommand from '../../commands/remove-list-command';
-import RemoveMarkCommand from '../../commands/remove-mark-command';
 import RemoveMarkFromRangeCommand from '../../commands/remove-mark-from-range-command';
 import RemoveMarkFromSelectionCommand from '../../commands/remove-mark-from-selection-command';
 import RemoveMarksFromRangesCommand from '../../commands/remove-marks-from-ranges-command';
@@ -62,6 +61,7 @@ import {
   readHtml,
 } from '@lblod/ember-rdfa-editor/core/model/readers/html-reader';
 import MarksManager from '../model/marks/marks-manager';
+import RemoveMarkFromNodeCommand from '@lblod/ember-rdfa-editor/commands/remove-mark-from-node-command';
 
 export interface StateArgs {
   document: ModelElement;
@@ -230,7 +230,7 @@ export function defaultCommands(): Partial<Commands> {
     readSelection: new ReadSelectionCommand(),
     removeComponent: new RemoveComponentCommand(),
     removeList: new RemoveListCommand(),
-    removeMark: new RemoveMarkCommand(),
+    removeMarkFromNode: new RemoveMarkFromNodeCommand(),
     removeMarkFromRange: new RemoveMarkFromRangeCommand(),
     removeMarkFromSelection: new RemoveMarkFromSelectionCommand(),
     removeMarksFromRanges: new RemoveMarksFromRangesCommand(),

--- a/addon/core/state/steps/operation-step.ts
+++ b/addon/core/state/steps/operation-step.ts
@@ -18,18 +18,7 @@ export default class OperationStep implements BaseStep {
     if (initialState.document !== operation.range.root) {
       throw new OperationError();
     }
-    const {
-      mapper,
-      defaultRange,
-      insertedNodes,
-      overwrittenNodes,
-      markCheckNodes,
-    } = this.operation.execute();
-    initialState.marksRegistry.updateMarks({
-      insertedNodes,
-      overwrittenNodes,
-      markCheckNodes,
-    });
+    const { mapper, defaultRange } = this.operation.execute();
     this.mapper = mapper;
     this._defaultRange = defaultRange;
     initialState.selection = this.mapper.mapSelection(initialState.selection);

--- a/addon/core/state/steps/operation-step.ts
+++ b/addon/core/state/steps/operation-step.ts
@@ -18,7 +18,18 @@ export default class OperationStep implements BaseStep {
     if (initialState.document !== operation.range.root) {
       throw new OperationError();
     }
-    const { mapper, defaultRange } = this.operation.execute();
+    const {
+      mapper,
+      defaultRange,
+      insertedNodes,
+      overwrittenNodes,
+      markCheckNodes,
+    } = this.operation.execute();
+    initialState.marksRegistry.updateMarks({
+      insertedNodes,
+      overwrittenNodes,
+      markCheckNodes,
+    });
     this.mapper = mapper;
     this._defaultRange = defaultRange;
     initialState.selection = this.mapper.mapSelection(initialState.selection);

--- a/addon/core/state/transaction.ts
+++ b/addon/core/state/transaction.ts
@@ -36,6 +36,7 @@ import OperationStep from './steps/operation-step';
 import ConfigStep from './steps/config-step';
 import { createLogger } from '@lblod/ember-rdfa-editor/utils/logging-utils';
 import Operation from '@lblod/ember-rdfa-editor/core/model/operations/operation';
+import MarksManager from '../model/marks/marks-manager';
 
 interface TextInsertion {
   range: ModelRange;
@@ -62,6 +63,7 @@ export default class Transaction {
   // we clone the nodes, so rdfa is invalid even if nothing happens to them
   // TODO: improve this
   rdfInvalid = true;
+  marksInvalid = true;
   logger = createLogger('transaction');
   private _commandCache?: CommandExecutor;
 
@@ -133,6 +135,17 @@ export default class Transaction {
       this.rdfInvalid = false;
     }
     return this._workingCopy.datastore;
+  }
+
+  getMarksManager() {
+    if (this.marksInvalid) {
+      MarksManager.fromDocument(this._workingCopy.document);
+      this._workingCopy.marksManager = MarksManager.fromDocument(
+        this._workingCopy.document
+      );
+      this.marksInvalid = false;
+    }
+    return this._workingCopy.marksManager;
   }
 
   setPlugins(plugins: InitializedPlugin[]): void {
@@ -236,6 +249,7 @@ export default class Transaction {
       this._workingCopy.document !== this.initialState.document
     ) {
       this.getCurrentDataStore();
+      this.getMarksManager();
     }
     return this._workingCopy;
   }
@@ -335,6 +349,7 @@ export default class Transaction {
     this._workingCopy = step.resultState;
     if (isOperationStep(step)) {
       this.rdfInvalid = true;
+      this.marksInvalid = true;
     }
   }
 

--- a/addon/utils/array-utils.ts
+++ b/addon/utils/array-utils.ts
@@ -62,6 +62,13 @@ export default class ArrayUtils {
   static all<T>(array: Array<T>, condition: (e: T) => boolean) {
     return !array.some((e) => !condition(e));
   }
+
+  static lastItem<T>(array: Array<T>): T | null {
+    if (array.length) {
+      return array[array.length - 1];
+    }
+    return null;
+  }
 }
 
 export function pushOrExpand<T>(parent: T[], child: T | T[]): void {

--- a/tests/dummy/app/testplugin/dummy-plugin.ts
+++ b/tests/dummy/app/testplugin/dummy-plugin.ts
@@ -24,8 +24,8 @@ export default class DummyPlugin implements EditorPlugin {
     this.logger('recieved options: ', options);
     this.controller = controller;
     this.controller.addTransactionStepListener((tr) => {
-      for (const mark of this.controller.ownMarks) {
-        tr.commands.removeMark({ mark });
+      for (const { mark, node } of this.controller.ownMarks) {
+        tr.commands.removeMarkFromNode({ mark, node });
       }
 
       const walker = GenTreeWalker.fromSubTree({

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -21,6 +21,7 @@ import { EditorStore } from '@lblod/ember-rdfa-editor/utils/datastore/datastore'
 import { Difference } from '@lblod/ember-rdfa-editor/utils/tree-differ';
 import EventBus from '@lblod/ember-rdfa-editor/utils/event-bus';
 import hbs from 'htmlbars-inline-precompile';
+import MarksManager from '@lblod/ember-rdfa-editor/core/model/marks/marks-manager';
 
 /**
  * Utility to get the editor element in a type-safe way
@@ -79,6 +80,7 @@ export function testState({
   document = createModelRoot(),
   commands = defaultCommands(),
   marksRegistry = new MarksRegistry(),
+  marksManager = new MarksManager(),
   inlineComponentsRegistry = new InlineComponentsRegistry(),
   plugins = [],
   selection = new ModelSelection(),
@@ -92,6 +94,7 @@ export function testState({
     transactionStepListeners: [],
     commands,
     marksRegistry,
+    marksManager,
     inlineComponentsRegistry,
     plugins,
     selection,

--- a/tests/unit/model/marks/marks-manager-test.ts
+++ b/tests/unit/model/marks/marks-manager-test.ts
@@ -1,9 +1,8 @@
 import MarksManager from '@lblod/ember-rdfa-editor/core/model/marks/marks-manager';
 import ModelElement from '@lblod/ember-rdfa-editor/core/model/nodes/model-element';
-import { XmlReaderResult } from '@lblod/ember-rdfa-editor/core/model/readers/xml-reader';
 import ArrayUtils from '@lblod/ember-rdfa-editor/utils/array-utils';
 import { CORE_OWNER } from '@lblod/ember-rdfa-editor/utils/constants';
-import { domStripped, vdom } from '@lblod/ember-rdfa-editor/utils/xml-utils';
+import { vdom } from '@lblod/ember-rdfa-editor/utils/xml-utils';
 
 import { module, test } from 'qunit';
 
@@ -68,6 +67,10 @@ module('Unit | model | marks-manager-test | getMarksByOwner', function () {
     assert.strictEqual(markInstances[0].mark.name, 'bold');
     assert.strictEqual(markInstances[1].mark.name, 'underline');
     assert.strictEqual(markInstances[2].mark.name, 'italic');
+
+    assert.strictEqual(markInstances[0].node, text1);
+    assert.strictEqual(markInstances[1].node, text2);
+    assert.strictEqual(markInstances[2].node, text3);
   });
 });
 

--- a/tests/unit/model/marks/marks-manager-test.ts
+++ b/tests/unit/model/marks/marks-manager-test.ts
@@ -1,0 +1,164 @@
+import MarksManager from '@lblod/ember-rdfa-editor/core/model/marks/marks-manager';
+import ModelElement from '@lblod/ember-rdfa-editor/core/model/nodes/model-element';
+import { XmlReaderResult } from '@lblod/ember-rdfa-editor/core/model/readers/xml-reader';
+import ArrayUtils from '@lblod/ember-rdfa-editor/utils/array-utils';
+import { CORE_OWNER } from '@lblod/ember-rdfa-editor/utils/constants';
+import { domStripped, vdom } from '@lblod/ember-rdfa-editor/utils/xml-utils';
+
+import { module, test } from 'qunit';
+
+module('Unit | model | marks-manager-test | getMarksByOwner', function () {
+  test('one mark instance', function (assert) {
+    const {
+      root: initial,
+      textNodes: { text },
+    } = vdom`
+        <div>
+          <text __id="text" __marks="bold">abc</text>
+        </div>`;
+
+    const manager = MarksManager.fromDocument(initial as ModelElement);
+    const marksByOwner = manager.getMarksByOwner(CORE_OWNER);
+    const markInstances = [...marksByOwner.values()];
+    assert.strictEqual(markInstances.length, 1);
+    assert.strictEqual(markInstances[0].mark.name, 'bold');
+    assert.strictEqual(markInstances[0].node, text);
+  });
+  test('multiple mark instances', function (assert) {
+    const {
+      root: initial,
+      textNodes: { text1, text2, text3 },
+    } = vdom`
+        <div>
+          <text __id="text1" __marks="bold">abc</text>
+          <text __id="text2" __marks="bold">def</text>
+          <span>
+            <text __id="text3" __marks="bold">def</text>
+          </span>
+        </div>`;
+
+    const manager = MarksManager.fromDocument(initial as ModelElement);
+    const marksByOwner = manager.getMarksByOwner(CORE_OWNER);
+    const markInstances = [...marksByOwner.values()];
+    assert.strictEqual(markInstances.length, 3);
+    assert.true(
+      ArrayUtils.all(markInstances, (entry) => entry.mark.name === 'bold')
+    );
+    assert.strictEqual(markInstances[0].node, text1);
+    assert.strictEqual(markInstances[1].node, text2);
+    assert.strictEqual(markInstances[2].node, text3);
+  });
+  test('multiple mark types', function (assert) {
+    const {
+      root: initial,
+      textNodes: { text1, text2, text3 },
+    } = vdom`
+        <div>
+          <text __id="text1" __marks="bold">abc</text>
+          <text __id="text2" __marks="underline">def</text>
+          <span>
+            <text __id="text3" __marks="italic">def</text>
+          </span>
+        </div>`;
+
+    const manager = MarksManager.fromDocument(initial as ModelElement);
+    const marksByOwner = manager.getMarksByOwner(CORE_OWNER);
+    const markInstances = [...marksByOwner.values()];
+    assert.strictEqual(markInstances.length, 3);
+    assert.strictEqual(markInstances[0].mark.name, 'bold');
+    assert.strictEqual(markInstances[1].mark.name, 'underline');
+    assert.strictEqual(markInstances[2].mark.name, 'italic');
+  });
+});
+
+module(
+  'Unit | model | marks-manager-test | getVisualMarkGroupsByMarkName',
+  function () {
+    test('one mark instance', function (assert) {
+      const {
+        root: initial,
+        textNodes: { text },
+      } = vdom`
+        <div>
+          <text __id="text" __marks="bold">abc</text>
+        </div>`;
+
+      const manager = MarksManager.fromDocument(initial as ModelElement);
+      const markGroupsByMarkName =
+        manager.getVisualMarkGroupsByMarkName('bold');
+      assert.strictEqual(markGroupsByMarkName.length, 1);
+      const markGroup = markGroupsByMarkName[0];
+      assert.strictEqual(markGroup.length, 1);
+      assert.strictEqual(markGroup[0].mark.name, 'bold');
+      assert.strictEqual(markGroup[0].node, text);
+    });
+    test('multiple mark instances', function (assert) {
+      const {
+        root: initial,
+        textNodes: { text1, text2, text3 },
+      } = vdom`
+        <div>
+          <text __id="text1" __marks="bold">abc</text>
+          <text __id="text2" __marks="bold">def</text>
+          <span>
+            <text __id="text3" __marks="bold">def</text>
+          </span>
+        </div>`;
+
+      const manager = MarksManager.fromDocument(initial as ModelElement);
+      const markGroupsByMarkName =
+        manager.getVisualMarkGroupsByMarkName('bold');
+      assert.strictEqual(markGroupsByMarkName.length, 2);
+      const markGroup1 = markGroupsByMarkName[0];
+      const markGroup2 = markGroupsByMarkName[1];
+      assert.strictEqual(markGroup1.length, 2);
+      assert.strictEqual(markGroup2.length, 1);
+      assert.strictEqual(markGroup1[0].mark.name, 'bold');
+      assert.strictEqual(markGroup1[1].mark.name, 'bold');
+      assert.strictEqual(markGroup2[0].mark.name, 'bold');
+      assert.strictEqual(markGroup1[0].node, text1);
+      assert.strictEqual(markGroup1[1].node, text2);
+      assert.strictEqual(markGroup2[0].node, text3);
+    });
+    test('multiple mark types', function (assert) {
+      const {
+        root: initial,
+        textNodes: { text1, text2, text3 },
+      } = vdom`
+        <div>
+          <text __id="text1" __marks="bold,italic">abc</text>
+          <text __id="text2" __marks="underline,bold">def</text>
+          <span>
+            <text __id="text3" __marks="italic,underline">def</text>
+          </span>
+        </div>`;
+
+      const manager = MarksManager.fromDocument(initial as ModelElement);
+      const boldMarkGroups = manager.getVisualMarkGroupsByMarkName('bold');
+      const italicMarkGroups = manager.getVisualMarkGroupsByMarkName('italic');
+      const underlineMarkGroups =
+        manager.getVisualMarkGroupsByMarkName('underline');
+      assert.strictEqual(boldMarkGroups.length, 1);
+      assert.strictEqual(italicMarkGroups.length, 2);
+      assert.strictEqual(underlineMarkGroups.length, 2);
+
+      assert.strictEqual(boldMarkGroups[0][0].mark.name, 'bold');
+      assert.strictEqual(boldMarkGroups[0][1].mark.name, 'bold');
+
+      assert.strictEqual(italicMarkGroups[0][0].mark.name, 'italic');
+      assert.strictEqual(italicMarkGroups[1][0].mark.name, 'italic');
+
+      assert.strictEqual(underlineMarkGroups[0][0].mark.name, 'underline');
+      assert.strictEqual(underlineMarkGroups[1][0].mark.name, 'underline');
+
+      assert.strictEqual(boldMarkGroups[0][0].node, text1);
+      assert.strictEqual(boldMarkGroups[0][1].node, text2);
+
+      assert.strictEqual(italicMarkGroups[0][0].node, text1);
+      assert.strictEqual(italicMarkGroups[1][0].node, text3);
+
+      assert.strictEqual(underlineMarkGroups[0][0].node, text2);
+      assert.strictEqual(underlineMarkGroups[1][0].node, text3);
+    });
+  }
+);

--- a/tests/unit/model/model-text-test.ts
+++ b/tests/unit/model/model-text-test.ts
@@ -13,7 +13,7 @@ module('Unit | model | model-text-test', function () {
     test('textnodes with different properties are not the same', function (assert) {
       const t0 = new ModelText('abc');
       const t1 = new ModelText('abc');
-      t1.addMark(new Mark(boldMarkSpec, {}, t1));
+      t1.addMark(new Mark(boldMarkSpec, {}));
       assert.false(t0.sameAs(t1));
     });
   });


### PR DESCRIPTION
This PR introduces a MarksManager class, seperate from the existing MarksRegistry. The functionality of the MarksManager includes:
- updating the different mark instances in a document 
- the possiblity to retrieve mark instances grouped by type/owner.

When retrieving mark instances given a mark type, an array containing VisualMarkGroups is returned. Each VisualMarkGroup contains a list of mark instances which are visually rendered as the same mark. (e.g. adjacent text with the same mark types).

For a specific transaction, the MarksManager can be retrieved using the `getMarksManager()` function.

This PR also removes the Mark management functionality from the MarksRegistry. The MarksRegistry will only be responsible for keeping track of the registered MarkSpecs.