### PR TITLE
Refresh inline components after model read

### DIFF
--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -111,6 +111,9 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
     this.editor.on('modelWritten', () => {
       this.inlineComponents = this.editor!.getComponentInstances();
     });
+    this.editor.on('modelRead', () => {
+      this.inlineComponents = this.editor!.getComponentInstances();
+    });
     this.toolbarWidgets = editor.widgetMap.get('toolbar') || [];
     this.sidebarWidgets = editor.widgetMap.get('sidebar') || [];
     this.insertSidebarWidgets = editor.widgetMap.get('insertSidebar') || [];


### PR DESCRIPTION
This PR includes a reload of the inline components after a `modelRead` has happened in order to ensure that the inline components have access to their latest model.