### PR TITLE
bug(datastore): guarantee reference stability for datastore data

### DIFF
--- a/addon/utils/datastore/datastore.ts
+++ b/addon/utils/datastore/datastore.ts
@@ -480,7 +480,7 @@ export class EditorStore<N> implements Datastore<N> {
     }
   }
 
-  *asQuads(): Generator<RDF.Quad, void, null> {
+  *asQuads(): Generator<RDF.Quad, void, undefined> {
     for (const quad of this.dataset) {
       yield quad;
     }

--- a/addon/utils/reference-manager.ts
+++ b/addon/utils/reference-manager.ts
@@ -1,0 +1,24 @@
+export class ReferenceManager<C, R> {
+  private readonly map: Map<string, R>;
+
+  private readonly constr: (config: C) => R;
+
+  private readonly hash: (config: C) => string;
+
+  constructor(constr: (config: C) => R, hash: (config: C) => string) {
+    this.map = new Map();
+    this.hash = hash;
+    this.constr = constr;
+  }
+
+  get(config: C): R {
+    let result = this.map.get(this.hash(config));
+    if (result) {
+      return result;
+    } else {
+      result = this.constr(config);
+      this.map.set(this.hash(config), result);
+      return result;
+    }
+  }
+}


### PR DESCRIPTION
This fixes an issue where too many nodes were filtered out in the
objectNodeGenerator, because we were doing reference checks with
objects that are dynamically created.

This commit introduces a referencemanager class, which guarantees
reference stability based on a configurable hash function.
