### PR TITLE
Inline components: serializable properties

### DIFF
--- a/addon/commands/insert-component-command.ts
+++ b/addon/commands/insert-component-command.ts
@@ -1,7 +1,6 @@
 import {
   ModelInlineComponent,
   Properties,
-  State,
 } from '../model/inline-components/model-inline-component';
 import Model from '../model/model';
 import ModelElement from '../model/model-element';
@@ -25,7 +24,6 @@ export default class InsertComponentCommand extends Command {
   execute(
     componentName: string,
     props: Properties = {},
-    state: State = {},
     createSnapshot = true,
     range: ModelRange | null = this.model.selection.lastRange
   ): void {
@@ -35,7 +33,7 @@ export default class InsertComponentCommand extends Command {
     const componentSpec =
       this.model.inlineComponentsRegistry.lookUpComponent(componentName);
     if (componentSpec) {
-      const component = new ModelInlineComponent(componentSpec, props, state);
+      const component = new ModelInlineComponent(componentSpec, props);
       this.model.change(
         (mutator) => {
           const resultingRange = mutator.insertNodes(range, component);

--- a/addon/model/inline-components/inline-component-controller.ts
+++ b/addon/model/inline-components/inline-component-controller.ts
@@ -1,27 +1,17 @@
 import Controller from '../controller';
 import { Serializable } from '../util/render-spec';
-import {
-  ModelInlineComponent,
-  Properties,
-  State,
-} from './model-inline-component';
+import { ModelInlineComponent } from './model-inline-component';
 
-export interface InlineComponentArgs<
-  A extends Properties = Properties,
-  S extends State = State
-> {
-  componentController: InlineComponentController<A, S>;
+export interface InlineComponentArgs {
+  componentController: InlineComponentController;
   editorController: Controller;
 }
 
-export default class InlineComponentController<
-  A extends Properties = Properties,
-  S extends State = State
-> {
-  private _model: ModelInlineComponent<A, S>;
+export default class InlineComponentController {
+  private _model: ModelInlineComponent;
   private _node: HTMLElement;
 
-  constructor(model: ModelInlineComponent<A, S>, node: HTMLElement) {
+  constructor(model: ModelInlineComponent, node: HTMLElement) {
     this._model = model;
     this._node = node;
   }
@@ -29,20 +19,16 @@ export default class InlineComponentController<
     return this._model.props;
   }
 
-  get state() {
-    return this._model.state;
-  }
-
   get model() {
     return this._model;
   }
 
-  setStateProperty(property: keyof S, value: Serializable) {
-    this._model.setStateProperty(property, value);
-    this._node.dataset['__state'] = JSON.stringify(this._model.state);
+  setProperty(property: string, value: Serializable) {
+    this._model.setProperty(property, value);
+    // this._node.dataset['props'] = JSON.stringify(this._model.props);
   }
 
-  getStateProperty(property: keyof S) {
-    return this._model.getStateProperty(property);
+  getStateProperty(property: string) {
+    return this._model.getProperty(property);
   }
 }

--- a/addon/model/inline-components/inline-component-controller.ts
+++ b/addon/model/inline-components/inline-component-controller.ts
@@ -28,7 +28,7 @@ export default class InlineComponentController {
     // this._node.dataset['props'] = JSON.stringify(this._model.props);
   }
 
-  getStateProperty(property: string) {
+  getProperty(property: string) {
     return this._model.getProperty(property);
   }
 }

--- a/addon/model/inline-components/inline-component-controller.ts
+++ b/addon/model/inline-components/inline-component-controller.ts
@@ -25,7 +25,16 @@ export default class InlineComponentController {
 
   setProperty(property: string, value: Serializable) {
     this._model.setProperty(property, value);
-    // this._node.dataset['props'] = JSON.stringify(this._model.props);
+    // We need to ensure that the properties of the model are not overwritten by a read, in the new TEDI API this is no longer necessary
+    const serializedProps: Record<string, Serializable | null | undefined> = {};
+    for (const [propName, { serializable, defaultValue }] of Object.entries(
+      this.model.spec.properties
+    )) {
+      if (serializable) {
+        serializedProps[propName] = this.model.props[propName] ?? defaultValue;
+      }
+    }
+    this._node.dataset['props'] = JSON.stringify(serializedProps);
   }
 
   getProperty(property: string) {

--- a/addon/model/inline-components/model-inline-component.ts
+++ b/addon/model/inline-components/model-inline-component.ts
@@ -42,10 +42,11 @@ function render(spec: InlineComponentSpec, props?: Properties, dynamic = true) {
         serializedProps[propName] = props[propName] ?? defaultValue;
       }
     }
-    node.dataset['props'] = JSON.stringify(serializedProps);
+    node.dataset.props = JSON.stringify(serializedProps);
   }
   node.contentEditable = 'false';
-  node.classList.add('inline-component', spec.name);
+  node.classList.add('inline-component');
+  node.dataset.inlineComponent = spec.name;
   if (!dynamic) {
     node.innerHTML = spec._renderStatic(props);
   }

--- a/addon/model/inline-components/model-inline-component.ts
+++ b/addon/model/inline-components/model-inline-component.ts
@@ -55,6 +55,8 @@ function render(spec: InlineComponentSpec, props?: Properties, dynamic = true) {
 export class ModelInlineComponent extends ModelElement {
   modelNodeType: ModelNodeType = 'INLINE-COMPONENT';
   private _spec: InlineComponentSpec;
+
+  @tracked
   private _props: Properties;
 
   constructor(spec: InlineComponentSpec, props: Properties) {

--- a/addon/model/inline-components/model-inline-component.ts
+++ b/addon/model/inline-components/model-inline-component.ts
@@ -5,12 +5,14 @@ import ModelElement from '../model-element';
 import { ModelNodeType } from '../model-node';
 import { AttributeSpec, Serializable } from '../util/render-spec';
 
-export type Properties = Record<string, Serializable | undefined>;
-
-export type State = Record<string, Serializable | undefined>;
+export type Properties = Record<string, Serializable | undefined | null>;
 export abstract class InlineComponentSpec {
   name: string;
   tag: keyof HTMLElementTagNameMap;
+  abstract properties: Record<
+    string,
+    { serializable: boolean; defaultValue?: Serializable | null }
+  >;
 
   abstract matcher: DomNodeMatcher<AttributeSpec>;
   controller: Controller;
@@ -25,65 +27,55 @@ export abstract class InlineComponentSpec {
     this.controller = controller;
   }
 
-  abstract _renderStatic(props?: Properties, state?: State): string;
+  abstract _renderStatic(props?: Properties): string;
 }
 
-function render(
-  spec: InlineComponentSpec,
-  props?: Properties,
-  state?: State,
-  dynamic = true
-) {
+function render(spec: InlineComponentSpec, props?: Properties, dynamic = true) {
   const node = document.createElement(spec.tag);
+
   if (props) {
-    node.dataset['__props'] = JSON.stringify(props);
-  }
-  if (state) {
-    node.dataset['__state'] = JSON.stringify(state);
+    const serializedProps: Record<string, Serializable | null | undefined> = {};
+    for (const [propName, { serializable, defaultValue }] of Object.entries(
+      spec.properties
+    )) {
+      if (serializable) {
+        serializedProps[propName] = props[propName] ?? defaultValue;
+      }
+    }
+    node.dataset['props'] = JSON.stringify(serializedProps);
   }
   node.contentEditable = 'false';
   node.classList.add('inline-component', spec.name);
   if (!dynamic) {
-    node.innerHTML = spec._renderStatic(props, state);
+    node.innerHTML = spec._renderStatic(props);
   }
   return node;
 }
 
-export class ModelInlineComponent<
-  A extends Properties = Properties,
-  S extends State = State
-> extends ModelElement {
+export class ModelInlineComponent extends ModelElement {
   modelNodeType: ModelNodeType = 'INLINE-COMPONENT';
   private _spec: InlineComponentSpec;
-  private _props: A;
+  private _props: Properties;
 
-  @tracked
-  private _state: S;
-
-  constructor(spec: InlineComponentSpec, props: A, state: S) {
+  constructor(spec: InlineComponentSpec, props: Properties) {
     super(spec.tag);
     this._spec = spec;
-    this._props = props;
-    this._state = tracked(state);
+    this._props = tracked(props);
   }
 
   get props() {
     return this._props;
   }
 
-  get state() {
-    return this._state;
+  setProperty(property: string, value: Serializable) {
+    this._props = tracked({ ...this.props, [property]: value });
   }
 
-  setStateProperty(property: keyof S, value: Serializable) {
-    this._state = tracked({ ...this.state, [property]: value });
-  }
-
-  getStateProperty(property: keyof S) {
-    if (property in this.state) {
-      return this.state[property];
+  getProperty(property: string) {
+    if (property in this.props) {
+      return this.props[property];
     } else {
-      return null;
+      return this.spec.properties[property]?.defaultValue;
     }
   }
 
@@ -91,11 +83,11 @@ export class ModelInlineComponent<
     return this._spec;
   }
   write(dynamic = true): Node {
-    return render(this.spec, this.props, this.state, dynamic);
+    return render(this.spec, this.props, dynamic);
   }
 
-  clone(): ModelInlineComponent<A, S> {
-    const result = new ModelInlineComponent(this.spec, this.props, this.state);
+  clone(): ModelInlineComponent {
+    const result = new ModelInlineComponent(this.spec, this.props);
     return result;
   }
 

--- a/addon/model/readers/html-inline-component-reader.ts
+++ b/addon/model/readers/html-inline-component-reader.ts
@@ -20,17 +20,20 @@ export default class HtmlInlineComponentReader
     context: HtmlReaderContext
   ): ModelInlineComponent[] {
     const { element, spec } = from;
-    const propsAttribute = element.dataset['__props'];
+    // For legacy reasons we still need to check if the element has a __props dataset attribute
+    const propsAttribute =
+      element.dataset['props'] ?? element.dataset['__props'];
     let props: Properties = {};
     if (propsAttribute) {
       props = JSON.parse(propsAttribute) as Properties;
     }
+    // For legacy reasons we still need to check if the element has a __state dataset attribute
     const stateAttribute = element.dataset['__state'];
-    let state: State = {};
     if (stateAttribute) {
-      state = JSON.parse(stateAttribute) as State;
+      const state = JSON.parse(stateAttribute) as Properties;
+      props = { ...props, ...state };
     }
-    const component = new ModelInlineComponent(spec, props, state);
+    const component = new ModelInlineComponent(spec, props);
 
     context.registerNodeView(component, {
       viewRoot: element,

--- a/addon/model/readers/html-inline-component-reader.ts
+++ b/addon/model/readers/html-inline-component-reader.ts
@@ -2,7 +2,6 @@ import {
   InlineComponentSpec,
   ModelInlineComponent,
   Properties,
-  State,
 } from '../inline-components/model-inline-component';
 import { HtmlReaderContext } from './html-reader';
 import Reader from './reader';

--- a/tests/dummy/app/components/inline-components-plugin/counter.hbs
+++ b/tests/dummy/app/components/inline-components-plugin/counter.hbs
@@ -1,0 +1,2 @@
+<AuButton type='button' {{on 'click' this.click}}>Increase</AuButton>
+<span>{{this.count}}</span>

--- a/tests/dummy/app/components/inline-components-plugin/counter.ts
+++ b/tests/dummy/app/components/inline-components-plugin/counter.ts
@@ -1,0 +1,22 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import InlineComponentController from '@lblod/ember-rdfa-editor/model/inline-components/inline-component-controller';
+
+type CounterArgs = {
+  componentController: InlineComponentController;
+};
+
+export default class InlineComponentsPluginCounter extends Component<CounterArgs> {
+  get componentController() {
+    return this.args.componentController;
+  }
+
+  @action
+  click() {
+    this.componentController.setProperty('count', this.count + 1);
+  }
+
+  get count() {
+    return this.componentController.getProperty('count') as number;
+  }
+}

--- a/tests/dummy/app/components/inline-components-plugin/dropdown.hbs
+++ b/tests/dummy/app/components/inline-components-plugin/dropdown.hbs
@@ -1,0 +1,10 @@
+<AuDropdown
+  @title={{this.title}}
+  @alignment='left'
+  typeof='reglementaireBijlage'
+  role="menu"
+>
+  {{#each this.articles as |article|}}
+    <AuLinkExternal role='menuitem'>{{article}}</AuLinkExternal>
+  {{/each}}
+</AuDropdown>

--- a/tests/dummy/app/components/inline-components-plugin/dropdown.ts
+++ b/tests/dummy/app/components/inline-components-plugin/dropdown.ts
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class InlineComponentsPluginDropdown extends Component {
+  get title() {
+    return 'Example Dropdown';
+  }
+
+  get articles() {
+    return [1, 2, 3, 4, 5, 6, 7].map((i) => `Article ${i}`);
+  }
+}

--- a/tests/dummy/app/components/inline-components-plugin/rdfa-ic-plugin-insert.hbs
+++ b/tests/dummy/app/components/inline-components-plugin/rdfa-ic-plugin-insert.hbs
@@ -1,0 +1,20 @@
+<AuList::Item>
+  <AuButton
+    @icon='add'
+    @iconAlignment='left'
+    @skin='link'
+    {{on 'click' this.insertCounter}}
+  >
+    Insert Counter
+  </AuButton>
+</AuList::Item>
+<AuList::Item>
+  <AuButton
+    @icon='add'
+    @iconAlignment='left'
+    @skin='link'
+    {{on 'click' this.insertDropdown}}
+  >
+    Insert Dropdown
+  </AuButton>
+</AuList::Item>

--- a/tests/dummy/app/components/inline-components-plugin/rdfa-ic-plugin-insert.ts
+++ b/tests/dummy/app/components/inline-components-plugin/rdfa-ic-plugin-insert.ts
@@ -1,0 +1,25 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import Controller from '@lblod/ember-rdfa-editor/model/controller';
+
+type RdfaIcPluginInsertComponentArgs = {
+  controller: Controller;
+};
+
+export default class RdfaIcPluginInsertComponent extends Component<RdfaIcPluginInsertComponentArgs> {
+  @action
+  insertCounter() {
+    this.args.controller.executeCommand(
+      'insert-component',
+      'inline-components-plugin/counter'
+    );
+  }
+
+  @action
+  insertDropdown() {
+    this.args.controller.executeCommand(
+      'insert-component',
+      'inline-components-plugin/dropdown'
+    );
+  }
+}

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -5,7 +5,10 @@ import RdfaDocument from '@lblod/ember-rdfa-editor/utils/rdfa/rdfa-document';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: RdfaDocument;
-  @tracked plugins = [{ name: 'dummy', options: { testKey: 'hello' } }];
+  @tracked plugins = [
+    { name: 'dummy', options: { testKey: 'hello' } },
+    'inline-components',
+  ];
 
   @action
   rdfaEditorInit(rdfaEditor: RdfaDocument) {

--- a/tests/dummy/app/dummy-plugins/inline-components-plugin/inline-component-models/counter.ts
+++ b/tests/dummy/app/dummy-plugins/inline-components-plugin/inline-component-models/counter.ts
@@ -10,10 +10,7 @@ export default class CounterSpec extends InlineComponentSpec {
     tag: this.tag,
     attributeBuilder: (node: Node) => {
       if (isElement(node)) {
-        if (
-          node.classList.contains('inline-component') &&
-          node.classList.contains(this.name)
-        ) {
+        if (node.dataset.inlineComponent === this.name) {
           return {};
         }
       }

--- a/tests/dummy/app/dummy-plugins/inline-components-plugin/inline-component-models/counter.ts
+++ b/tests/dummy/app/dummy-plugins/inline-components-plugin/inline-component-models/counter.ts
@@ -1,0 +1,37 @@
+import Controller from '@lblod/ember-rdfa-editor/model/controller';
+import {
+  InlineComponentSpec,
+  Properties,
+} from '@lblod/ember-rdfa-editor/model/inline-components/model-inline-component';
+import { isElement } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+
+export default class CounterSpec extends InlineComponentSpec {
+  matcher = {
+    tag: this.tag,
+    attributeBuilder: (node: Node) => {
+      if (isElement(node)) {
+        if (
+          node.classList.contains('inline-component') &&
+          node.classList.contains(this.name)
+        ) {
+          return {};
+        }
+      }
+      return null;
+    },
+  };
+
+  properties = {
+    count: { serializable: true, defaultValue: 0 },
+  };
+
+  _renderStatic(props: Properties) {
+    const count = props.count?.toString() || this.properties.count.defaultValue;
+    return `
+      <p>${count}</p>
+    `;
+  }
+  constructor(controller: Controller) {
+    super('inline-components-plugin/counter', 'span', controller);
+  }
+}

--- a/tests/dummy/app/dummy-plugins/inline-components-plugin/inline-component-models/dropdown.ts
+++ b/tests/dummy/app/dummy-plugins/inline-components-plugin/inline-component-models/dropdown.ts
@@ -1,0 +1,30 @@
+import Controller from '@lblod/ember-rdfa-editor/model/controller';
+import { InlineComponentSpec } from '@lblod/ember-rdfa-editor/model/inline-components/model-inline-component';
+import { isElement } from '@lblod/ember-rdfa-editor/utils/dom-helpers';
+
+export default class DropdownSpec extends InlineComponentSpec {
+  matcher = {
+    tag: this.tag,
+    attributeBuilder: (node: Node) => {
+      if (isElement(node)) {
+        if (
+          node.classList.contains('inline-component') &&
+          node.classList.contains(this.name)
+        ) {
+          return {};
+        }
+      }
+      return null;
+    },
+  };
+  properties = {};
+
+  _renderStatic() {
+    return `
+      <p>Dropdown</p>
+    `;
+  }
+  constructor(controller: Controller) {
+    super('inline-components-plugin/dropdown', 'span', controller);
+  }
+}

--- a/tests/dummy/app/dummy-plugins/inline-components-plugin/inline-component-models/dropdown.ts
+++ b/tests/dummy/app/dummy-plugins/inline-components-plugin/inline-component-models/dropdown.ts
@@ -7,10 +7,7 @@ export default class DropdownSpec extends InlineComponentSpec {
     tag: this.tag,
     attributeBuilder: (node: Node) => {
       if (isElement(node)) {
-        if (
-          node.classList.contains('inline-component') &&
-          node.classList.contains(this.name)
-        ) {
+        if (node.dataset.inlineComponent === this.name) {
           return {};
         }
       }

--- a/tests/dummy/app/dummy-plugins/inline-components-plugin/inline-components-plugin.ts
+++ b/tests/dummy/app/dummy-plugins/inline-components-plugin/inline-components-plugin.ts
@@ -1,0 +1,24 @@
+import { EditorPlugin } from '@lblod/ember-rdfa-editor/utils/editor-plugin';
+import Controller from '@lblod/ember-rdfa-editor/model/controller';
+import CounterSpec from './inline-component-models/counter';
+import DropdownSpec from './inline-component-models/dropdown';
+
+export default class InlineComponentsPlugin implements EditorPlugin {
+  controller!: Controller;
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async initialize(controller: Controller): Promise<void> {
+    this.controller = controller;
+
+    controller.registerWidget({
+      componentName: 'inline-components-plugin/rdfa-ic-plugin-insert',
+      desiredLocation: 'insertSidebar',
+    });
+    controller.registerInlineComponent(new CounterSpec(this.controller));
+    controller.registerInlineComponent(new DropdownSpec(this.controller));
+  }
+
+  get name(): string {
+    return 'inline-components';
+  }
+}

--- a/tests/dummy/app/initializers/dummy-plugins.ts
+++ b/tests/dummy/app/initializers/dummy-plugins.ts
@@ -1,6 +1,7 @@
 import Application from '@ember/application';
 import DummyPlugin from 'dummy/testplugin/dummy-plugin';
 import { EditorPlugin } from '@lblod/ember-rdfa-editor/utils/editor-plugin';
+import InlineComponentsPlugin from '../dummy-plugins/inline-components-plugin/inline-components-plugin';
 
 function pluginFactory(plugin: new () => EditorPlugin) {
   return {
@@ -16,6 +17,13 @@ export function initialize(application: Application) {
   application.register('plugin:dummy', pluginFactory(DummyPlugin), {
     singleton: false,
   });
+  application.register(
+    'plugin:inline-components',
+    pluginFactory(InlineComponentsPlugin),
+    {
+      singleton: false,
+    }
+  );
 }
 
 export default {


### PR DESCRIPTION
This PR introduces the following changes:
- The `props` and `state` object of inline components are merged into one. 
    * Properties can be written and read using the `setProperty` and `getProperty` methods.
- When defining an inline component spec, you need to define which properties it uses. For each of the properties you can defined whether it should be serialized and what default value it has (if it has one). This makes the DOM attributes less cluttered if only the properties are included that should be serialized.
    * E.g. properties that can be derived from other properties should not be serialized.
- Inline component matchers can now match an inline component on a dataset attribute instead of a class.
    * Inline components now contain a `data-inline-component` attribute with as value the name of the inline component.
- Two sample inline components are included in the editor dummy app to make testing easier.