### PR TITLE
Return pos instead of resolved pos from datastore

### DIFF
--- a/addon/core/prosemirror.ts
+++ b/addon/core/prosemirror.ts
@@ -246,7 +246,7 @@ export class ProseReferenceManager extends ReferenceManager<
     super(
       (node: ResolvedPNode) => node,
       (node: ResolvedPNode) => {
-        return `${node.pos?.pos ?? 'root'} - ${node.node.toString()} `;
+        return `${node.pos} - ${node.node.toString()} `;
       }
     );
   }

--- a/addon/plugins/datastore/index.ts
+++ b/addon/plugins/datastore/index.ts
@@ -33,7 +33,7 @@ export function datastore({
       init(config: EditorStateConfig, state: EditorState) {
         const refman = new ProseReferenceManager();
         const store = proseStoreFromParse({
-          root: { node: state.doc },
+          root: { node: state.doc, pos: -1 },
           textContent,
           tag: tag(state.schema),
           children: children(state.schema, refman),
@@ -57,7 +57,7 @@ export function datastore({
         const refman = new ProseReferenceManager();
         if (tr.docChanged) {
           const newStore = proseStoreFromParse({
-            root: { node: newState.doc },
+            root: { node: newState.doc, pos: -1 },
             textContent,
             tag: tag(newState.schema),
             children: children(newState.schema, refman),
@@ -115,30 +115,27 @@ function getLinkMark(schema: Schema, node: PNode): Mark | undefined {
 function children(schema: Schema, refman: ProseReferenceManager) {
   return function (resolvedNode: ResolvedPNode): Iterable<ResolvedPNode> {
     let result: Iterable<ResolvedPNode>;
-    const { node, pos: resolvedPos } = resolvedNode;
+    const { node, pos } = resolvedNode;
     if (node.isText) {
       const linkMark = getLinkMark(schema, node);
       if (linkMark) {
         result = [
           refman.get({
             node: node.mark(linkMark.removeFromSet(node.marks)),
-            pos: resolvedPos,
+            pos,
           }),
         ];
       } else {
         result = [];
       }
     } else {
-      const root = resolvedPos ? resolvedPos.doc : node;
       const rslt: ResolvedPNode[] = [];
       node.descendants((child, relativePos) => {
-        const absolutePos = resolvedPos
-          ? resolvedPos.pos + 1 + relativePos
-          : relativePos;
+        const absolutePos = pos + 1 + relativePos;
         rslt.push(
           refman.get({
             node: child,
-            pos: root.resolve(absolutePos),
+            pos: absolutePos,
           })
         );
         return false;
@@ -177,14 +174,15 @@ function getParent(refman: ProseReferenceManager) {
   ): ResolvedPNode | null {
     let result: ResolvedPNode | null;
     const { pos } = resolvedNode;
+    const resolvedPos = resolvedRoot.node.resolve(pos);
     if (!pos) {
       result = null;
-    } else if (pos.depth === 0) {
-      result = refman.get({ node: resolvedRoot.node });
+    } else if (resolvedPos.depth === 0) {
+      result = refman.get({ node: resolvedRoot.node, pos: -1 });
     } else {
       result = refman.get({
-        node: pos.parent,
-        pos: resolvedRoot.node.resolve(pos.before(pos.depth)),
+        node: resolvedPos.parent,
+        pos: resolvedPos.before(),
       });
     }
     return result;

--- a/addon/utils/datastore/prose-store.ts
+++ b/addon/utils/datastore/prose-store.ts
@@ -3,7 +3,7 @@ import {
   RdfaParseConfig,
   RdfaParser,
 } from '@lblod/ember-rdfa-editor/utils/rdfa-parser/rdfa-parser';
-import { Node as PNode, ResolvedPos } from 'prosemirror-model';
+import { Node as PNode } from 'prosemirror-model';
 import { defaultPrefixes } from '@lblod/ember-rdfa-editor/config/rdfa';
 import { EditorState } from 'prosemirror-state';
 import SetUtils from '@lblod/ember-rdfa-editor/utils/set-utils';
@@ -13,7 +13,7 @@ import Datastore, {
 
 export type ResolvedPNode = {
   node: PNode;
-  pos?: ResolvedPos;
+  pos: number;
 };
 
 export interface ProseDatastore extends Datastore<ResolvedPNode> {


### PR DESCRIPTION
Most plugins do not require the resolved positions, this also makes the interface more similar to what descendants returns. If the node is root, the position is set as -1 (as the root does not have a position).