### PR TITLE
Improve editor keybindings

### DIFF
--- a/addon/components/plugins/table/table-menu.ts
+++ b/addon/components/plugins/table/table-menu.ts
@@ -12,6 +12,7 @@ import {
   deleteTable,
 } from 'prosemirror-tables';
 import { PNode } from '@lblod/ember-rdfa-editor';
+import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
 
 interface Args {
   controller: ProseController;
@@ -37,7 +38,7 @@ export default class TableMenu extends Component<Args> {
     for (let r = 0; r < rows; r++) {
       const cells = [];
       for (let c = 0; c < columns; c++) {
-        cells.push(schema.node('table_cell', null, []));
+        cells.push(unwrap(schema.nodes.table_cell.createAndFill()));
       }
       tableContent.push(schema.node('table_row', null, cells));
     }

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -3,16 +3,31 @@ import { splitListItem } from 'prosemirror-schema-list';
 import { Command } from 'prosemirror-state';
 import { Schema } from 'prosemirror-model';
 import { toggleMarkAddFirst } from '@lblod/ember-rdfa-editor/commands/toggle-mark-add-first';
+import { chainCommands, exitCode } from 'prosemirror-commands';
 
 export type Keymap = (schema: Schema) => Record<string, Command>;
 
 export function defaultKeymap(schema: Schema): Record<string, Command> {
   return {
     'Ctrl-z': undo,
-    'Ctrl-Shift-z': redo,
+    'Ctrl-Z': undo,
+    'Ctrl-y': redo,
+    'Ctrl-Y': redo,
     'Ctrl-b': toggleMarkAddFirst(schema.marks['strong']),
+    'Ctrl-B': toggleMarkAddFirst(schema.marks['strong']),
     'Ctrl-i': toggleMarkAddFirst(schema.marks['em']),
+    'Ctrl-I': toggleMarkAddFirst(schema.marks['em']),
     'Ctrl-u': toggleMarkAddFirst(schema.marks['underline']),
+    'Ctrl-U': toggleMarkAddFirst(schema.marks['underline']),
     Enter: splitListItem(schema.nodes.list_item),
+    'Shift-Enter': chainCommands(exitCode, (state, dispatch) => {
+      if (dispatch)
+        dispatch(
+          state.tr
+            .replaceSelectionWith(schema.nodes.hard_break.create())
+            .scrollIntoView()
+        );
+      return true;
+    }),
   };
 }

--- a/addon/plugins/table/utils.ts
+++ b/addon/plugins/table/utils.ts
@@ -1,0 +1,105 @@
+/**
+ *
+ * Modified from https://github.com/ProseMirror/prosemirror-tables
+ *
+ * Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+import { NodeSelection, ResolvedPos } from '@lblod/ember-rdfa-editor';
+import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
+import { cellAround, CellSelection, Direction } from 'prosemirror-tables';
+
+export function findNextCell(
+  $cell: ResolvedPos,
+  dir: Direction
+): number | null {
+  if (dir < 0) {
+    const before = $cell.nodeBefore;
+    if (before) return $cell.pos - before.nodeSize;
+    for (
+      let row = $cell.index(-1) - 1, rowEnd = $cell.before();
+      row >= 0;
+      row--
+    ) {
+      const rowNode = $cell.node(-1).child(row);
+      const lastChild = rowNode.lastChild;
+      if (lastChild) {
+        return rowEnd - 1 - lastChild.nodeSize;
+      }
+      rowEnd -= rowNode.nodeSize;
+    }
+  } else {
+    if ($cell.index() < $cell.parent.childCount - 1) {
+      return $cell.pos + unwrap($cell.nodeAfter).nodeSize;
+    }
+    const table = $cell.node(-1);
+    for (
+      let row = $cell.indexAfter(-1), rowStart = $cell.after();
+      row < table.childCount;
+      row++
+    ) {
+      const rowNode = table.child(row);
+      if (rowNode.childCount) return rowStart + 1;
+      rowStart += rowNode.nodeSize;
+    }
+  }
+  return null;
+}
+
+export function selectionCell(sel: CellSelection | NodeSelection): ResolvedPos {
+  if ('$anchorCell' in sel && sel.$anchorCell) {
+    return sel.$anchorCell.pos > sel.$headCell.pos
+      ? sel.$anchorCell
+      : sel.$headCell;
+  } else if (
+    'node' in sel &&
+    sel.node &&
+    sel.node.type.spec.tableRole == 'cell'
+  ) {
+    return sel.$anchor;
+  }
+  const $cell = cellAround(sel.$head) || cellNear(sel.$head);
+  if ($cell) {
+    return $cell;
+  }
+  throw new RangeError(`No cell found around position ${sel.head}`);
+}
+
+function cellNear($pos: ResolvedPos): ResolvedPos | undefined {
+  for (
+    let after = $pos.nodeAfter, pos = $pos.pos;
+    after;
+    after = after.firstChild, pos++
+  ) {
+    const role = after.type.spec.tableRole as string;
+    if (role == 'cell' || role == 'header_cell') return $pos.doc.resolve(pos);
+  }
+  for (
+    let before = $pos.nodeBefore, pos = $pos.pos;
+    before;
+    before = before.lastChild, pos--
+  ) {
+    const role = before.type.spec.tableRole as string;
+    if (role == 'cell' || role == 'header_cell')
+      return $pos.doc.resolve(pos - before.nodeSize);
+  }
+  return;
+}

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -52,7 +52,7 @@ const nodes = {
   ordered_list,
   bullet_list,
   placeholder,
-  ...tableNodes({ tableGroup: 'block', cellContent: 'inline*' }),
+  ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
   heading,
   blockquote,
 


### PR DESCRIPTION
This PR adds/improves various keybindings in the editor:
- Shift+Enter: adds a line break
- Ctrl+y: undo
- Tab in tables: goes to the next cell, unless if the cursor is located in the last cell, then it inserts a new row
- Table cells can now contain block nodes, the enter key inserts a newline instead of a new row.
- All shortcuts now also work as expected when CAPS lock is enabled

Solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3943, based on feedback from the testers.