### PR TITLE
feature/simple positions

### DIFF
--- a/addon/core/model/nodes/model-node.ts
+++ b/addon/core/model/nodes/model-node.ts
@@ -3,6 +3,7 @@ import ModelElement from '@lblod/ember-rdfa-editor/core/model/nodes/model-elemen
 import {
   ModelError,
   NoParentError,
+  NotImplementedError,
   OutsideRootError,
 } from '@lblod/ember-rdfa-editor/utils/errors';
 import XmlWriter from '@lblod/ember-rdfa-editor/core/model/writers/xml-writer';
@@ -143,6 +144,20 @@ export default abstract class ModelNode implements Walkable {
     return 1;
   }
 
+  get size(): number {
+    if (ModelNode.isModelText(this)) {
+      return this.content.length;
+    } else if (this.isLeaf) {
+      return 1;
+    } else if (ModelNode.isModelInlineComponent(this)) {
+      return 1;
+    } else if (ModelNode.isModelElement(this)) {
+      return this.children.reduce((prev, node) => prev + node.size, 0) + 2;
+    } else {
+      throw new NotImplementedError();
+    }
+  }
+
   get connected(): boolean {
     if (this.parent) {
       return this.parent.children.indexOf(this) !== -1;
@@ -185,6 +200,7 @@ export default abstract class ModelNode implements Walkable {
   }
 
   abstract hasVisibleText(): boolean;
+
   /**
    * Debugging utility
    */
@@ -226,6 +242,7 @@ export default abstract class ModelNode implements Walkable {
   setTextAttribute(_key: TextAttribute, _value: boolean) {
     //no-op function
   }
+
   *findSelfOrAncestors(
     predicate: Predicate<ModelNode>
   ): Generator<ModelNode, void, void> {
@@ -270,6 +287,7 @@ export default abstract class ModelNode implements Walkable {
 
     return oldParent;
   }
+
   remove() {
     if (!this.parent) {
       throw new ModelError('Cannot remove root');

--- a/addon/core/model/simple-position.ts
+++ b/addon/core/model/simple-position.ts
@@ -1,0 +1,49 @@
+import ModelPosition from '@lblod/ember-rdfa-editor/core/model/model-position';
+import ModelNode from '@lblod/ember-rdfa-editor/core/model/nodes/model-node';
+import { SimplePositionOutOfRangeError } from '@lblod/ember-rdfa-editor/utils/errors';
+
+export type SimplePosition = number;
+
+export function simplePosToModelPos(
+  simplePos: SimplePosition,
+  root: ModelNode
+): ModelPosition {
+  if (simplePos < 0) {
+    throw new SimplePositionOutOfRangeError(simplePos);
+  }
+  if (simplePos === 0) {
+    return ModelPosition.fromInNode(root, 0);
+  }
+  let cur: ModelNode | null = root.firstChild;
+  let count = 0;
+  while (cur) {
+    const curSize = cur.size;
+    if (count + curSize < simplePos) {
+      count += curSize;
+      cur = cur.nextSibling;
+    } else if (count + curSize === simplePos) {
+      return ModelPosition.fromAfterNode(cur);
+    } else {
+      if (ModelNode.isModelElement(cur) && !cur.isLeaf) {
+        count += 1;
+        if (cur.firstChild) {
+          cur = cur.firstChild;
+        } else {
+          return ModelPosition.fromInNode(cur, simplePos - count);
+        }
+      } else {
+        if (ModelNode.isModelText(cur)) {
+          return ModelPosition.fromInNode(cur, simplePos - count);
+        } else {
+          return ModelPosition.fromBeforeNode(cur);
+        }
+      }
+    }
+  }
+
+  throw new SimplePositionOutOfRangeError(simplePos);
+}
+
+export function modelPosToSimplePos(modelPos: ModelPosition): SimplePosition {
+  return 0;
+}

--- a/addon/utils/errors.ts
+++ b/addon/utils/errors.ts
@@ -60,6 +60,12 @@ export class NoParentError extends ModelError {
 
 export class PositionError extends CustomError {}
 
+export class SimplePositionOutOfRangeError extends PositionError {
+  constructor(position: number) {
+    super(`Simple position ${position} not valid in this document`);
+  }
+}
+
 /**
  * Error to throw in tests when asserting something you also want
  * typescript to know about
@@ -101,6 +107,7 @@ export class ParseError extends CustomError {}
  * Thrown when a method is invoked with an argument which it can not reasonably deal with
  */
 export class IllegalArgumentError extends CustomError {}
+
 export class UnkownCommandError extends IllegalArgumentError {
   constructor(name: string) {
     super(`Could not find command with name ${name}`);

--- a/addon/utils/unwrap.ts
+++ b/addon/utils/unwrap.ts
@@ -1,0 +1,10 @@
+import { AssertionError } from '@lblod/ember-rdfa-editor/utils/errors';
+
+function unwrap<A>(thing?: A | null): NonNullable<A> {
+  if (thing === undefined || thing === null) {
+    throw new AssertionError('Unwrapped a null or undefined value!');
+  }
+  return thing;
+}
+
+export default unwrap;

--- a/tests/unit/model/simple-position-test.ts
+++ b/tests/unit/model/simple-position-test.ts
@@ -1,0 +1,193 @@
+import { module, test } from 'qunit';
+import { vdom } from '@lblod/ember-rdfa-editor/utils/xml-utils';
+import ModelPosition from '@lblod/ember-rdfa-editor/core/model/model-position';
+import { simplePosToModelPos } from '@lblod/ember-rdfa-editor/core/model/simple-position';
+import { SimplePositionOutOfRangeError } from '@lblod/ember-rdfa-editor/utils/errors';
+
+module('Unit | model | simple-position-test', function () {
+  module('Unit | model | simple-position-test | simple to model', function () {
+    test('0 is only valid pos in empty document', function (assert) {
+      //language=XML
+      const { root: doc } = vdom`
+        <modelRoot/>
+      `;
+      const invalidBefore = -1;
+      const invalidAfter = 1;
+      const valid = 0;
+
+      const expected = ModelPosition.fromInNode(doc, 0);
+      const actualValid = simplePosToModelPos(valid, doc);
+      assert.true(actualValid.sameAs(expected));
+      assert.throws(() => {
+        simplePosToModelPos(invalidBefore, doc);
+      }, SimplePositionOutOfRangeError);
+      assert.throws(() => {
+        simplePosToModelPos(invalidAfter, doc);
+      }, SimplePositionOutOfRangeError);
+    });
+    test('various positions in textnode', function (assert) {
+      //language=XML
+      const {
+        root: doc,
+        textNodes: { textNode },
+      } = vdom`
+        <modelRoot>
+          <text __id="textNode">abc</text>
+        </modelRoot>
+      `;
+
+      const actual1 = simplePosToModelPos(0, doc);
+      const expected1 = ModelPosition.fromInNode(doc, 0);
+
+      const actual2 = simplePosToModelPos(1, doc);
+      const expected2 = ModelPosition.fromInNode(textNode, 1);
+
+      const actual3 = simplePosToModelPos(3, doc);
+      const expected3 = ModelPosition.fromInNode(textNode, 3);
+
+      assert.true(actual1.sameAs(expected1));
+      assert.true(actual2.sameAs(expected2));
+      assert.true(actual3.sameAs(expected3));
+      assert.throws(
+        () => simplePosToModelPos(4, doc),
+        SimplePositionOutOfRangeError
+      );
+    });
+    test('counts non-text leafnode as 1', function (assert) {
+      //language=XML
+      const {
+        root: doc,
+        elements: { br },
+      } = vdom`
+        <modelRoot>
+          <text __id="text1">abc</text>
+          <br __id="br"/>
+          <text __id="text2">def</text>
+        </modelRoot>
+      `;
+      const actual1 = simplePosToModelPos(3, doc);
+      const expected1 = ModelPosition.fromBeforeNode(br);
+      const actual2 = simplePosToModelPos(4, doc);
+      const expected2 = ModelPosition.fromAfterNode(br);
+
+      assert.true(actual1.sameAs(expected1));
+      assert.true(actual2.sameAs(expected2));
+    });
+    test('counts opening and closing tags as 1', function (assert) {
+      //language=XML
+      const {
+        root: doc,
+        textNodes: { innerText },
+        elements: { span },
+      } = vdom`
+        <modelRoot>
+          <text __id="text1">abc</text>
+          <span __id="span">
+            <text __id="innerText">test</text>
+          </span>
+          <text __id="text2">def</text>
+        </modelRoot>
+      `;
+      const actual1 = simplePosToModelPos(3, doc);
+      const expected1 = ModelPosition.fromBeforeNode(span);
+      const actual2 = simplePosToModelPos(4, doc);
+      const expected2 = ModelPosition.fromInNode(span, 0);
+
+      const actual3 = simplePosToModelPos(8, doc);
+      const expected3 = ModelPosition.fromAfterNode(innerText);
+      const actual4 = simplePosToModelPos(9, doc);
+      const expected4 = ModelPosition.fromAfterNode(span);
+      assert.true(actual1.sameAs(expected1));
+      assert.true(actual2.sameAs(expected2));
+      assert.true(actual3.sameAs(expected3));
+      assert.true(actual4.sameAs(expected4));
+    });
+
+    test('empty non-leaf element', function (assert) {
+      //language=XML
+      const {
+        root: doc,
+        elements: { span },
+      } = vdom`
+        <modelRoot>
+          <span __id="span">
+          </span>
+        </modelRoot>
+      `;
+      const actual1 = simplePosToModelPos(0, doc);
+      const expected1 = ModelPosition.fromBeforeNode(span);
+
+      const actual2 = simplePosToModelPos(1, doc);
+      const expected2 = ModelPosition.fromInNode(span, 0);
+
+      const actual3 = simplePosToModelPos(2, doc);
+      const expected3 = ModelPosition.fromAfterNode(span);
+      assert.true(actual1.sameAs(expected1));
+      assert.true(actual2.sameAs(expected2));
+      assert.true(actual3.sameAs(expected3));
+    });
+    test('multiple non-text leafnodes', function (assert) {
+      //language=XML
+      const {
+        root: doc,
+        elements: { span, br1, br2, br3 },
+      } = vdom`
+        <modelRoot>
+          <span __id="span">
+            <br __id="br1"/>
+            <br __id="br2"/>
+            <br __id="br3"/>
+          </span>
+        </modelRoot>
+      `;
+      const actual1 = simplePosToModelPos(0, doc);
+      const expected1 = ModelPosition.fromBeforeNode(span);
+
+      const actual2 = simplePosToModelPos(1, doc);
+      const expected2 = ModelPosition.fromInNode(span, 0);
+
+      const actual3 = simplePosToModelPos(2, doc);
+      const expected3 = ModelPosition.fromAfterNode(br1);
+
+      const actual4 = simplePosToModelPos(3, doc);
+      const expected4 = ModelPosition.fromAfterNode(br2);
+
+      const actual5 = simplePosToModelPos(4, doc);
+      const expected5 = ModelPosition.fromAfterNode(br3);
+      assert.true(actual1.sameAs(expected1));
+      assert.true(actual2.sameAs(expected2), actual2.path.toString());
+      assert.true(actual3.sameAs(expected3));
+      assert.true(actual4.sameAs(expected4));
+      assert.true(actual5.sameAs(expected5));
+    });
+    test('multiple empty text nodes', function (assert) {
+      //language=XML
+      const {
+        root: doc,
+        textNodes: { text1 },
+      } = vdom`
+        <modelRoot>
+          <text __id="text1"/>
+          <text __id="text2"/>
+          <text __id="text3"/>
+        </modelRoot>
+      `;
+      const actual1 = simplePosToModelPos(0, doc);
+      const expected1 = ModelPosition.fromBeforeNode(text1);
+
+      assert.true(actual1.sameAs(expected1));
+      assert.throws(
+        () => simplePosToModelPos(1, doc),
+        SimplePositionOutOfRangeError
+      );
+      assert.throws(
+        () => simplePosToModelPos(2, doc),
+        SimplePositionOutOfRangeError
+      );
+    });
+  });
+  module(
+    'Unit | model | simple-position-test | model to simple',
+    function () {}
+  );
+});


### PR DESCRIPTION
implements the simple positions from the [modelnode](https://github.com/lblod/ember-rdfa-editor/blob/master/rfcs/model.md) rfc
closes https://binnenland.atlassian.net/browse/GN-3620
First I tried converting places we were using the modelposition to simple positions, but I ended up rolling back those changes and do them as part of the modelnode rework