### PR TITLE
Fix: view to model behaviour

### DIFF
--- a/addon/core/view/index.ts
+++ b/addon/core/view/index.ts
@@ -211,8 +211,14 @@ export function viewToModel(
   if (domNode === viewRoot) {
     return state.document;
   }
+
   const position = domPosToModelPos(state, viewRoot, domNode, 0);
-  const node = position.nodeAfter();
+  let node : ModelNode | null;
+  if (position.path.length === 0) {
+    node = position.root;
+  } else {
+    node = position.parent.childAtOffset(position.parentOffset, true);
+  }
   if (!node) {
     throw new PositionError('no node found after position');
   }

--- a/addon/core/view/index.ts
+++ b/addon/core/view/index.ts
@@ -213,7 +213,7 @@ export function viewToModel(
   }
 
   const position = domPosToModelPos(state, viewRoot, domNode, 0);
-  let node : ModelNode | null;
+  let node: ModelNode | null;
   if (position.path.length === 0) {
     node = position.root;
   } else {

--- a/tests/unit/model/model-element-test.ts
+++ b/tests/unit/model/model-element-test.ts
@@ -3,7 +3,6 @@ import ModelText from '@lblod/ember-rdfa-editor/core/model/nodes/model-text';
 import { vdom } from '@lblod/ember-rdfa-editor/utils/xml-utils';
 import { IndexOutOfRangeError } from '@lblod/ember-rdfa-editor/utils/errors';
 import { module, test } from 'qunit';
-import ModelPosition from '@lblod/ember-rdfa-editor/core/model/model-position';
 
 module('Unit | model | model-element-test', function () {
   module('Unit | model | model-element-test | offsetToIndex', function () {

--- a/tests/unit/model/model-element-test.ts
+++ b/tests/unit/model/model-element-test.ts
@@ -3,6 +3,7 @@ import ModelText from '@lblod/ember-rdfa-editor/core/model/nodes/model-text';
 import { vdom } from '@lblod/ember-rdfa-editor/utils/xml-utils';
 import { IndexOutOfRangeError } from '@lblod/ember-rdfa-editor/utils/errors';
 import { module, test } from 'qunit';
+import ModelPosition from '@lblod/ember-rdfa-editor/core/model/model-position';
 
 module('Unit | model | model-element-test', function () {
   module('Unit | model | model-element-test | offsetToIndex', function () {
@@ -68,6 +69,13 @@ module('Unit | model | model-element-test', function () {
       assert.strictEqual(div.offsetToIndex(3), 1);
       assert.strictEqual(div.offsetToIndex(4), 2);
       assert.strictEqual(div.offsetToIndex(5), 3);
+    });
+    test('two empty text children', function (assert) {
+      const div = new ModelElement('div');
+      const text1 = new ModelText('');
+      const text2 = new ModelText('');
+      div.appendChildren(text1, text2);
+      assert.strictEqual(div.offsetToIndex(0), 2);
     });
   });
 
@@ -224,6 +232,22 @@ module('Unit | model | model-element-test', function () {
         child.getVocab(),
         'http://mu.semte.ch/vocabularies/core/'
       );
+    });
+  });
+  module('Unit | model | model-element-test | childAtOffset', function () {
+    test('two empty text children - includeLast = false', function (assert) {
+      const div = new ModelElement('div');
+      const text1 = new ModelText('');
+      const text2 = new ModelText('');
+      div.appendChildren(text1, text2);
+      assert.strictEqual(div.childAtOffset(0, false), null);
+    });
+    test('two empty text children - includeLast = true', function (assert) {
+      const div = new ModelElement('div');
+      const text1 = new ModelText('');
+      const text2 = new ModelText('');
+      div.appendChildren(text1, text2);
+      assert.strictEqual(div.childAtOffset(0, true), text2);
     });
   });
 });

--- a/tests/unit/model/model-position-test.ts
+++ b/tests/unit/model/model-position-test.ts
@@ -849,4 +849,14 @@ module('Unit | model | model-position', function () {
       assert.true(oneRight.sameAs(shiftedRight), shiftedRight.path.toString());
     });
   });
+  module('Unit | model | model-position | nodeAfter', () => {
+    test('two empty text nodes', function (assert) {
+      const div = new ModelElement('div');
+      const text1 = new ModelText('');
+      const text2 = new ModelText('');
+      div.appendChildren(text1, text2);
+      const pos = ModelPosition.fromBeforeNode(text1);
+      assert.strictEqual(pos.nodeAfter(), null);
+    });
+  });
 });


### PR DESCRIPTION
This PR modifies the behaviour of viewToModel in order to ensure that the last child of a parent is selected when the offset is equal to the maxOffset of the parent.

Solves https://binnenland.atlassian.net/browse/GN-3677?atlOrigin=eyJpIjoiZmE5NzlhYmJmNGZhNGJhODk0YTRlOTMxYjNlY2FjZGQiLCJwIjoiaiJ9.