### PR TITLE
Remove context from parsing rule paragraph

### DIFF
--- a/addon/nodes/paragraph.ts
+++ b/addon/nodes/paragraph.ts
@@ -16,7 +16,6 @@ export const paragraph: NodeSpec = {
         }
         return null;
       },
-      context: 'block/',
     },
   ],
   toDOM(node: PNode) {


### PR DESCRIPTION
This ensures that paragraphs can be parsed inside nodes which are not in the group `block`.

Partial fix for https://binnenland.atlassian.net/browse/GN-3953?atlOrigin=eyJpIjoiNzY2ZjZjODI4OTIwNGQwZTg2ZmMxZTNiMzdhN2Y2OTkiLCJwIjoiaiJ9.