### PR TITLE
Fix issue with inline components not being persisted correctly across reloads

### DIFF
--- a/addon/components/rdfa/editor-toolbar.hbs
+++ b/addon/components/rdfa/editor-toolbar.hbs
@@ -1,4 +1,4 @@
-<div class='say-toolbar'>
+<div class='say-toolbar' {{did-insert this.didInsert}}>
   <div class='say-toolbar__styling-tools'>
     <div class='say-toolbar__group'>
       <button

--- a/addon/components/rdfa/editor-toolbar.ts
+++ b/addon/components/rdfa/editor-toolbar.ts
@@ -38,9 +38,15 @@ export default class EditorToolbar extends Component<Args> {
   @tracked tableAddColumns = 2;
   selection: ModelSelection | null = null;
 
-  constructor(parent: unknown, args: Args) {
-    super(parent, args);
+  @action
+  didInsert() {
     this.args.controller.addTransactionStepListener(this.update.bind(this));
+  }
+
+  @action
+  willDestroy(): void {
+    this.args.controller.removeTransactionStepListener(this.update.bind(this));
+    super.willDestroy();
   }
 
   get controller() {

--- a/addon/components/rdfa/inline-component-manager.hbs
+++ b/addon/components/rdfa/inline-component-manager.hbs
@@ -1,9 +1,11 @@
-{{#each this.inlineComponents as |compEntry|}}
-  {{#in-element compEntry.node insertBefore=null}}
-    {{component
-      compEntry.emberComponentName
-      componentController=compEntry.componentController
-      editorController=compEntry.editorController
-    }}
-  {{/in-element}}
-{{/each}}
+<div {{did-insert this.didInsert}}>
+  {{#each this.inlineComponents as |compEntry|}}
+    {{#in-element compEntry.node insertBefore=null}}
+      {{component
+        compEntry.emberComponentName
+        componentController=compEntry.componentController
+        editorController=compEntry.editorController
+      }}
+    {{/in-element}}
+  {{/each}}
+</div>

--- a/addon/components/rdfa/inline-component-manager.ts
+++ b/addon/components/rdfa/inline-component-manager.ts
@@ -5,6 +5,7 @@ import { ActiveComponentEntry } from '@lblod/ember-rdfa-editor/core/model/inline
 import { ModelInlineComponent } from '@lblod/ember-rdfa-editor/core/model/inline-components/model-inline-component';
 import { tracked } from '@glimmer/tracking';
 import { isOperationStep } from '@lblod/ember-rdfa-editor/core/state/steps/step';
+import { action } from '@ember/object';
 
 interface InlineComponentManagerArgs {
   controller: Controller;
@@ -12,12 +13,21 @@ interface InlineComponentManagerArgs {
 
 export default class InlineComponentManager extends Component<InlineComponentManagerArgs> {
   @tracked inlineComponents: ActiveComponentEntry[] = [];
-  constructor(parent: unknown, args: InlineComponentManagerArgs) {
-    super(parent, args);
+
+  @action
+  didInsert() {
     this.args.controller.addTransactionDispatchListener(
       this.updateInlineComponents.bind(this)
     );
     this.refreshInlineComponents();
+  }
+
+  @action
+  willDestroy(): void {
+    this.args.controller.removeTransactionDispatchListener(
+      this.updateInlineComponents.bind(this)
+    );
+    super.willDestroy();
   }
 
   updateInlineComponents(transaction: Transaction) {

--- a/addon/components/rdfa/inline-component-manager.ts
+++ b/addon/components/rdfa/inline-component-manager.ts
@@ -17,15 +17,20 @@ export default class InlineComponentManager extends Component<InlineComponentMan
     this.args.controller.addTransactionDispatchListener(
       this.updateInlineComponents.bind(this)
     );
+    this.refreshInlineComponents();
   }
 
   updateInlineComponents(transaction: Transaction) {
     if (transaction.steps.some((step) => isOperationStep(step))) {
-      const inlineComponentsMap =
-        this.args.controller?.currentState.inlineComponentsRegistry
-          .activeComponents ||
-        new Map<ModelInlineComponent, ActiveComponentEntry>();
-      this.inlineComponents = [...inlineComponentsMap.values()];
+      this.refreshInlineComponents();
     }
+  }
+
+  refreshInlineComponents() {
+    const inlineComponentsMap =
+      this.args.controller?.currentState.inlineComponentsRegistry
+        .activeComponents ||
+      new Map<ModelInlineComponent, ActiveComponentEntry>();
+    this.inlineComponents = [...inlineComponentsMap.values()];
   }
 }

--- a/addon/plugins/show-active-rdfa/show-active-rdfa.ts
+++ b/addon/plugins/show-active-rdfa/show-active-rdfa.ts
@@ -2,7 +2,6 @@ import ConfigStep from '@lblod/ember-rdfa-editor/core/state/steps/config-step';
 import {
   isConfigStep,
   isSelectionStep,
-  Step,
 } from '@lblod/ember-rdfa-editor/core/state/steps/step';
 import Transaction from '@lblod/ember-rdfa-editor/core/state/transaction';
 import Controller from '@lblod/ember-rdfa-editor/core/controllers/controller';


### PR DESCRIPTION
This PR ensures that the ember inline components are loaded on startup of the editor. Fixes https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4/backlog?view=detail&selectedIssue=GN-3675&issueLimit=100