### PR TITLE
Remove tracked array from inline components registry

### DIFF
--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -119,7 +119,6 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
     if (this.args.rdfaEditorInit) {
       this.args.rdfaEditorInit(rdfaDocument);
     }
-    // this.initializeComponents();
     this.editorLoading = false;
   }
 

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -70,7 +70,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
   @tracked sidebarWidgets: InternalWidgetSpec[] = [];
   @tracked insertSidebarWidgets: InternalWidgetSpec[] = [];
   @tracked toolbarController: Controller | null = null;
-  @tracked inlineComponents = tracked<ActiveComponentEntry>([]);
+  @tracked inlineComponents: ActiveComponentEntry[] = [];
 
   @tracked editorLoading = true;
   private owner: ApplicationInstance;
@@ -108,6 +108,9 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
   @action
   handleRawEditorInit(editor: RawEditor) {
     this.editor = editor;
+    this.editor.on('modelWritten', () => {
+      this.inlineComponents = this.editor!.getComponentInstances();
+    });
     this.toolbarWidgets = editor.widgetMap.get('toolbar') || [];
     this.sidebarWidgets = editor.widgetMap.get('sidebar') || [];
     this.insertSidebarWidgets = editor.widgetMap.get('insertSidebar') || [];
@@ -116,7 +119,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
     if (this.args.rdfaEditorInit) {
       this.args.rdfaEditorInit(rdfaDocument);
     }
-    this.initializeComponents();
+    // this.initializeComponents();
     this.editorLoading = false;
   }
 
@@ -158,12 +161,6 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
     } else {
       this.showRdfaBlocks = false;
       this.toolbarController!.setConfig('showRdfaBlocks', null);
-    }
-  }
-
-  initializeComponents() {
-    if (this.editor) {
-      this.inlineComponents = this.editor.getComponentInstances();
     }
   }
 }

--- a/addon/model/inline-components/inline-components-registry.ts
+++ b/addon/model/inline-components/inline-components-registry.ts
@@ -1,6 +1,5 @@
 import { tagName } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 import { TagMatch } from '../mark';
-import { tracked } from 'tracked-built-ins';
 import MapUtils from '../util/map-utils';
 import {
   InlineComponentSpec,
@@ -22,7 +21,7 @@ export default class InlineComponentsRegistry {
     InlineComponentSpec[]
   >();
 
-  activeComponents = tracked<ActiveComponentEntry>([]);
+  activeComponents: ActiveComponentEntry[] = [];
 
   matchInlineComponentSpec(node: Node): InlineComponentSpec | null {
     const potentialMatches =
@@ -89,10 +88,8 @@ export default class InlineComponentsRegistry {
 
   getComponentInstances(filter?: { componentName: string }) {
     if (filter) {
-      return tracked<ActiveComponentEntry>(
-        this.activeComponents.filter(
-          (entry) => entry.emberComponentName === filter.componentName
-        )
+      return this.activeComponents.filter(
+        (entry) => entry.emberComponentName === filter.componentName
       );
     } else {
       return this.activeComponents;

--- a/addon/model/model.ts
+++ b/addon/model/model.ts
@@ -18,6 +18,7 @@ import SimplifiedModel from '@lblod/ember-rdfa-editor/model/simplified-model';
 import EventBus from '@lblod/ember-rdfa-editor/utils/event-bus';
 import {
   ModelReadEvent,
+  ModelWrittenEvent,
   SelectionChangedEvent,
 } from '@lblod/ember-rdfa-editor/utils/editor-event';
 import MarksRegistry from '@lblod/ember-rdfa-editor/model/marks-registry';
@@ -173,6 +174,7 @@ export default class Model {
     if (writeSelection) {
       this.writeSelection(moveSelectionIntoView);
     }
+    this._eventBus?.emit(new ModelWrittenEvent());
   }
 
   registerMark(markSpec: MarkSpec) {


### PR DESCRIPTION
This PR removes the tracked modifier from the `activeComponents` array in the inline components registry as it was causing issue with circular tracking.
In order to replace the purpose of the tracked array, `modelWritten` events were used. The `rdfa-editor` components updates its component instances in reaction to a `modelWritten` event.