### PR TITLE
Make mark buttons and commands work like they used to

### DIFF
--- a/addon/commands/toggle-mark-add-first.ts
+++ b/addon/commands/toggle-mark-add-first.ts
@@ -1,0 +1,118 @@
+import { PNode } from '@lblod/ember-rdfa-editor';
+import { Attrs, MarkType } from 'prosemirror-model';
+import {
+  Command,
+  EditorState,
+  SelectionRange,
+  TextSelection,
+} from 'prosemirror-state';
+
+export function rangeHasMarkEverywhere(
+  root: PNode,
+  from: number,
+  to: number,
+  markType: MarkType
+) {
+  let found = false;
+  let keepSearching = true;
+  if (to > from) {
+    root.nodesBetween(from, to, (node) => {
+      if (node.isText && keepSearching) {
+        const hasMark = !!markType.isInSet(node.marks);
+        found = hasMark;
+        if (!hasMark) {
+          keepSearching = false;
+        }
+      }
+      return keepSearching;
+    });
+  }
+  return found;
+}
+
+function markApplies(
+  doc: PNode,
+  ranges: readonly SelectionRange[],
+  type: MarkType
+) {
+  for (let i = 0; i < ranges.length; i++) {
+    let { $from, $to } = ranges[i];
+    let can =
+      $from.depth == 0
+        ? doc.inlineContent && doc.type.allowsMarkType(type)
+        : false;
+    doc.nodesBetween($from.pos, $to.pos, (node) => {
+      if (can) {
+        return false;
+      }
+      can = node.inlineContent && node.type.allowsMarkType(type);
+      return true;
+    });
+    if (can) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Adapted from https://github.com/ProseMirror/prosemirror-commands/blob/7635496296b2e561a5893b03154bd89c127a6972/src/commands.ts#L579
+ * Create a command function that toggles the given mark with the
+ * given attributes. Will return `false` when the current selection
+ * doesn't support that mark. This will remove the mark if any marks
+ * of that type exist in the selection, or add it otherwise. If the
+ * selection is empty, this applies to the {@link EditorState#storedMarks stored marks}
+ * instead of a range of the document.
+ *
+ * @param markType
+ * @param attrs
+ */
+export function toggleMarkAddFirst(
+  markType: MarkType,
+  attrs: Attrs | null = null
+): Command {
+  return function (state, dispatch) {
+    let { empty, $cursor, ranges } = state.selection as TextSelection;
+    if ((empty && !$cursor) || !markApplies(state.doc, ranges, markType)) {
+      return false;
+    }
+    if (dispatch) {
+      if ($cursor) {
+        if (markType.isInSet(state.storedMarks || $cursor.marks())) {
+          dispatch(state.tr.removeStoredMark(markType));
+        } else {
+          dispatch(state.tr.addStoredMark(markType.create(attrs)));
+        }
+      } else {
+        let has = false;
+        let tr = state.tr;
+        for (let i = 0; !has && i < ranges.length; i++) {
+          let { $from, $to } = ranges[i];
+          has = rangeHasMarkEverywhere(state.doc, $from.pos, $to.pos, markType);
+        }
+        for (let i = 0; i < ranges.length; i++) {
+          let { $from, $to } = ranges[i];
+          if (has) {
+            tr.removeMark($from.pos, $to.pos, markType);
+          } else {
+            let from = $from.pos;
+            let to = $to.pos;
+            let start = $from.nodeAfter;
+            let end = $to.nodeBefore;
+            let spaceStart =
+              start && start.isText ? /^\s*/.exec(start.text!)![0].length : 0;
+            let spaceEnd =
+              end && end.isText ? /\s*$/.exec(end.text!)![0].length : 0;
+            if (from + spaceStart < to) {
+              from += spaceStart;
+              to -= spaceEnd;
+            }
+            tr.addMark(from, to, markType.create(attrs));
+          }
+        }
+        dispatch(tr.scrollIntoView());
+      }
+    }
+    return true;
+  };
+}

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -2,6 +2,7 @@ import { redo, undo } from 'prosemirror-history';
 import { splitListItem } from 'prosemirror-schema-list';
 import { Command } from 'prosemirror-state';
 import { Schema } from 'prosemirror-model';
+import { toggleMark } from 'prosemirror-commands';
 
 export type Keymap = (schema: Schema) => Record<string, Command>;
 
@@ -9,6 +10,9 @@ export function defaultKeymap(schema: Schema): Record<string, Command> {
   return {
     'Ctrl-z': undo,
     'Ctrl-Shift-z': redo,
+    'Ctrl-b': toggleMark(schema.marks['strong']),
+    'Ctrl-i': toggleMark(schema.marks['em']),
+    'Ctrl-u': toggleMark(schema.marks['underline']),
     Enter: splitListItem(schema.nodes.list_item),
   };
 }

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -2,7 +2,7 @@ import { redo, undo } from 'prosemirror-history';
 import { splitListItem } from 'prosemirror-schema-list';
 import { Command } from 'prosemirror-state';
 import { Schema } from 'prosemirror-model';
-import { toggleMark } from 'prosemirror-commands';
+import { toggleMarkAddFirst } from '@lblod/ember-rdfa-editor/commands/toggle-mark-add-first';
 
 export type Keymap = (schema: Schema) => Record<string, Command>;
 
@@ -10,9 +10,9 @@ export function defaultKeymap(schema: Schema): Record<string, Command> {
   return {
     'Ctrl-z': undo,
     'Ctrl-Shift-z': redo,
-    'Ctrl-b': toggleMark(schema.marks['strong']),
-    'Ctrl-i': toggleMark(schema.marks['em']),
-    'Ctrl-u': toggleMark(schema.marks['underline']),
+    'Ctrl-b': toggleMarkAddFirst(schema.marks['strong']),
+    'Ctrl-i': toggleMarkAddFirst(schema.marks['em']),
+    'Ctrl-u': toggleMarkAddFirst(schema.marks['underline']),
     Enter: splitListItem(schema.nodes.list_item),
   };
 }

--- a/addon/core/prosemirror.ts
+++ b/addon/core/prosemirror.ts
@@ -6,7 +6,7 @@ import {
   MarkType,
   Schema,
 } from 'prosemirror-model';
-import { baseKeymap, selectAll, toggleMark } from 'prosemirror-commands';
+import { baseKeymap, selectAll } from 'prosemirror-commands';
 import {
   getPathFromRoot,
   isElement,
@@ -30,6 +30,10 @@ import {
   ResolvedPNode,
 } from '@lblod/ember-rdfa-editor/plugins/datastore';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
+import {
+  rangeHasMarkEverywhere,
+  toggleMarkAddFirst,
+} from '@lblod/ember-rdfa-editor/commands/toggle-mark-add-first';
 
 export type WidgetLocation =
   | 'toolbarMiddle'
@@ -152,7 +156,7 @@ export class ProseController {
 
   toggleMark(name: string) {
     this.focus();
-    this.doCommand(toggleMark(this.schema.marks[name]));
+    this.doCommand(toggleMarkAddFirst(this.schema.marks[name]));
   }
 
   focus() {
@@ -195,7 +199,7 @@ export class ProseController {
     if (empty) {
       return !!markType.isInSet(this.state.storedMarks || $from.marks());
     } else {
-      return this.state.doc.rangeHasMark(from, to, markType);
+      return rangeHasMarkEverywhere(this.state.doc, from, to, markType);
     }
   }
 


### PR DESCRIPTION
Our old behavior was the inverse of prosemirror's default.
Only when a mark is present on ALL textnodes of a range do we consider it active. ProseMirror normally considers it active when it is present on ANY one of the textnodes in a range.