### PR TITLE
Set word-wrap as break-word on editor

### DIFF
--- a/app/styles/ember-rdfa-editor/_c-editor.scss
+++ b/app/styles/ember-rdfa-editor/_c-editor.scss
@@ -71,6 +71,7 @@ $say-annotation-width: $au-unit-huge * 1.5 !default;
   position: relative;
   min-height: $say-paper-min-height;
   white-space: pre-wrap;
+  word-wrap: break-word;
 
   // Remove start styles
   &:focus {


### PR DESCRIPTION
This ensures that lines do not overflow in the editor and wrap to the next line.