### PR TITLE
Fix issue with computing differences on transaction dispatch 

### DIFF
--- a/addon/components/rdfa/editor-toolbar.ts
+++ b/addon/components/rdfa/editor-toolbar.ts
@@ -40,12 +40,12 @@ export default class EditorToolbar extends Component<Args> {
 
   @action
   didInsert() {
-    this.args.controller.addTransactionStepListener(this.update.bind(this));
+    this.args.controller.addTransactionStepListener(this.update);
   }
 
   @action
   willDestroy(): void {
-    this.args.controller.removeTransactionStepListener(this.update.bind(this));
+    this.args.controller.removeTransactionStepListener(this.update);
     super.willDestroy();
   }
 
@@ -57,11 +57,11 @@ export default class EditorToolbar extends Component<Args> {
     return steps.some((step) => isSelectionStep(step) || isOperationStep(step));
   }
 
-  update(transaction: Transaction, steps: Step[]) {
+  update = (transaction: Transaction, steps: Step[]) => {
     if (this.modifiesSelection(steps)) {
       this.updateProperties(transaction);
     }
-  }
+  };
 
   updateProperties(transaction: Transaction) {
     const {

--- a/addon/components/rdfa/editor-toolbar.ts
+++ b/addon/components/rdfa/editor-toolbar.ts
@@ -40,12 +40,12 @@ export default class EditorToolbar extends Component<Args> {
 
   @action
   didInsert() {
-    this.args.controller.addTransactionStepListener(this.update);
+    this.args.controller.addTransactionDispatchListener(this.update);
   }
 
   @action
   willDestroy(): void {
-    this.args.controller.removeTransactionStepListener(this.update);
+    this.args.controller.removeTransactionDispatchListener(this.update);
     super.willDestroy();
   }
 
@@ -57,8 +57,8 @@ export default class EditorToolbar extends Component<Args> {
     return steps.some((step) => isSelectionStep(step) || isOperationStep(step));
   }
 
-  update = (transaction: Transaction, steps: Step[]) => {
-    if (this.modifiesSelection(steps)) {
+  update = (transaction: Transaction) => {
+    if (this.modifiesSelection(transaction.steps)) {
       this.updateProperties(transaction);
     }
   };

--- a/addon/components/rdfa/inline-component-manager.ts
+++ b/addon/components/rdfa/inline-component-manager.ts
@@ -17,7 +17,7 @@ export default class InlineComponentManager extends Component<InlineComponentMan
   @action
   didInsert() {
     this.args.controller.addTransactionDispatchListener(
-      this.updateInlineComponents.bind(this)
+      this.updateInlineComponents
     );
     this.refreshInlineComponents();
   }
@@ -25,16 +25,16 @@ export default class InlineComponentManager extends Component<InlineComponentMan
   @action
   willDestroy(): void {
     this.args.controller.removeTransactionDispatchListener(
-      this.updateInlineComponents.bind(this)
+      this.updateInlineComponents
     );
     super.willDestroy();
   }
 
-  updateInlineComponents(transaction: Transaction) {
+  updateInlineComponents = (transaction: Transaction) => {
     if (transaction.steps.some((step) => isOperationStep(step))) {
       this.refreshInlineComponents();
     }
-  }
+  };
 
   refreshInlineComponents() {
     const inlineComponentsMap =

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -136,9 +136,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
     if (this.args.rdfaEditorInit) {
       this.args.rdfaEditorInit(rdfaDocument);
     }
-    this.controller.addTransactionDispatchListener(
-      this.onTransactionDispatch.bind(this)
-    );
+    this.controller.addTransactionDispatchListener(this.onTransactionDispatch);
     this.editorLoading = false;
   }
 
@@ -197,11 +195,11 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
     }
   }
 
-  onTransactionDispatch(transaction: Transaction) {
+  onTransactionDispatch = (transaction: Transaction) => {
     if (transaction.steps.some((step) => isPluginStep(step))) {
       this.updateWidgets();
     }
-  }
+  };
 
   updateWidgets() {
     if (this.controller) {

--- a/addon/core/controllers/controller.ts
+++ b/addon/core/controllers/controller.ts
@@ -80,7 +80,7 @@ export default interface Controller {
 
   dryRun<R>(action: (transaction: Transaction) => R): R;
 
-  dispatchTransaction(tr: Transaction, updateView?: boolean): void;
+  dispatchTransaction(tr: Transaction): void;
 
   modelToView(node: ModelNode): Node | null;
 

--- a/addon/core/state/index.ts
+++ b/addon/core/state/index.ts
@@ -67,8 +67,8 @@ export interface StateArgs {
   document: ModelElement;
   selection: ModelSelection;
   plugins: InitializedPlugin[];
-  transactionStepListeners: TransactionStepListener[];
-  transactionDispatchListeners: TransactionDispatchListener[];
+  transactionStepListeners: Set<TransactionStepListener>;
+  transactionDispatchListeners: Set<TransactionDispatchListener>;
   commands: Partial<Commands>;
   marksRegistry: MarksRegistry;
   marksManager: MarksManager;
@@ -118,8 +118,8 @@ export default interface State {
 
   eventBus: EventBus;
   config: Map<string, string | null>;
-  transactionStepListeners: TransactionStepListener[];
-  transactionDispatchListeners: TransactionDispatchListener[];
+  transactionStepListeners: Set<TransactionStepListener>;
+  transactionDispatchListeners: Set<TransactionDispatchListener>;
 }
 
 export class SayState implements State {
@@ -132,8 +132,8 @@ export class SayState implements State {
   marksManager: MarksManager;
   inlineComponentsRegistry: InlineComponentsRegistry;
   eventBus: EventBus;
-  transactionStepListeners: TransactionStepListener[];
-  transactionDispatchListeners: TransactionDispatchListener[];
+  transactionStepListeners: Set<TransactionStepListener>;
+  transactionDispatchListeners: Set<TransactionDispatchListener>;
   /**
    * The previous "relevant" state. This is not necessarily
    * the state directly preceding this one. It is up to the discretion
@@ -262,8 +262,8 @@ export function emptyState(eventBus = new EventBus()): State {
     baseIRI: 'http://example.org',
     eventBus,
     keymap: defaultKeyMap,
-    transactionStepListeners: [],
-    transactionDispatchListeners: [],
+    transactionStepListeners: new Set(),
+    transactionDispatchListeners: new Set(),
   });
 }
 
@@ -313,8 +313,8 @@ export function createState({
   pathFromDomRoot = [],
   baseIRI = window.document.baseURI,
   keymap = defaultKeyMap,
-  transactionStepListeners: transactionStepListeners = [],
-  transactionDispatchListeners: transactionDispatchListeners = [],
+  transactionStepListeners: transactionStepListeners = new Set(),
+  transactionDispatchListeners: transactionDispatchListeners = new Set(),
 }: InitialStateArgs): State {
   return new SayState({
     document,

--- a/addon/core/state/transaction.ts
+++ b/addon/core/state/transaction.ts
@@ -177,26 +177,19 @@ export default class Transaction {
   }
 
   addTransactionStepListener(listener: TransactionStepListener) {
-    this._workingCopy.transactionStepListeners.push(listener);
+    this._workingCopy.transactionStepListeners.add(listener);
   }
 
   removeTransactionStepListener(listener: TransactionStepListener) {
-    const index = this._workingCopy.transactionStepListeners.indexOf(listener);
-    if (index !== -1) {
-      this._workingCopy.transactionStepListeners.splice(index, 1);
-    }
+    this._workingCopy.transactionStepListeners.delete(listener);
   }
 
   addTransactionDispatchListener(listener: TransactionDispatchListener) {
-    this._workingCopy.transactionDispatchListeners.push(listener);
+    this._workingCopy.transactionDispatchListeners.add(listener);
   }
 
   removeTransactionDispatchListener(listener: TransactionDispatchListener) {
-    const index =
-      this._workingCopy.transactionDispatchListeners.indexOf(listener);
-    if (index !== -1) {
-      this._workingCopy.transactionDispatchListeners.splice(index, 1);
-    }
+    this._workingCopy.transactionDispatchListeners.delete(listener);
   }
 
   addMark(range: ModelRange, spec: MarkSpec, attributes: AttributeSpec) {

--- a/addon/core/state/transaction.ts
+++ b/addon/core/state/transaction.ts
@@ -67,8 +67,8 @@ export default class Transaction {
   rangeMapper: RangeMapper;
   // we clone the nodes, so rdfa is invalid even if nothing happens to them
   // TODO: improve this
-  rdfInvalid = true;
-  marksInvalid = true;
+  rdfInvalid = false;
+  marksInvalid = false;
   logger = createLogger('transaction');
   private _commandCache?: CommandExecutor;
 
@@ -126,6 +126,8 @@ export default class Transaction {
           this.initialState.document,
           documentClone
         );
+      this.rdfInvalid = true;
+      this.marksInvalid = true;
     }
   }
 
@@ -363,10 +365,6 @@ export default class Transaction {
   }
 
   selectRange(range: ModelRange): void {
-    // const op = new SelectionOperation(undefined, this._workingCopy.selection, [
-    //   this.cloneRange(range),
-    // ]);
-    // this.executeOperation(op);
     const clone = this.cloneSelection(this.workingCopy.selection);
     clone.selectRange(range, clone.isRightToLeft);
     clone.isRightToLeft = this.workingCopy.selection.isRightToLeft;

--- a/addon/core/view/index.ts
+++ b/addon/core/view/index.ts
@@ -145,27 +145,11 @@ export class EditorView implements View {
     const newState = transaction.apply();
 
     let differences: Difference[] = [];
-    // we can only optimize for browserdefault flow if
-    // no listeners added any steps
     if (calculateDiffs || listenersAddedSteps) {
-      // Ensure that the document we compare with corresponds correctly to the current DOM
-      const parsedNodes = readHtml(
-        this.domRoot,
-        new HtmlReaderContext({
-          inlineComponentsRegistry:
-            transaction.workingCopy.inlineComponentsRegistry,
-          marksRegistry: transaction.workingCopy.marksRegistry,
-        })
+      differences = computeDifference(
+        this.currentState.document,
+        newState.document
       );
-      if (parsedNodes.length !== 1) {
-        throw new NotImplementedError();
-      }
-      const currentDocument = parsedNodes[0];
-      if (!ModelNode.isModelElement(currentDocument)) {
-        throw new NotImplementedError();
-      }
-      // const currentDocument = this.currentState.document;
-      differences = computeDifference(currentDocument, newState.document);
     }
     this.currentState = newState;
     this.update(this.currentState, differences, transaction.shouldFocus);

--- a/addon/core/view/index.ts
+++ b/addon/core/view/index.ts
@@ -9,7 +9,7 @@ import {
   isTextNode,
   modelPosToDomPos,
 } from '../../utils/dom-helpers';
-import { NotImplementedError, PositionError } from '../../utils/errors';
+import { PositionError } from '../../utils/errors';
 import { createLogger, Logger } from '../../utils/logging-utils';
 import Transaction from '../state/transaction';
 import {
@@ -18,7 +18,6 @@ import {
 } from '@lblod/ember-rdfa-editor/input/input-handler';
 import { ViewController } from '@lblod/ember-rdfa-editor/core/controllers/view-controller';
 import { ResolvedPluginConfig } from '@lblod/ember-rdfa-editor/components/rdfa/rdfa-editor';
-import { readHtml, HtmlReaderContext } from '../model/readers/html-reader';
 
 export type Dispatch = (transaction: Transaction) => void;
 

--- a/addon/core/view/index.ts
+++ b/addon/core/view/index.ts
@@ -148,6 +148,7 @@ export class EditorView implements View {
     // we can only optimize for browserdefault flow if
     // no listeners added any steps
     if (calculateDiffs || listenersAddedSteps) {
+      // Ensure that the document we compare with corresponds correctly to the current DOM
       const parsedNodes = readHtml(
         this.domRoot,
         new HtmlReaderContext({

--- a/addon/core/view/index.ts
+++ b/addon/core/view/index.ts
@@ -119,26 +119,27 @@ export class EditorView implements View {
     // notify listeners while there are new operations added to the transaction
     let newSteps = transaction.size > 0;
     const handledSteps = new Array<number>(
-      transaction.workingCopy.transactionStepListeners.length
+      transaction.workingCopy.transactionStepListeners.size
     ).fill(0);
+    const transactionStepListenersArray = [
+      ...transaction.workingCopy.transactionStepListeners,
+    ];
     // keep track if any listeners added any steps at all
     let listenersAddedSteps = false;
     while (newSteps) {
       newSteps = false;
-      transaction.workingCopy.transactionStepListeners.forEach(
-        (listener, i) => {
-          const oldTransactionSize = transaction.size;
-          if (handledSteps[i] < transaction.size) {
-            // notify listener of new operations
-            listener(transaction, transaction.steps.slice(handledSteps[i]));
-            handledSteps[i] = transaction.size;
-          }
-          if (transaction.size > oldTransactionSize) {
-            newSteps = true;
-            listenersAddedSteps = true;
-          }
+      transactionStepListenersArray.forEach((listener, i) => {
+        const oldTransactionSize = transaction.size;
+        if (handledSteps[i] < transaction.size) {
+          // notify listener of new operations
+          listener(transaction, transaction.steps.slice(handledSteps[i]));
+          handledSteps[i] = transaction.size;
         }
-      );
+        if (transaction.size > oldTransactionSize) {
+          newSteps = true;
+          listenersAddedSteps = true;
+        }
+      });
     }
     const newState = transaction.apply();
     const differences =

--- a/addon/core/view/index.ts
+++ b/addon/core/view/index.ts
@@ -9,7 +9,7 @@ import {
   isTextNode,
   modelPosToDomPos,
 } from '../../utils/dom-helpers';
-import { PositionError } from '../../utils/errors';
+import { NotImplementedError, PositionError } from '../../utils/errors';
 import { createLogger, Logger } from '../../utils/logging-utils';
 import Transaction from '../state/transaction';
 import {
@@ -18,6 +18,7 @@ import {
 } from '@lblod/ember-rdfa-editor/input/input-handler';
 import { ViewController } from '@lblod/ember-rdfa-editor/core/controllers/view-controller';
 import { ResolvedPluginConfig } from '@lblod/ember-rdfa-editor/components/rdfa/rdfa-editor';
+import { readHtml, HtmlReaderContext } from '../model/readers/html-reader';
 
 export type Dispatch = (transaction: Transaction) => void;
 
@@ -142,12 +143,29 @@ export class EditorView implements View {
       });
     }
     const newState = transaction.apply();
-    const differences =
-      // we can only optimize for browserdefault flow if
-      // no listeners added any steps
-      calculateDiffs || listenersAddedSteps
-        ? computeDifference(this.currentState.document, newState.document)
-        : [];
+
+    let differences: Difference[] = [];
+    // we can only optimize for browserdefault flow if
+    // no listeners added any steps
+    if (calculateDiffs || listenersAddedSteps) {
+      const parsedNodes = readHtml(
+        this.domRoot,
+        new HtmlReaderContext({
+          inlineComponentsRegistry:
+            transaction.workingCopy.inlineComponentsRegistry,
+          marksRegistry: transaction.workingCopy.marksRegistry,
+        })
+      );
+      if (parsedNodes.length !== 1) {
+        throw new NotImplementedError();
+      }
+      const currentDocument = parsedNodes[0];
+      if (!ModelNode.isModelElement(currentDocument)) {
+        throw new NotImplementedError();
+      }
+      // const currentDocument = this.currentState.document;
+      differences = computeDifference(currentDocument, newState.document);
+    }
     this.currentState = newState;
     this.update(this.currentState, differences, transaction.shouldFocus);
     this.currentState.transactionDispatchListeners.forEach((listener) => {

--- a/addon/input/insert.ts
+++ b/addon/input/insert.ts
@@ -19,15 +19,13 @@ export function handleInsertText(
   controller: Controller,
   event: InputEvent
 ): void {
-  if (controller.selection.activeMarks.size !== 0) {
-    event.preventDefault();
-    controller.perform((tr) => {
-      tr.commands.insertText({
-        range: controller.selection.lastRange!,
-        text: event.data ?? '',
-      });
+  event.preventDefault();
+  controller.perform((tr) => {
+    tr.commands.insertText({
+      range: controller.selection.lastRange!,
+      text: event.data ?? '',
     });
-  }
+  });
 }
 
 export function handleInsertListItem(

--- a/addon/input/keymap.ts
+++ b/addon/input/keymap.ts
@@ -114,7 +114,8 @@ function moveCursor(steps: number) {
       const resultRange = new ModelRange(newPosition);
       const tr = controller.createTransaction();
       tr.selectRange(resultRange);
-      controller.dispatchTransaction(tr);
+      controller.view.stateOnlyDispatch(tr);
+      // controller.dispatchTransaction(tr);
     }
   };
 }

--- a/addon/plugins/show-active-rdfa/show-active-rdfa.ts
+++ b/addon/plugins/show-active-rdfa/show-active-rdfa.ts
@@ -25,12 +25,10 @@ export default class ShowActiveRdfaPlugin implements EditorPlugin {
   // eslint-disable-next-line @typescript-eslint/require-await
   async initialize(_transaction: Transaction, controller: Controller) {
     this.controller = controller;
-    controller.addTransactionDispatchListener(
-      this.onTransactionDispatch.bind(this)
-    );
+    controller.addTransactionDispatchListener(this.onTransactionDispatch);
   }
 
-  onTransactionDispatch(transaction: Transaction) {
+  onTransactionDispatch = (transaction: Transaction) => {
     const configSteps: ConfigStep[] = transaction.steps.filter(
       (step) => isConfigStep(step) && step.key === 'showRdfaBlocks'
     ) as ConfigStep[];
@@ -46,7 +44,7 @@ export default class ShowActiveRdfaPlugin implements EditorPlugin {
     if (transaction.steps.some(isSelectionStep)) {
       this.updateAttributes();
     }
-  }
+  };
 
   updateAttributes() {
     removePathAttributes();

--- a/tests/dummy/app/components/code-mark-plugin/toolbar-button.ts
+++ b/tests/dummy/app/components/code-mark-plugin/toolbar-button.ts
@@ -18,12 +18,12 @@ export default class InlineComponentsCounter extends Component<Args> {
 
   @action
   didInsert() {
-    this.args.controller.addTransactionStepListener(this.update);
+    this.args.controller.addTransactionDispatchListener(this.update);
   }
 
   @action
   willDestroy(): void {
-    this.args.controller.removeTransactionStepListener(this.update);
+    this.args.controller.removeTransactionDispatchListener(this.update);
     super.willDestroy();
   }
 
@@ -35,8 +35,8 @@ export default class InlineComponentsCounter extends Component<Args> {
     return steps.some((step) => isSelectionStep(step) || isOperationStep(step));
   }
 
-  update = (transaction: Transaction, steps: Step[]) => {
-    if (this.modifiesSelection(steps)) {
+  update = (transaction: Transaction) => {
+    if (this.modifiesSelection(transaction.steps)) {
       this.updateProperties(transaction);
     }
   };

--- a/tests/dummy/app/components/code-mark-plugin/toolbar-button.ts
+++ b/tests/dummy/app/components/code-mark-plugin/toolbar-button.ts
@@ -18,12 +18,12 @@ export default class InlineComponentsCounter extends Component<Args> {
 
   @action
   didInsert() {
-    this.args.controller.addTransactionStepListener(this.update.bind(this));
+    this.args.controller.addTransactionStepListener(this.update);
   }
 
   @action
   willDestroy(): void {
-    this.args.controller.removeTransactionStepListener(this.update.bind(this));
+    this.args.controller.removeTransactionStepListener(this.update);
     super.willDestroy();
   }
 
@@ -35,11 +35,11 @@ export default class InlineComponentsCounter extends Component<Args> {
     return steps.some((step) => isSelectionStep(step) || isOperationStep(step));
   }
 
-  update(transaction: Transaction, steps: Step[]) {
+  update = (transaction: Transaction, steps: Step[]) => {
     if (this.modifiesSelection(steps)) {
       this.updateProperties(transaction);
     }
-  }
+  };
 
   updateProperties(transaction: Transaction) {
     const { currentSelection: selection } = transaction;

--- a/tests/dummy/app/dummy-plugins/highlight-plugin/highlight-plugin.ts
+++ b/tests/dummy/app/dummy-plugins/highlight-plugin/highlight-plugin.ts
@@ -8,6 +8,10 @@ import {
   Logger,
 } from '@lblod/ember-rdfa-editor/utils/logging-utils';
 import Transaction from '@lblod/ember-rdfa-editor/core/state/transaction';
+import {
+  isOperationStep,
+  Step,
+} from '@lblod/ember-rdfa-editor/core/state/steps/step';
 
 export interface HighlightPluginOptions {
   testKey: string;
@@ -32,7 +36,8 @@ export default class HighlightPlugin implements EditorPlugin {
     transaction.removeTransactionStepListener(this.onTransactionStep);
   }
 
-  onTransactionStep = (transaction: Transaction) => {
+  onTransactionStep = (transaction: Transaction, steps: Step[]) => {
+    if (!steps.some(isOperationStep)) return;
     for (const { mark, node } of transaction
       .getMarksManager()
       .getMarksByOwner(this.name)) {

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -91,7 +91,7 @@ export function testState({
   const baseIRI = 'http://example.org';
   return new SayState({
     document,
-    transactionStepListeners: [],
+    transactionStepListeners: new Set(),
     commands,
     marksRegistry,
     marksManager,
@@ -99,7 +99,7 @@ export function testState({
     plugins,
     selection,
     baseIRI,
-    transactionDispatchListeners: [],
+    transactionDispatchListeners: new Set(),
     config: new Map(),
     datastore: EditorStore.fromParse({ baseIRI, modelRoot: document }),
     eventBus: new EventBus(),


### PR DESCRIPTION
This PR introduces the following fixes and improvements:
- Text insertion is now again completely handled by the virtual dom instead of the browser. This solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3729. It does unfortunately reduce typing performance.
- The `moveCursor` input handler now uses state only dispatch to prevent an extra write and difference calculation
- When a transaction is created, `rdfInvalid` and `marksInvalid` are initialized to `false` to prevent unnecessary mark and datastore calculations.
- Internally, the datastructure which keeps track of transaction listeners has been changed from a list to a set.
- The toolbar now uses a `TransactionDispatchListener` in order to update the status of its buttons.
- Transaction listeners have been mostly converted to arrow function in order to be able to omit the use of `this` binding.