### PR TITLE
Bugfix: inline component reload

### DIFF
--- a/addon/components/rdfa/rdfa-editor.hbs
+++ b/addon/components/rdfa/rdfa-editor.hbs
@@ -87,7 +87,7 @@
     </div>
   </div>
   {{#each this.inlineComponents as |compEntry|}}
-    {{#in-element compEntry.node insertBefore=null}}
+    {{#in-element compEntry.node }}
       {{component
         compEntry.emberComponentName
         componentController=compEntry.componentController

--- a/addon/model/inline-components/model-inline-component.ts
+++ b/addon/model/inline-components/model-inline-component.ts
@@ -1,4 +1,3 @@
-import Handlebars from 'handlebars';
 import { tracked } from 'tracked-built-ins';
 import Controller from '../controller';
 import { DomNodeMatcher } from '../mark';

--- a/addon/model/inline-components/model-inline-component.ts
+++ b/addon/model/inline-components/model-inline-component.ts
@@ -45,8 +45,7 @@ function render(
   node.contentEditable = 'false';
   node.classList.add('inline-component', spec.name);
   if (!dynamic) {
-    const template = Handlebars.compile(spec._renderStatic(props, state));
-    node.innerHTML = template({});
+    node.innerHTML = spec._renderStatic(props, state);
   }
   return node;
 }


### PR DESCRIPTION
This fix ensures that the static content of an inline component is replace by the dynamic version when reloading (inserting html) the editor. Additionally this PR removes the HBS compile step for the static render, the responsibility of compiling templates lays at the plugin level now. Solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3642.