### PR TITLE
Enable model node size cache

### DIFF
--- a/addon/core/model/simple-range.ts
+++ b/addon/core/model/simple-range.ts
@@ -13,18 +13,22 @@ export interface SimpleRange {
 
 export function simpleRangeToModelRange(
   simpleRange: SimpleRange,
-  root: ModelElement
+  root: ModelElement,
+  useSizeCache = true
 ): ModelRange {
   return new ModelRange(
-    simplePosToModelPos(simpleRange.start, root),
-    simplePosToModelPos(simpleRange.end, root)
+    simplePosToModelPos(simpleRange.start, root, useSizeCache),
+    simplePosToModelPos(simpleRange.end, root, useSizeCache)
   );
 }
 
-export function modelRangeToSimpleRange(modelRange: ModelRange): SimpleRange {
+export function modelRangeToSimpleRange(
+  modelRange: ModelRange,
+  useSizeCache = true
+): SimpleRange {
   return {
-    start: modelPosToSimplePos(modelRange.start),
-    end: modelPosToSimplePos(modelRange.end),
+    start: modelPosToSimplePos(modelRange.start, useSizeCache),
+    end: modelPosToSimplePos(modelRange.end, useSizeCache),
   };
 }
 

--- a/addon/core/state/steps/mark-step.ts
+++ b/addon/core/state/steps/mark-step.ts
@@ -59,7 +59,7 @@ export default class MarkStep implements OperationStep {
     const resultState = cloneStateInRange(range, initialState);
     const root = resultState.document;
 
-    const modelRange = simpleRangeToModelRange(range, root);
+    const modelRange = simpleRangeToModelRange(range, root, false);
 
     if (modelRange.collapsed) {
       OperationAlgorithms.splitText(root, range.start);

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -162,8 +162,12 @@ export function vdomToDom(vdom: ModelNode): Node {
   return view.domRoot;
 }
 
-export function pathToSimplePos(root: ModelElement, path: number[]) {
-  return modelPosToSimplePos(ModelPosition.fromPath(root, path));
+export function pathToSimplePos(
+  root: ModelElement,
+  path: number[],
+  useSizeCache = true
+) {
+  return modelPosToSimplePos(ModelPosition.fromPath(root, path), useSizeCache);
 }
 
 export function pathsToSimpleRange(

--- a/tests/unit/model/operations/algorithms/insert-algorithm-test.ts
+++ b/tests/unit/model/operations/algorithms/insert-algorithm-test.ts
@@ -156,12 +156,24 @@ module(
       const newDeepPos = mapper.mapPosition(deepPos);
 
       assert.true(initial.sameAs(expected));
-      assert.strictEqual(newEndPos, pathToSimplePos(initial, [1, 2, 0, 0]));
-      assert.strictEqual(newStartPos, pathToSimplePos(initial, [1, 0]));
-      assert.strictEqual(newStartPosRight, pathToSimplePos(initial, [1, 2]));
-      assert.strictEqual(newTestPos1, pathToSimplePos(initial, [1, 2, 0, 1]));
-      assert.strictEqual(newTestPos2, pathToSimplePos(initial, [1, 2, 1]));
-      assert.strictEqual(newTestPos3, pathToSimplePos(initial, [4]));
+      assert.strictEqual(
+        newEndPos,
+        pathToSimplePos(initial, [1, 2, 0, 0], false)
+      );
+      assert.strictEqual(newStartPos, pathToSimplePos(initial, [1, 0], false));
+      assert.strictEqual(
+        newStartPosRight,
+        pathToSimplePos(initial, [1, 2], false)
+      );
+      assert.strictEqual(
+        newTestPos1,
+        pathToSimplePos(initial, [1, 2, 0, 1], false)
+      );
+      assert.strictEqual(
+        newTestPos2,
+        pathToSimplePos(initial, [1, 2, 1], false)
+      );
+      assert.strictEqual(newTestPos3, pathToSimplePos(initial, [4], false));
       assert.strictEqual(
         newTestPos4LeftBias,
         pathToSimplePos(initial, [1, 2, 0, 0])
@@ -169,9 +181,12 @@ module(
       assert.strictEqual(newTestPos4RightBias, newEndPos);
       assert.strictEqual(
         newTestPos5,
-        pathToSimplePos(initial, [1, 2, 0, 8, 2])
+        pathToSimplePos(initial, [1, 2, 0, 8, 2], false)
       );
-      assert.strictEqual(newDeepPos, pathToSimplePos(initial, [7, 0, 0, 0, 2]));
+      assert.strictEqual(
+        newDeepPos,
+        pathToSimplePos(initial, [7, 0, 0, 0, 2], false)
+      );
     });
     test('collapsed insertion', function (assert) {
       //language=XML
@@ -310,17 +325,32 @@ module(
       const newDeepPos = mapper.mapPosition(deepPos);
 
       assert.true(initial.sameAs(expected));
-      assert.strictEqual(newEndPos, pathToSimplePos(initial, [1, 0, 4]));
-      assert.strictEqual(newStartPos, pathToSimplePos(initial, [1, 0, 4]));
-      assert.strictEqual(newStartPosLeft, pathToSimplePos(initial, [1, 0, 2]));
-      assert.strictEqual(newTestPos1, pathToSimplePos(initial, [1, 0, 7, 4]));
-      assert.strictEqual(newTestPos2, pathToSimplePos(initial, [1, 0, 8]));
-      assert.strictEqual(newTestPos3, pathToSimplePos(initial, [4]));
+      assert.strictEqual(newEndPos, pathToSimplePos(initial, [1, 0, 4], false));
+      assert.strictEqual(
+        newStartPos,
+        pathToSimplePos(initial, [1, 0, 4], false)
+      );
+      assert.strictEqual(
+        newStartPosLeft,
+        pathToSimplePos(initial, [1, 0, 2], false)
+      );
+      assert.strictEqual(
+        newTestPos1,
+        pathToSimplePos(initial, [1, 0, 7, 4], false)
+      );
+      assert.strictEqual(
+        newTestPos2,
+        pathToSimplePos(initial, [1, 0, 8], false)
+      );
+      assert.strictEqual(newTestPos3, pathToSimplePos(initial, [4], false));
       assert.strictEqual(
         newTestPos5,
-        pathToSimplePos(initial, [1, 0, 7, 11, 2])
+        pathToSimplePos(initial, [1, 0, 7, 11, 2], false)
       );
-      assert.strictEqual(newDeepPos, pathToSimplePos(initial, [7, 0, 0, 0, 2]));
+      assert.strictEqual(
+        newDeepPos,
+        pathToSimplePos(initial, [7, 0, 0, 0, 2], false)
+      );
     });
     test('insert single char', function (assert) {
       //language=XML
@@ -343,20 +373,20 @@ module(
       const insertionRange = ModelRange.fromInTextNode(initial, text1, 1, 1);
       const { mapper } = OperationAlgorithms.insert(
         initial,
-        modelRangeToSimpleRange(insertionRange),
+        modelRangeToSimpleRange(insertionRange, false),
         insertNode
       );
-      const cursorPosition = modelPosToSimplePos(insertionRange.end);
+      const cursorPosition = modelPosToSimplePos(insertionRange.end, false);
       assert.true(initial.sameAs(expected));
       assert.strictEqual(
         mapper.mapPosition(cursorPosition, { bias: 'left' }),
-        pathToSimplePos(initial, [1])
+        pathToSimplePos(initial, [1], false)
       );
       assert.strictEqual(
         mapper.mapPosition(cursorPosition, {
           bias: 'right',
         }),
-        pathToSimplePos(initial, [2])
+        pathToSimplePos(initial, [2], false)
       );
     });
   }

--- a/tests/unit/model/operations/algorithms/remove-algorithm-test.ts
+++ b/tests/unit/model/operations/algorithms/remove-algorithm-test.ts
@@ -128,22 +128,37 @@ module(
       const newDeepPos = removeMapper.mapPosition(deepPos);
 
       assert.true(initial.sameAs(expected));
-      assert.strictEqual(newEndPos, pathToSimplePos(initial, [1, 0, 0, 0]));
-      assert.strictEqual(newStartPos, pathToSimplePos(initial, [1, 0]));
-      assert.strictEqual(newStartPosLeft, pathToSimplePos(initial, [1, 0]));
-      assert.strictEqual(newTestPos1, pathToSimplePos(initial, [1, 0, 0, 1]));
-      assert.strictEqual(newTestPos2, pathToSimplePos(initial, [1, 0, 1]));
-      assert.strictEqual(newTestPos3, pathToSimplePos(initial, [4]));
+      assert.strictEqual(
+        newEndPos,
+        pathToSimplePos(initial, [1, 0, 0, 0], false)
+      );
+      assert.strictEqual(newStartPos, pathToSimplePos(initial, [1, 0], false));
+      assert.strictEqual(
+        newStartPosLeft,
+        pathToSimplePos(initial, [1, 0], false)
+      );
+      assert.strictEqual(
+        newTestPos1,
+        pathToSimplePos(initial, [1, 0, 0, 1], false)
+      );
+      assert.strictEqual(
+        newTestPos2,
+        pathToSimplePos(initial, [1, 0, 1], false)
+      );
+      assert.strictEqual(newTestPos3, pathToSimplePos(initial, [4], false));
       assert.strictEqual(
         newTestPos4LeftBias,
-        pathToSimplePos(initial, [1, 0, 0, 0])
+        pathToSimplePos(initial, [1, 0, 0, 0], false)
       );
       assert.strictEqual(newTestPos4RightBias, newEndPos);
       assert.strictEqual(
         newTestPos5,
-        pathToSimplePos(initial, [1, 0, 0, 8, 2])
+        pathToSimplePos(initial, [1, 0, 0, 8, 2], false)
       );
-      assert.strictEqual(newDeepPos, pathToSimplePos(initial, [7, 0, 0, 0, 2]));
+      assert.strictEqual(
+        newDeepPos,
+        pathToSimplePos(initial, [7, 0, 0, 0, 2], false)
+      );
     });
   }
 );

--- a/tests/unit/model/operations/algorithms/remove-new-algorithm-test.ts
+++ b/tests/unit/model/operations/algorithms/remove-new-algorithm-test.ts
@@ -276,28 +276,28 @@ module(
       const end1 = ModelPosition.fromInTextNode(initial, text1, 3);
       OperationAlgorithms.removeNew(
         initial,
-        modelRangeToSimpleRange(new ModelRange(start1, end1))
+        modelRangeToSimpleRange(new ModelRange(start1, end1), false)
       );
 
       const start2 = ModelPosition.fromInTextNode(initial, text2, 4);
       const end2 = ModelPosition.fromInTextNode(initial, text2, 5);
       OperationAlgorithms.removeNew(
         initial,
-        modelRangeToSimpleRange(new ModelRange(start2, end2))
+        modelRangeToSimpleRange(new ModelRange(start2, end2), false)
       );
 
       const start4 = ModelPosition.fromInTextNode(initial, text4, 0);
       const end4 = ModelPosition.fromAfterNode(initial, text5);
       OperationAlgorithms.removeNew(
         initial,
-        modelRangeToSimpleRange(new ModelRange(start4, end4))
+        modelRangeToSimpleRange(new ModelRange(start4, end4), false)
       );
 
       const start5 = ModelPosition.fromInTextNode(initial, text6, 4);
       const end5 = ModelPosition.fromInTextNode(initial, text7, 1);
       OperationAlgorithms.removeNew(
         initial,
-        modelRangeToSimpleRange(new ModelRange(start5, end5))
+        modelRangeToSimpleRange(new ModelRange(start5, end5), false)
       );
 
       assert.expect(1);
@@ -335,28 +335,28 @@ module(
       const end = ModelPosition.fromInTextNode(initial, text2, 2);
       OperationAlgorithms.removeNew(
         initial,
-        modelRangeToSimpleRange(new ModelRange(start, end))
+        modelRangeToSimpleRange(new ModelRange(start, end), false)
       );
 
       const start1 = ModelPosition.fromInTextNode(initial, text3, 2);
       const end1 = ModelPosition.fromInTextNode(initial, text4, 2);
       OperationAlgorithms.removeNew(
         initial,
-        modelRangeToSimpleRange(new ModelRange(start1, end1))
+        modelRangeToSimpleRange(new ModelRange(start1, end1), false)
       );
 
       const start2 = ModelPosition.fromInTextNode(initial, text4, 0);
       const end2 = ModelPosition.fromInTextNode(initial, text4, 1);
       OperationAlgorithms.removeNew(
         initial,
-        modelRangeToSimpleRange(new ModelRange(start2, end2))
+        modelRangeToSimpleRange(new ModelRange(start2, end2), false)
       );
 
       const start3 = ModelPosition.fromInTextNode(initial, text1, 1);
       const end3 = ModelPosition.fromInTextNode(initial, text4, 1);
       OperationAlgorithms.removeNew(
         initial,
-        modelRangeToSimpleRange(new ModelRange(start3, end3))
+        modelRangeToSimpleRange(new ModelRange(start3, end3), false)
       );
 
       assert.expect(1);

--- a/tests/unit/model/operations/algorithms/split-algorithm-test.ts
+++ b/tests/unit/model/operations/algorithms/split-algorithm-test.ts
@@ -52,11 +52,17 @@ module(
       });
       const newTestPos2 = mapper.mapPosition(testPos2);
       assert.true(initial.sameAs(expected));
-      assert.deepEqual(newSplitPos, pathToSimplePos(initial, [1]));
-      assert.deepEqual(newSplitPosLeft, pathToSimplePos(initial, [0, 2]));
-      assert.deepEqual(newTestPos1, pathToSimplePos(initial, [1, 1]));
-      assert.deepEqual(newTestPos1Left, pathToSimplePos(initial, [1, 1]));
-      assert.deepEqual(newTestPos2, pathToSimplePos(initial, [2]));
+      assert.deepEqual(newSplitPos, pathToSimplePos(initial, [1], false));
+      assert.deepEqual(
+        newSplitPosLeft,
+        pathToSimplePos(initial, [0, 2], false)
+      );
+      assert.deepEqual(newTestPos1, pathToSimplePos(initial, [1, 1], false));
+      assert.deepEqual(
+        newTestPos1Left,
+        pathToSimplePos(initial, [1, 1], false)
+      );
+      assert.deepEqual(newTestPos2, pathToSimplePos(initial, [2], false));
     });
     test('rangeMapping is correct after split at end', function (assert) {
       const {
@@ -99,11 +105,17 @@ module(
       });
       const newTestPos2 = mapper.mapPosition(testPos2);
       assert.true(initial.sameAs(expected));
-      assert.strictEqual(newSplitPos, pathToSimplePos(initial, [1]));
-      assert.strictEqual(newSplitPosLeft, pathToSimplePos(initial, [0, 4]));
-      assert.strictEqual(newTestPos1, pathToSimplePos(initial, [0, 3]));
-      assert.strictEqual(newTestPos1Left, pathToSimplePos(initial, [0, 3]));
-      assert.strictEqual(newTestPos2, pathToSimplePos(initial, [2]));
+      assert.strictEqual(newSplitPos, pathToSimplePos(initial, [1], false));
+      assert.strictEqual(
+        newSplitPosLeft,
+        pathToSimplePos(initial, [0, 4], false)
+      );
+      assert.strictEqual(newTestPos1, pathToSimplePos(initial, [0, 3], false));
+      assert.strictEqual(
+        newTestPos1Left,
+        pathToSimplePos(initial, [0, 3], false)
+      );
+      assert.strictEqual(newTestPos2, pathToSimplePos(initial, [2], false));
     });
   }
 );


### PR DESCRIPTION
This PR enables size caching on model-nodes. The caching is disabled while doing mutable operations (e.g. in operation-algorithms).