### PR TITLE
Ensure children of inline component are cleared when reading

### DIFF
--- a/addon/model/readers/html-inline-component-reader.ts
+++ b/addon/model/readers/html-inline-component-reader.ts
@@ -20,6 +20,7 @@ export default class HtmlInlineComponentReader
     context: HtmlReaderContext
   ): ModelInlineComponent[] {
     const { element, spec } = from;
+    from.element.replaceChildren();
     const propsAttribute = element.dataset['__props'];
     let props: Properties = {};
     if (propsAttribute) {


### PR DESCRIPTION
This fix is to ensure the static content of an inline component is cleared before reading it into the editor.