### PR TITLE
fix(initialization): emit a selectionchanged after init

### DIFF
--- a/addon/utils/ce/raw-editor.ts
+++ b/addon/utils/ce/raw-editor.ts
@@ -123,11 +123,13 @@ export default class RawEditor {
     this.eventBus.on(
       'contentChanged',
       () => {
+        this.logger('recalculating datastore');
         this._datastore = EditorStore.fromParse({
           modelRoot: this.model.rootModelNode,
           pathFromDomRoot: getPathFromRoot(this.model.rootNode, false),
           baseIRI: (properties?.baseIRI as string | null) || document.baseURI,
         });
+        this.logger(`Parsed ${this._datastore.size} triples`);
       },
       { priority: 'highest' }
     );
@@ -228,6 +230,7 @@ export default class RawEditor {
     this.rangeFactory = new ModelRangeFactory(this.rootModelNode);
     this.modelSelectionTracker = new ModelSelectionTracker(this._model);
     this.modelSelectionTracker.startTracking();
+    this.model.emitSelectionChanged();
   }
 
   /**


### PR DESCRIPTION
selectionchanged events only emit when a new, different selection is set on the model. In the initialization phase, this never happens, since it's the first time the selection is set, so the selection is not "different". But plugins do need to recieve this initial trigger.

note: left the logger statements in intentionally, I think it's useful logging output (and we have a logging framework for a reason).

fixes https://binnenland.atlassian.net/browse/GN-3856