### PR TITLE
fix deprecations

### DIFF
--- a/addon/components/rdfa/plugin-wrapper.hbs
+++ b/addon/components/rdfa/plugin-wrapper.hbs
@@ -4,8 +4,9 @@
       @nowrap={{true}}
       @reverse={{true}}
       {{on 'click' this.toggle}}
+      as |Group|
     >
-      <AuToolbarGroup>
+      <Group>
         <div>
           <AuButton
             @skin='tertiary'
@@ -16,8 +17,8 @@
             {{@title}}
           </AuButton>
         </div>
-      </AuToolbarGroup>
-      <AuToolbarGroup>
+      </Group>
+      <Group>
         {{#if this.expanded}}
           <AuIcon
             @icon="remove"
@@ -39,7 +40,7 @@
             Sluit accordion
           </span>
         {{/if}}
-      </AuToolbarGroup>
+      </Group>
     </AuToolbar>
     <div class={{if this.expanded "au-c-accordion__content" "au-u-hidden"}}>
       <AuList @divider={{true}}>


### PR DESCRIPTION
fix: Invoking `AuToolbarGroup` directly is deprecated. You should use the component that is yielded from the `AuToolbar` component instead. [deprecation id: @appuniversum/ember-appuniversum.au-toolbar-group.direct-invocation]