### PR TITLE
Addition of sub- & superscript text styling plugins

### DIFF
--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -17,6 +17,7 @@ import {
   Logger,
 } from '@lblod/ember-rdfa-editor/utils/logging-utils';
 import BasicStyles from '@lblod/ember-rdfa-editor/plugins/basic-styles/basic-styles';
+import ExtendedStyles from '@lblod/ember-rdfa-editor/plugins/extended-styles/extended-styles';
 import LumpNodePlugin from '@lblod/ember-rdfa-editor/plugins/lump-node/lump-node';
 import { ActiveComponentEntry } from '@lblod/ember-rdfa-editor/model/inline-components/inline-components-registry';
 import ShowActiveRdfaPlugin from '@lblod/ember-rdfa-editor/plugins/show-active-rdfa/show-active-rdfa';
@@ -131,6 +132,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
       { instance: new BasicStyles(), options: null },
       { instance: new LumpNodePlugin(), options: null },
       { instance: new ShowActiveRdfaPlugin(), options: null },
+      { instance: new ExtendedStyles(), options: null },
     ];
     for (const config of pluginConfigs) {
       let name;

--- a/addon/components/subscript-button.hbs
+++ b/addon/components/subscript-button.hbs
@@ -1,0 +1,11 @@
+<button
+  type='button'
+  class='say-toolbar__button {{if this.isSubscript " is-active"}}'
+  {{on 'click' this.toggle}}
+  title={{t 'ember-rdfa-editor.subscript'}}
+>
+  <AuIcon @icon='question-circle' @ariaHidden={{true}} @size='large'/> {{!-- TODO: Replace icon with 'subscript' icon when added to ember-appuniversum --}}
+  <span class='au-u-hidden-visually'>
+    {{t 'ember-rdfa-editor.subscript'}}
+  </span>
+</button>

--- a/addon/components/subscript-button.ts
+++ b/addon/components/subscript-button.ts
@@ -1,0 +1,46 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import Controller from '@lblod/ember-rdfa-editor/model/controller';
+import { tracked } from '@glimmer/tracking';
+import { SelectionChangedEvent } from '@lblod/ember-rdfa-editor/utils/editor-event';
+
+interface Args {
+  controller: Controller;
+}
+
+export default class SubscriptButton extends Component<Args> {
+  @tracked isSubscript = false;
+
+  constructor(parent: unknown, args: Args) {
+    super(parent, args);
+    this.args.controller.onEvent(
+      'selectionChanged',
+      this.updateProperties.bind(this)
+    );
+  }
+
+  updateProperties(event: SelectionChangedEvent) {
+    this.isSubscript = event.payload.hasMark('subscript');
+  }
+
+  @action toggle() {
+    this.setMark(!this.isSubscript, 'subscript');
+  }
+
+  @action
+  setMark(value: boolean, markName: string, attributes = {}) {
+    if (value) {
+      this.args.controller.executeCommand(
+        'add-mark-to-selection',
+        markName,
+        attributes
+      );
+    } else {
+      this.args.controller.executeCommand(
+        'remove-mark-from-selection',
+        markName,
+        attributes
+      );
+    }
+  }
+}

--- a/addon/components/superscript-button.hbs
+++ b/addon/components/superscript-button.hbs
@@ -1,0 +1,11 @@
+<button
+  type='button'
+  class='say-toolbar__button {{if this.isSuperscript " is-active"}}'
+  {{on 'click' this.toggle}}
+  title={{t 'ember-rdfa-editor.superscript'}}
+>
+  <AuIcon @icon='question-circle' @ariaHidden={{true}} @size='large'/> {{!-- TODO: Replace icon with 'superscript' icon when added to ember-appuniversum --}}
+  <span class='au-u-hidden-visually'>
+    {{t 'ember-rdfa-editor.superscript'}}
+  </span>
+</button>

--- a/addon/components/superscript-button.ts
+++ b/addon/components/superscript-button.ts
@@ -1,0 +1,46 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import Controller from '@lblod/ember-rdfa-editor/model/controller';
+import { tracked } from '@glimmer/tracking';
+import { SelectionChangedEvent } from '@lblod/ember-rdfa-editor/utils/editor-event';
+
+interface Args {
+  controller: Controller;
+}
+
+export default class SuperscriptButton extends Component<Args> {
+  @tracked isSuperscript = false;
+
+  constructor(parent: unknown, args: Args) {
+    super(parent, args);
+    this.args.controller.onEvent(
+      'selectionChanged',
+      this.updateProperties.bind(this)
+    );
+  }
+
+  updateProperties(event: SelectionChangedEvent) {
+    this.isSuperscript = event.payload.hasMark('superscript');
+  }
+
+  @action toggle() {
+    this.setMark(!this.isSuperscript, 'superscript');
+  }
+
+  @action
+  setMark(value: boolean, markName: string, attributes = {}) {
+    if (value) {
+      this.args.controller.executeCommand(
+        'add-mark-to-selection',
+        markName,
+        attributes
+      );
+    } else {
+      this.args.controller.executeCommand(
+        'remove-mark-from-selection',
+        markName,
+        attributes
+      );
+    }
+  }
+}

--- a/addon/plugins/extended-styles/extended-styles.ts
+++ b/addon/plugins/extended-styles/extended-styles.ts
@@ -1,0 +1,27 @@
+import { EditorPlugin } from '@lblod/ember-rdfa-editor/utils/editor-plugin';
+import Controller from '@lblod/ember-rdfa-editor/model/controller';
+import { subscriptMarkSpec } from '@lblod/ember-rdfa-editor/plugins/extended-styles/marks/subscript';
+import { superscriptMarkSpec } from '@lblod/ember-rdfa-editor/plugins/extended-styles/marks/superscript';
+
+export default class ExtendedStyles implements EditorPlugin {
+  get name(): string {
+    return 'extended-styles';
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async initialize(controller: Controller): Promise<void> {
+    controller.registerWidget({
+      componentName: 'subscript-button',
+      desiredLocation: 'toolbar',
+    });
+
+    controller.registerMark(subscriptMarkSpec);
+
+    controller.registerWidget({
+      componentName: 'superscript-button',
+      desiredLocation: 'toolbar',
+    });
+
+    controller.registerMark(superscriptMarkSpec);
+  }
+}

--- a/addon/plugins/extended-styles/marks/subscript.ts
+++ b/addon/plugins/extended-styles/marks/subscript.ts
@@ -1,0 +1,17 @@
+import { MarkSpec } from '@lblod/ember-rdfa-editor/model/mark';
+import {
+  RenderSpec,
+  SLOT,
+} from '@lblod/ember-rdfa-editor/model/util/render-spec';
+
+export const subscriptMarkSpec: MarkSpec = {
+  matchers: [{ tag: 'sub' }],
+  name: 'subscript',
+  priority: 100,
+  renderSpec(): RenderSpec {
+    return {
+      tag: 'sub',
+      children: [SLOT],
+    };
+  },
+};

--- a/addon/plugins/extended-styles/marks/superscript.ts
+++ b/addon/plugins/extended-styles/marks/superscript.ts
@@ -1,0 +1,17 @@
+import { MarkSpec } from '@lblod/ember-rdfa-editor/model/mark';
+import {
+  RenderSpec,
+  SLOT,
+} from '@lblod/ember-rdfa-editor/model/util/render-spec';
+
+export const superscriptMarkSpec: MarkSpec = {
+  matchers: [{ tag: 'sup' }],
+  name: 'superscript',
+  priority: 100,
+  renderSpec(): RenderSpec {
+    return {
+      tag: 'sup',
+      children: [SLOT],
+    };
+  },
+};

--- a/app/components/subscript-button.js
+++ b/app/components/subscript-button.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/components/subscript-button';

--- a/app/components/superscript-button.js
+++ b/app/components/superscript-button.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/components/superscript-button';

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -315,6 +315,16 @@ $say-editor-highlight-hover-color: var(--au-gray-200) !default;
     display: inline-block;
   }
 
+  sub {
+    vertical-align: sub;
+    font-size: smaller;
+  }
+
+  sup {
+    vertical-align: super;
+    font-size: smaller;
+  }
+
   // Table styling
   table th {
     white-space: initial;

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4,6 +4,8 @@ ember-rdfa-editor:
   italic: Italic
   underline: Underline
   strikethrough: Strikethrough
+  subscript: Subscript
+  superscript: Superscript
   unordered-list: Unordered list
   ordered-list: Ordered list
   unindent-list: List level higher

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -4,6 +4,8 @@ ember-rdfa-editor:
   italic: Schuingedrukt
   underline: Onderstreept
   strikethrough: Doorstreept
+  subscript: Subscript
+  superscript: Superscript
   unordered-list: Ongeordende lijst
   ordered-list: Geordende lijst
   unindent-list: Lijstniveau hoger


### PR DESCRIPTION
Concerning #404: the addition of sub- & superscript text styling plugins (visualised in the editor toolbar).

These plugins are not added to the basic styles set but to a new extended styles set. The option to show these buttons by default will be set to `false`.

What still needs to be done:
- [ ] Request new sub- & superscript icons within `ember-appuniversum` to use within the toolbar button (@brenner-company).
- [ ] Move sub- & superscript buttons next to the existing buttons on the left of the toolbar (@abeforgit).
- [ ] Fix bug where added buttons are only toggle-able two times (@abeforgit).
- [ ] Addition of new toolbar option. Something like `showExtendedTextStyleButtons` (@abeforgit)? 