### PR TITLE
Make parsing rules of lists and paragraphs non consuming

### DIFF
--- a/addon/nodes/list-nodes.ts
+++ b/addon/nodes/list-nodes.ts
@@ -19,6 +19,7 @@ export const ordered_list: NodeSpec = {
           ...getRdfaAttrs(dom),
         };
       },
+      consuming: false,
     },
   ],
   toDOM(node) {
@@ -41,6 +42,7 @@ export const bullet_list: NodeSpec = {
           ...getRdfaAttrs(node),
         };
       },
+      consuming: false,
     },
   ],
   toDOM(node: PNode) {

--- a/addon/nodes/paragraph.ts
+++ b/addon/nodes/paragraph.ts
@@ -16,6 +16,7 @@ export const paragraph: NodeSpec = {
         }
         return null;
       },
+      consuming: false,
     },
   ],
   toDOM(node: PNode) {


### PR DESCRIPTION
To prevent recursion errors, the `doc` and `paragraph` nodes should have the highest priority in any schema. But we should make sure the parsing rules of a `paragraph` is non consuming so that other nodes which match on the `p` tag (such as `repaired_block` or specific custom nodes) also have the chance for their parsing rules to run.