### PR TITLE
Ensure dom nodes are correctly converted to model nodes

### DIFF
--- a/addon/core/view/index.ts
+++ b/addon/core/view/index.ts
@@ -212,7 +212,7 @@ export function viewToModel(
     return state.document;
   }
 
-  const position = domPosToModelPos(state, viewRoot, domNode, 0);
+  const position = domPosToModelPos(state, viewRoot, domNode);
   let node: ModelNode | null;
   if (position.path.length === 0) {
     node = position.root;

--- a/addon/utils/dom-helpers.ts
+++ b/addon/utils/dom-helpers.ts
@@ -617,7 +617,8 @@ export function domPosToModelPos(
       cur = cur.children[index];
     }
   }
-  if (!(offset == null)) {
+  if (!(offset === null || offset === undefined)) {
+    // offset may not be null or undefined but can be 0
     const modelOffset = domOffsetToModelOffset(state, offset, container);
     if (ModelNode.isModelText(cur) || cur.isLeaf) {
       offsetPath[offsetPath.length - 1] = cur.getOffset() + modelOffset;

--- a/addon/utils/dom-helpers.ts
+++ b/addon/utils/dom-helpers.ts
@@ -583,7 +583,7 @@ export function domPosToModelPos(
   state: State,
   viewRoot: Element,
   container: Node,
-  offset: number
+  offset?: number
 ): ModelPosition {
   // get the path of dom index to the container node
   const path = getPositionPathFromAncestor(viewRoot, container);
@@ -617,16 +617,18 @@ export function domPosToModelPos(
       cur = cur.children[index];
     }
   }
-  const modelOffset = domOffsetToModelOffset(state, offset, container);
-  if (ModelNode.isModelText(cur) || cur.isLeaf) {
-    offsetPath[offsetPath.length - 1] = cur.getOffset() + modelOffset;
-  } else if (ModelNode.isModelElement(cur)) {
-    if (!cur.length) {
-      offsetPath.push(0);
-    } else if (cur.children.length > modelOffset) {
-      offsetPath.push(cur.children[modelOffset].getOffset());
-    } else {
-      offsetPath.push(cur.getMaxOffset());
+  if (!(offset == null)) {
+    const modelOffset = domOffsetToModelOffset(state, offset, container);
+    if (ModelNode.isModelText(cur) || cur.isLeaf) {
+      offsetPath[offsetPath.length - 1] = cur.getOffset() + modelOffset;
+    } else if (ModelNode.isModelElement(cur)) {
+      if (!cur.length) {
+        offsetPath.push(0);
+      } else if (cur.children.length > modelOffset) {
+        offsetPath.push(cur.children[modelOffset].getOffset());
+      } else {
+        offsetPath.push(cur.getMaxOffset());
+      }
     }
   }
 


### PR DESCRIPTION
This PR introduces some changes some changes in the `viewToModel` and `domPosToModelPos` methods. 
The `offset` parameter in `domPosToModelPos` is now optional. `viewToModel` now correctly maps a domNode to a modelNode.

This issue solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3705.