### PR TITLE
Get remove command working with immutability and fix issues with moveToPosition

### DIFF
--- a/addon/core/state/steps/attribute-step.ts
+++ b/addon/core/state/steps/attribute-step.ts
@@ -24,7 +24,7 @@ interface AddArgs {
   key: string;
   value: string;
 }
-
+ 
 interface RemoveArgs {
   action: 'remove';
   nodePos: SimplePosition;

--- a/addon/core/state/steps/insert-text-step.ts
+++ b/addon/core/state/steps/insert-text-step.ts
@@ -39,12 +39,13 @@ export default class InsertTextStep implements OperationStep {
       text,
       marks
     );
-    const { defaultRange } = op.execute();
+    const { defaultRange, overwrittenNodes: removedNodes } = op.execute();
     return {
       state: resultState,
       defaultRange: modelRangeToSimpleRange(defaultRange),
       mapper: EMPTY_MAPPER,
       timestamp: new Date(),
+      removedNodes,
     };
   }
 }

--- a/addon/core/state/steps/mark-step.ts
+++ b/addon/core/state/steps/mark-step.ts
@@ -72,7 +72,8 @@ export default class MarkStep implements OperationStep {
       }
       //insert new textNode with property set
       this.markAction(node, spec, attributes, action);
-      const { mapper } = OperationAlgorithms.insert(root, range, node);
+      const { mapper, overwrittenNodes: removedNodes } =
+        OperationAlgorithms.insert(root, range, node);
 
       //put the cursor inside that node
       const newRange = ModelRange.fromInNode(root, node, 1, 1);
@@ -86,6 +87,7 @@ export default class MarkStep implements OperationStep {
         mapper,
         state: resultState,
         timestamp: new Date(),
+        removedNodes,
       };
     } else {
       OperationAlgorithms.splitText(root, range.start);
@@ -112,6 +114,7 @@ export default class MarkStep implements OperationStep {
         mapper: new SimpleRangeMapper(),
         state: resultState,
         timestamp: new Date(),
+        removedNodes: [],
       };
     }
   }

--- a/addon/core/state/steps/remove-step.ts
+++ b/addon/core/state/steps/remove-step.ts
@@ -26,7 +26,7 @@ export default class RemoveStep implements OperationStep {
   getResult(initialState: State): OperationStepResult {
     const { range } = this.args;
     const resultState = cloneStateInRange(range, initialState);
-    const { mapper } = OperationAlgorithms.removeNew(
+    const { mapper, removedNodes } = OperationAlgorithms.removeNew(
       resultState.document,
       range
     );
@@ -39,6 +39,7 @@ export default class RemoveStep implements OperationStep {
       defaultRange: mapper.mapRange(range),
       mapper,
       timestamp: new Date(),
+      removedNodes,
     };
   }
 }

--- a/addon/core/state/steps/replace-step.ts
+++ b/addon/core/state/steps/replace-step.ts
@@ -35,17 +35,22 @@ export default class ReplaceStep implements OperationStep {
   getResult(initialState: State): OperationStepResult {
     const resultState = cloneStateInRange(this.range, initialState);
     let mapper: SimpleRangeMapper;
+    let removedNodes: ModelNode[];
     if (!this.nodes.length) {
-      mapper = OperationAlgorithms.remove(
+      const result = OperationAlgorithms.remove(
         resultState.document,
         this.range
-      ).mapper;
+      );
+      mapper = result.mapper;
+      removedNodes = result.removedNodes;
     } else {
-      mapper = OperationAlgorithms.insert(
+      const result = OperationAlgorithms.insert(
         resultState.document,
         this.range,
         ...this.nodes
-      ).mapper;
+      );
+      mapper = result.mapper;
+      removedNodes = result.overwrittenNodes;
     }
     resultState.selection = mapper.mapSelection(
       initialState.selection,
@@ -56,6 +61,7 @@ export default class ReplaceStep implements OperationStep {
       defaultRange: mapper.mapRange(this.range),
       mapper,
       timestamp: new Date(),
+      removedNodes,
     };
   }
 

--- a/addon/core/state/steps/split-step.ts
+++ b/addon/core/state/steps/split-step.ts
@@ -47,6 +47,7 @@ export default class SplitStep implements OperationStep {
         defaultRange: { start: position, end: position },
         mapper,
         timestamp: new Date(),
+        removedNodes: [],
       };
     } else {
       const { position: end, mapper: endMapper } = this.doSplit(
@@ -67,6 +68,7 @@ export default class SplitStep implements OperationStep {
         defaultRange: { start: start, end: startMapper.mapPosition(end) },
         mapper,
         timestamp: new Date(),
+        removedNodes: [],
       };
     }
   }

--- a/addon/core/state/steps/step.ts
+++ b/addon/core/state/steps/step.ts
@@ -12,6 +12,7 @@ import SplitStep from '@lblod/ember-rdfa-editor/core/state/steps/split-step';
 import StateStep from '@lblod/ember-rdfa-editor/core/state/steps/state-step';
 import AttributeStep from '@lblod/ember-rdfa-editor/core/state/steps/attribute-step';
 import WrapStep from '@lblod/ember-rdfa-editor/core/state/steps/wrap-step';
+import ModelNode from '../../model/nodes/model-node';
 
 const OPERATION_STEP_TYPES = new Set<StepType>([
   'replace-step',
@@ -34,6 +35,7 @@ export interface BaseStep {
 
 export interface OperationStepResult extends StepResult {
   defaultRange: SimpleRange;
+  removedNodes: ModelNode[];
 }
 
 export interface OperationStep extends BaseStep {

--- a/addon/core/state/steps/wrap-step.ts
+++ b/addon/core/state/steps/wrap-step.ts
@@ -64,17 +64,15 @@ export default class WrapStep implements OperationStep {
       insertPosition = 0,
     } = this.args;
     const resultState = cloneStateInRange(replaceRange, initialState);
-    const { removedNodes: preservedNodes, mapper: deleteMapper  } = OperationAlgorithms.remove(
-      resultState.document,
-      preserveRange
-    );
+    const { removedNodes: preservedNodes, mapper: deleteMapper } =
+      OperationAlgorithms.remove(resultState.document, preserveRange);
     if (wrappingElement) {
       OperationAlgorithms.insert(
         wrappingElement,
         { start: insertPosition, end: insertPosition },
         ...preservedNodes
       );
-      OperationAlgorithms.insert(
+      const result = OperationAlgorithms.insert(
         resultState.document,
         deleteMapper.mapRange(replaceRange),
         wrappingElement
@@ -93,9 +91,10 @@ export default class WrapStep implements OperationStep {
         timestamp: new Date(),
         mapper,
         defaultRange: mapper.mapRange(replaceRange),
+        removedNodes: result.overwrittenNodes,
       };
     } else {
-      OperationAlgorithms.insert(
+      const result = OperationAlgorithms.insert(
         resultState.document,
         deleteMapper.mapRange(replaceRange),
         ...preservedNodes
@@ -108,6 +107,7 @@ export default class WrapStep implements OperationStep {
         timestamp: new Date(),
         mapper: mapper,
         defaultRange: mapper.mapRange(replaceRange),
+        removedNodes: result.overwrittenNodes,
       };
     }
   }

--- a/addon/core/state/transaction.ts
+++ b/addon/core/state/transaction.ts
@@ -32,7 +32,12 @@ import {
   commandMapToCommandExecutor,
 } from '../../commands/command-manager';
 import { CommandName, Commands } from '@lblod/ember-rdfa-editor';
-import { isOperationStep, OperationStepResult, Step, StepResult } from './steps/step';
+import {
+  isOperationStep,
+  OperationStepResult,
+  Step,
+  StepResult,
+} from './steps/step';
 import SelectionStep from './steps/selection-step';
 import ConfigStep from './steps/config-step';
 import { createLogger } from '@lblod/ember-rdfa-editor/utils/logging-utils';
@@ -408,34 +413,9 @@ export default class Transaction {
     }
     const range = modelRangeToSimpleRange(rangeToMove);
     const position = modelPosToSimplePos(targetPosition);
-    const splitStep = new SplitStep({ range });
-    this.addStep(splitStep);
 
-    const stateAfterSplit = this.apply();
-
-    const rangeAfterSplit = this.mapRange(range, { fromState: startState });
-
-    const modelRangeAfterSplit = simpleRangeToModelRange(
-      rangeAfterSplit,
-      stateAfterSplit.document
-    );
-    const confinedRanges = modelRangeAfterSplit.getMinimumConfinedRanges();
-
-    const nodesToMove: ModelNode[] = [];
-    for (const range of confinedRanges) {
-      let currentNode = range.start.nodeAfter();
-      while (currentNode) {
-        nodesToMove.push(currentNode);
-        if (currentNode === range.end.nodeBefore()) {
-          currentNode = null;
-        } else {
-          currentNode = currentNode.getNextSibling(stateAfterSplit.document);
-        }
-      }
-    }
-
-    const deleteStep = new ReplaceStep({ range: rangeAfterSplit, nodes: [] });
-    this.addStep(deleteStep);
+    const deleteStep = new ReplaceStep({ range, nodes: [] });
+    const deleteStepResult = this.addAndCommitOperationStep(deleteStep);
 
     const positionAfterDelete = this.mapPosition(position, {
       fromState: startState,
@@ -444,7 +424,7 @@ export default class Transaction {
     this.addStep(
       new ReplaceStep({
         range: { start: positionAfterDelete, end: positionAfterDelete },
-        nodes: [...nodesToMove],
+        nodes: [...deleteStepResult.removedNodes],
       })
     );
     return simpleRangeToModelRange(

--- a/tests/unit/commands/remove-command-test.ts
+++ b/tests/unit/commands/remove-command-test.ts
@@ -11,6 +11,37 @@ module('Unit | commands | remove-command', function () {
   const command = new RemoveCommand();
   const executeCommand = makeTestExecute(command);
 
+  test('removing last character of first li in list', function (assert) {
+    const {
+      root: initial,
+      textNodes: { text2 },
+    } = vdom`
+      <modelRoot>
+        <ul>
+          <li><text __id="text2">abc</text></li>
+          <li><text>abc</text></li>
+        </ul>
+      </modelRoot>`;
+
+    const initialState = testState({ document: initial });
+    const { root: expected } = vdom`
+      <modelRoot>
+        <ul>
+          <li><text>ab</text></li>
+          <li><text>abc</text></li>
+        </ul>
+      </modelRoot>`;
+
+    const start = ModelPosition.fromInNode(initial as ModelElement, text2, 2);
+    const end = ModelPosition.fromInNode(initial as ModelElement, text2, 3);
+    const range = new ModelRange(start, end);
+    const { resultState } = executeCommand(initialState, { range });
+    assert.true(
+      resultState.document.sameAs(expected),
+      QUnit.dump.parse(resultState.document)
+    );
+  });
+
   test('removing part of first li in list', function (assert) {
     const {
       root: initial,

--- a/tests/unit/model/operations/move-operation-test.ts
+++ b/tests/unit/model/operations/move-operation-test.ts
@@ -114,22 +114,14 @@ module('Unit | model | operations | move-operation-test', function () {
         <div>
           <text>abgh</text>
           <span>
-            <span>
-              <text>ijkl</text>
-            </span>
-
-            <text>mnop</text>
-            <text>qr</text>
+            <text>ijkl</text>
           </span>
-          <text>cd</text>
+          <text>mnop</text>
+          <text>qrcd</text>
         </div>
-
         <div>
           <span>
             <text>ef</text>
-
-          </span>
-          <span>
             <span>
               <text __id="rangeEnd">st</text>
             </span>
@@ -156,7 +148,7 @@ module('Unit | model | operations | move-operation-test', function () {
     );
     assert.true(
       resultRange.sameAs(
-        ModelRange.fromPaths(actual.document, [1, 1], [1, 1, 0])
+        ModelRange.fromPaths(actual.document, [1, 0, 2], [1, 0, 2, 0])
       ),
       resultRange.toString()
     );


### PR DESCRIPTION
This PR introduces two main changes:
- The remove-command has been modified to take immutability into account, currently it has too use the `inWorkingCopy` method several times, which might need to be avoided.
- A change to how `moveToPosition` works: it now no longer executes a split, but only a remove and insert step.