### PR TITLE
Chore/cleanup feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,8 @@ module.exports = function(environment) {
 };
 ```
 
-* editor-html-paste: if enabled, support html paste input
-* editor-extended-html-paste: if enabled, support extended html paste input (old behavior)
-* editor-force-paragraph: if enabled, wrap text input in a paragraph if it's not already wrapped.
+* editor-html-paste: if enabled, support html paste input. defaults to true
+* editor-extended-html-paste: if enabled, support extended html paste input (old behavior). defaults to false
 
 ## Styling
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -4,18 +4,11 @@ module.exports = function (environment) {
   var ENV = {
     featureFlags: {
       'editor-html-paste': true,
+      'editor-extended-html-paste': false,
       'editor-cut': true,
       'editor-copy': true,
     },
   };
-
-  if (environment === 'development') {
-    ENV.featureFlags['editor-extended-html-paste'] = true;
-  }
-
-  if (environment === 'production') {
-    ENV.featureFlags['editor-html-paste'] = false;
-  }
 
   return ENV;
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -4,10 +4,8 @@ module.exports = function (environment) {
   var ENV = {
     featureFlags: {
       'editor-html-paste': true,
-      'editor-force-paragraph': false,
       'editor-cut': true,
       'editor-copy': true,
-      'editor-browser-delete': false,
     },
   };
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (environment) {
+module.exports = function (/* environment */) {
   var ENV = {
     featureFlags: {
       'editor-html-paste': true,


### PR DESCRIPTION
drop unused feature flags and be more consistent about the other ones. we should probably also consider:
- dropping the cut and copy feature flags
- moving extended html vs  html vs text paste to a config of the editor and not a feature flag