### PR TITLE
Fix: inline component selection issues

### DIFF
--- a/addon/commands/insert-component-command.ts
+++ b/addon/commands/insert-component-command.ts
@@ -3,15 +3,12 @@ import {
   Properties,
   State,
 } from '../core/model/inline-components/model-inline-component';
-import ModelElement from '../core/model/nodes/model-element';
 import ModelRange from '../core/model/model-range';
 import { ModelError } from '../utils/errors';
 import { logExecute } from '../utils/logging-utils';
 import Command, { CommandContext } from './command';
 import ModelText from '../core/model/nodes/model-text';
 import { INVISIBLE_SPACE } from '../utils/constants';
-import ModelNode from '../core/model/nodes/model-node';
-import ModelPosition from '../core/model/model-position';
 
 declare module '@lblod/ember-rdfa-editor' {
   export interface Commands {

--- a/addon/commands/insert-component-command.ts
+++ b/addon/commands/insert-component-command.ts
@@ -8,6 +8,10 @@ import ModelRange from '../core/model/model-range';
 import { ModelError } from '../utils/errors';
 import { logExecute } from '../utils/logging-utils';
 import Command, { CommandContext } from './command';
+import ModelText from '../core/model/nodes/model-text';
+import { INVISIBLE_SPACE } from '../utils/constants';
+import ModelNode from '../core/model/nodes/model-node';
+import ModelPosition from '../core/model/model-position';
 
 declare module '@lblod/ember-rdfa-editor' {
   export interface Commands {
@@ -53,14 +57,12 @@ export default class InsertComponentCommand
         props,
         componentState
       );
-      const newRange = transaction.insertNodes(range, component);
-      newRange.collapse();
-      if (!component.nextSibling) {
-        const brAfterComponent = new ModelElement('br');
-        brAfterComponent.setAttribute('class', 'trailing');
-        transaction.insertNodes(newRange, brAfterComponent);
-      }
-
+      const newRange = transaction.insertNodes(
+        range,
+        new ModelText(INVISIBLE_SPACE),
+        component,
+        new ModelText(INVISIBLE_SPACE)
+      );
       transaction.selectRange(newRange);
       if (createSnapshot) {
         transaction.createSnapshot();

--- a/addon/commands/insert-component-command.ts
+++ b/addon/commands/insert-component-command.ts
@@ -20,7 +20,7 @@ export interface InsertComponentCommandArgs {
   props?: Properties;
   componentState?: State;
   createSnapshot?: boolean;
-  range: ModelRange | null;
+  range?: ModelRange | null;
 }
 
 export default class InsertComponentCommand

--- a/addon/core/model/model-position.ts
+++ b/addon/core/model/model-position.ts
@@ -85,6 +85,8 @@ export default class ModelPosition {
       return ModelPosition.fromInTextNode(node, offset);
     } else if (ModelNode.isModelElement(node)) {
       return ModelPosition.fromInElement(node, offset);
+    } else if (ModelNode.isModelInlineComponent(node)) {
+      return ModelPosition.fromBeforeNode(node);
     } else {
       throw new NotImplementedError('Unsupported node type');
     }

--- a/addon/input/input-handler.ts
+++ b/addon/input/input-handler.ts
@@ -6,7 +6,10 @@ import {
 } from '@lblod/ember-rdfa-editor/input/insert';
 import { mapKeyEvent } from '@lblod/ember-rdfa-editor/input/keymap';
 import SelectionReader from '@lblod/ember-rdfa-editor/core/model/readers/selection-reader';
-import { getWindowSelection } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+import {
+  getWindowSelection,
+  isContentEditable,
+} from '@lblod/ember-rdfa-editor/utils/dom-helpers';
 import Controller from '../core/controllers/controller';
 import { NotImplementedError } from '../utils/errors';
 import { createLogger, Logger } from '../utils/logging-utils';
@@ -254,6 +257,9 @@ export class EditorInputHandler implements InputHandler {
     mutations: MutationRecord[],
     _observer: MutationObserver
   ) => {
+    mutations = mutations.filter((mutation) =>
+      isContentEditable(mutation.target)
+    );
     if (!mutations.length) {
       return;
     }

--- a/addon/utils/dom-helpers.ts
+++ b/addon/utils/dom-helpers.ts
@@ -173,6 +173,14 @@ export function isDisplayedAsBlock(domNode: Node): boolean {
   return displayStyle === 'block' || displayStyle === 'list-item';
 }
 
+export function isContentEditable(node: Node) {
+  if (isElement(node)) {
+    return node.isContentEditable;
+  } else {
+    return node.parentElement?.isContentEditable;
+  }
+}
+
 /**
  * Aggressive splitting specifically for content in an li.
  *

--- a/tests/dummy/app/components/inline-components/counter.hbs
+++ b/tests/dummy/app/components/inline-components/counter.hbs
@@ -1,0 +1,2 @@
+<AuButton type='button' {{on 'click' this.click}}>Increase</AuButton>
+<span>{{this.count}}</span>

--- a/tests/dummy/app/components/inline-components/counter.ts
+++ b/tests/dummy/app/components/inline-components/counter.ts
@@ -1,0 +1,22 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import InlineComponentController from '@lblod/ember-rdfa-editor/core/model/inline-components/inline-component-controller';
+
+type InlineComponentsCounterArgs = {
+  componentController: InlineComponentController;
+};
+
+export default class InlineComponentsCounter extends Component<InlineComponentsCounterArgs> {
+  get componentController() {
+    return this.args.componentController;
+  }
+
+  @action
+  click() {
+    this.componentController.setStateProperty('count', this.count + 1);
+  }
+
+  get count() {
+    return (this.componentController.getStateProperty('count') as number) || 0;
+  }
+}

--- a/tests/dummy/app/components/inline-components/dropdown.hbs
+++ b/tests/dummy/app/components/inline-components/dropdown.hbs
@@ -1,0 +1,9 @@
+<AuDropdown
+  @title={{this.title}}
+  @alignment='left'
+  typeof='reglementaireBijlage'
+>
+  {{#each this.articles as |article|}}
+    <AuLinkExternal role='menuitem'>{{article}}</AuLinkExternal>
+  {{/each}}
+</AuDropdown>

--- a/tests/dummy/app/components/inline-components/dropdown.ts
+++ b/tests/dummy/app/components/inline-components/dropdown.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class InlineComponentsDropdown extends Component {
+  get title() {
+    return 'Example Dropdown';
+  }
+
+  get articles() {
+    return [1, 2, 3, 4, 5, 6, 7].map((i) => `Article ${i}`);
+  }
+}

--- a/tests/dummy/app/components/rdfa-ic-plugin-insert.hbs
+++ b/tests/dummy/app/components/rdfa-ic-plugin-insert.hbs
@@ -1,0 +1,20 @@
+<AuList::Item>
+  <AuButton
+    @icon='add'
+    @iconAlignment='left'
+    @skin='link'
+    {{on 'click' this.insertCounter}}
+  >
+    Insert Counter
+  </AuButton>
+</AuList::Item>
+<AuList::Item>
+  <AuButton
+    @icon='add'
+    @iconAlignment='left'
+    @skin='link'
+    {{on 'click' this.insertDropdown}}
+  >
+    Insert Dropdown
+  </AuButton>
+</AuList::Item>

--- a/tests/dummy/app/components/rdfa-ic-plugin-insert.ts
+++ b/tests/dummy/app/components/rdfa-ic-plugin-insert.ts
@@ -1,0 +1,27 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import Controller from '@lblod/ember-rdfa-editor/core/controllers/controller';
+
+type RdfaIcPluginInsertComponentArgs = {
+  controller: Controller;
+};
+
+export default class RdfaIcPluginInsertComponent extends Component<RdfaIcPluginInsertComponentArgs> {
+  @action
+  insertCounter() {
+    this.args.controller.perform((transaction) => {
+      transaction.commands.insertComponent({
+        componentName: 'inline-components/counter',
+      });
+    });
+  }
+
+  @action
+  insertDropdown() {
+    this.args.controller.perform((transaction) => {
+      transaction.commands.insertComponent({
+        componentName: 'inline-components/dropdown',
+      });
+    });
+  }
+}

--- a/tests/dummy/app/testplugin/dummy-plugin.ts
+++ b/tests/dummy/app/testplugin/dummy-plugin.ts
@@ -7,6 +7,8 @@ import {
   createLogger,
   Logger,
 } from '@lblod/ember-rdfa-editor/utils/logging-utils';
+import CounterSpec from './models/inline-components/counter';
+import DropdownSpec from './models/inline-components/dropdown';
 
 export interface DummyPluginOptions {
   testKey: string;
@@ -43,6 +45,13 @@ export default class DummyPlugin implements EditorPlugin {
         });
       }
     });
+
+    controller.registerWidget({
+      componentName: 'rdfa-ic-plugin-insert',
+      desiredLocation: 'insertSidebar',
+    });
+    controller.registerInlineComponent(new CounterSpec(this.controller));
+    controller.registerInlineComponent(new DropdownSpec(this.controller));
   }
 
   get name(): string {

--- a/tests/dummy/app/testplugin/models/inline-components/counter.ts
+++ b/tests/dummy/app/testplugin/models/inline-components/counter.ts
@@ -1,0 +1,33 @@
+import Controller from '@lblod/ember-rdfa-editor/core/controllers/controller';
+import {
+  InlineComponentSpec,
+  Properties,
+  State,
+} from '@lblod/ember-rdfa-editor/core/model/inline-components/model-inline-component';
+import { isElement } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+
+export default class CounterSpec extends InlineComponentSpec {
+  matcher = {
+    tag: this.tag,
+    attributeBuilder: (node: Node) => {
+      if (isElement(node)) {
+        if (
+          node.classList.contains('inline-component') &&
+          node.classList.contains(this.name)
+        ) {
+          return {};
+        }
+      }
+      return null;
+    },
+  };
+  _renderStatic(_props: Properties, state: State) {
+    const count = state.count?.toString() || '0';
+    return `
+      <p>${count}</p>
+    `;
+  }
+  constructor(controller: Controller) {
+    super('inline-components/counter', 'span', controller);
+  }
+}

--- a/tests/dummy/app/testplugin/models/inline-components/dropdown.ts
+++ b/tests/dummy/app/testplugin/models/inline-components/dropdown.ts
@@ -1,0 +1,28 @@
+import Controller from '@lblod/ember-rdfa-editor/core/controllers/controller';
+import { InlineComponentSpec } from '@lblod/ember-rdfa-editor/core/model/inline-components/model-inline-component';
+import { isElement } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+
+export default class DropdownSpec extends InlineComponentSpec {
+  matcher = {
+    tag: this.tag,
+    attributeBuilder: (node: Node) => {
+      if (isElement(node)) {
+        if (
+          node.classList.contains('inline-component') &&
+          node.classList.contains(this.name)
+        ) {
+          return {};
+        }
+      }
+      return null;
+    },
+  };
+  _renderStatic() {
+    return `
+      <p>Dropdown</p>
+    `;
+  }
+  constructor(controller: Controller) {
+    super('inline-components/dropdown', 'span', controller);
+  }
+}


### PR DESCRIPTION
This PR includes changes to:
- the `fromInNode` method, it now takes into account inline components
- the `MutationObserver` handler, it now ignores mutation targets which are not content editable. (In order to ensure inline components are not taken into account)

This PR solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3706.