### PR TITLE
Remove unnecessary read on mouseup

### DIFF
--- a/addon/editor/input-handlers/fallback-input-handler.ts
+++ b/addon/editor/input-handlers/fallback-input-handler.ts
@@ -20,6 +20,7 @@ export default class FallbackInputHandler extends InputHandler {
     'keydown',
     'keyup',
     'mousedown',
+    'mouseup',
     'beforeinput',
   ];
 


### PR DESCRIPTION
This PR removes a model read in reaction to a `mouseup` event. This was necessary before but is now unneeded.