### PR TITLE
Enable html pasting by passing a property to the editor component

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,16 @@ To include the editor in a template (ember octane syntax) you can use the follow
     showListButtons="true" 
     showIndentButtons="true"
   }}
+  @pasteBehaviour='standard-html' {{! default is standard-html }}
 />
 ```
+
+The `pasteBehaviour` property can be one of three different values:
+- `textonly`: no structural html is kept
+- `standard-html`: structural html which is supported by the editor is kept intact
+- `full-html`: all structural html is kept intact
+
+The default default value for `pasteBehaviour` is `standard-html`.
 
 The callback provided to rdfaEditorInit is called when the editor element is inserted and provides an object with the following interface:
  - property `htmlContent`: a cleaned up (with as much as possible internal state remove) version of the htmlContent
@@ -64,33 +72,6 @@ You can pass basic options when you load the editor. Add a value of "true" to en
 - showTextStyleButtons: Show text styling buttons (bold, italic, underline, strikethrough)
 - showListButtons: Show list styling buttons (ordered list, unordered list)
 - showIndentButtons: Show indent buttons (indent, reverse indent)
-
-
-## Feature flags
-
-Some experimental features of the editor are hidden behind feature flags. They can be enabled for testing, but probably should not be enabled on a production system. 
-The flags can be set in the config/environment.js of your application.
-
-```javascript
-// config/environment.js
-module.exports = function(environment) {
-  var ENV = {
-    featureFlags: {
-      'editor-html-paste': true,
-    }
-  };
-
-  if (environment === 'production') {
-    ENV.featureFlags['editor-html-paste'] = false;
-  }
-
-  return ENV;
-};
-```
-
-* editor-html-paste: if enabled, support html paste input
-* editor-extended-html-paste: if enabled, support extended html paste input (old behavior)
-* editor-force-paragraph: if enabled, wrap text input in a paragraph if it's not already wrapped.
 
 ## Styling
 
@@ -299,4 +280,3 @@ created by [Ruben Taelman](https://github.com/rubensworks) and distributed under
 
 Due to unique requirements which would not benefit the original project we opted to make our modifications 
 in-house rather than contributing to the upstream.
-

--- a/addon/components/ce/content-editable.hbs
+++ b/addon/components/ce/content-editable.hbs
@@ -3,7 +3,6 @@
 <div
   {{did-insert this.insertedEditorElement}}
   {{will-destroy this.teardown}}
-  {{did-update this.initialize @plugins}}
   contenteditable='true'
   class={{@class}}
   ...attributes

--- a/addon/components/rdfa/rdfa-editor-with-debug.hbs
+++ b/addon/components/rdfa/rdfa-editor-with-debug.hbs
@@ -12,8 +12,8 @@
       </label>
       <select id="pasteSelect" {{on "input" this.setPasteBehaviour}}>
         <option value="textonly">text only</option>
-        <option value="limited">limited html</option>
-        <option value="full" selected>full html</option>
+        <option value="standard-html">standard html</option>
+        <option value="full-html" selected>full html</option>
       </select>
     </div>
     {{#if this.rdfaEditor}}
@@ -45,6 +45,7 @@
           @profile="default"
           @editorOptions={{@editorOptions}}
           @toolbarOptions={{@toolbarOptions}}
+          @pasteBehaviour={{this.pasteBehaviour}}
         />
       </div>
     </div>

--- a/addon/components/rdfa/rdfa-editor-with-debug.ts
+++ b/addon/components/rdfa/rdfa-editor-with-debug.ts
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
 import RdfaDocument from '@lblod/ember-rdfa-editor/core/controllers/rdfa-document';
 import xmlFormat from 'xml-formatter';
 import { basicSetup, EditorView } from 'codemirror';
@@ -9,11 +8,6 @@ import { xml } from '@codemirror/lang-xml';
 import { html } from '@codemirror/lang-html';
 import sampleData from '../../config/sample-data';
 import { EditorState } from '@codemirror/state';
-
-interface FeaturesService {
-  disable: (feature: string) => void;
-  enable: (feature: string) => void;
-}
 
 interface RdfaEditorDebugArgs {
   rdfaEditorInit: (rdfaDocument: RdfaDocument) => void;
@@ -24,7 +18,7 @@ export default class RdfaRdfaEditorWithDebug extends Component<RdfaEditorDebugAr
   @tracked debug: unknown;
   @tracked xmlDebuggerOpen = false;
   @tracked debuggerContent = '';
-  @service features!: FeaturesService;
+  @tracked pasteBehaviour = 'full-html';
   @tracked htmlDebuggerOpen = false;
   @tracked sampleData = sampleData;
   @tracked exportContent = '';
@@ -147,16 +141,7 @@ export default class RdfaRdfaEditorWithDebug extends Component<RdfaEditorDebugAr
   @action
   setPasteBehaviour(event: InputEvent) {
     const val = (event.target as HTMLSelectElement).value;
-    if (val === 'textonly') {
-      this.features.disable('editor-extended-html-paste');
-      this.features.disable('editor-html-paste');
-    } else if (val === 'limited') {
-      this.features.disable('editor-extended-html-paste');
-      this.features.enable('editor-html-paste');
-    } else if (val === 'full') {
-      this.features.enable('editor-extended-html-paste');
-      this.features.enable('editor-html-paste');
-    }
+    this.pasteBehaviour = val;
   }
 
   @action

--- a/addon/components/rdfa/rdfa-editor.hbs
+++ b/addon/components/rdfa/rdfa-editor.hbs
@@ -4,7 +4,7 @@
     {{if @editorOptions.showPaper "say-container--paper"}}
     {{if @editorOptions.showSidebar "say-container--sidebar-right"}}
     {{if @editorOptions.showToolbarBottom "say-container--toolbar-bottom"}}'
-  {{did-update this.updateProfile @profile}}
+  {{did-update (fn this.updateConfig 'pasteBehaviour' this.pasteBehaviour) @pasteBehaviour}}
 >
   {{#if this.toolbarController}}
     <Rdfa::EditorToolbar

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -25,6 +25,7 @@ import ListPlugin from '@lblod/ember-rdfa-editor/plugins/list/list';
 import RdfaConfirmationPlugin from '@lblod/ember-rdfa-editor/plugins/rdfa-confirmation/rdfa-confirmation';
 import { View } from '@lblod/ember-rdfa-editor/core/view';
 import { ViewController } from '@lblod/ember-rdfa-editor/core/controllers/view-controller';
+import { Serializable } from '@lblod/ember-rdfa-editor/utils/render-spec';
 
 export type PluginConfig =
   | string
@@ -48,6 +49,7 @@ interface RdfaEditorArgs {
 
   plugins: PluginConfig[];
   stealFocus?: boolean;
+  pasteBehaviour?: string;
 }
 
 /**
@@ -78,9 +80,6 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
   @tracked insertSidebarWidgets: InternalWidgetSpec[] = [];
   @tracked toolbarController: Controller | null = null;
   @tracked inlineComponentController: Controller | null = null;
-  // @tracked inlineComponents = tracked(
-  //   new Map<ModelInlineComponent, ActiveComponentEntry>()
-  // );
 
   @tracked editorLoading = true;
   private owner: ApplicationInstance;
@@ -92,6 +91,10 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
 
   get editorPlugins(): ResolvedPluginConfig[] {
     return this.getPlugins();
+  }
+
+  get pasteBehaviour() {
+    return this.args.pasteBehaviour ?? 'standard-html';
   }
 
   /**
@@ -134,6 +137,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
     );
     const rdfaDocument = new RdfaDocumentController('host', view);
     window.__EDITOR = new RdfaDocumentController('debug', view);
+    this.updateConfig('pasteBehaviour', this.pasteBehaviour);
     if (this.args.rdfaEditorInit) {
       this.args.rdfaEditorInit(rdfaDocument);
     }
@@ -183,6 +187,15 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
     } else {
       this.showRdfaBlocks = false;
       this.toolbarController!.setConfig('showRdfaBlocks', null);
+    }
+  }
+
+  @action
+  updateConfig(key: string, value: Serializable) {
+    if (this.controller) {
+      this.controller.perform((tr) => {
+        tr.setConfig(key, value.toString());
+      });
     }
   }
 }

--- a/addon/input/input-handler.ts
+++ b/addon/input/input-handler.ts
@@ -116,13 +116,15 @@ export class EditorInputHandler implements InputHandler {
     event.preventDefault();
   };
 
-  paste = (
-    event: ClipboardEvent,
-    pasteHTML?: boolean,
-    pasteExtendedHTML?: boolean
-  ) => {
+  paste = (event: ClipboardEvent) => {
     event.preventDefault();
-    handlePaste(this.inputController, event, pasteHTML, pasteExtendedHTML);
+    const pasteBehaviour = this.inputController.getConfig('pasteBehaviour');
+    handlePaste(
+      this.inputController,
+      event,
+      pasteBehaviour === 'standard-html' || pasteBehaviour === 'full-html',
+      pasteBehaviour === 'full-html'
+    );
   };
 
   cut = (event: ClipboardEvent) => {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,23 +1,5 @@
 'use strict';
 
-module.exports = function (environment) {
-  var ENV = {
-    featureFlags: {
-      'editor-html-paste': true,
-      'editor-force-paragraph': false,
-      'editor-cut': true,
-      'editor-copy': true,
-      'editor-browser-delete': false,
-    },
-  };
-
-  if (environment === 'development') {
-    ENV.featureFlags['editor-extended-html-paste'] = true;
-  }
-
-  if (environment === 'production') {
-    ENV.featureFlags['editor-html-paste'] = false;
-  }
-
-  return ENV;
+module.exports = function () {
+  return {};
 };


### PR DESCRIPTION
This PR enables HTML Pasting for the TEDI API. Users can pass a `pasteBehaviour` argument to the editor component.
This property can be one of three values:
- `textonly`
- `standard-html`
- `full-html`
The default value is `standard-html` (only keep html structures which are supported by the editor).