### PR TITLE
Make paragraphs not parse when they contain rdfa

### DIFF
--- a/addon/nodes/block-rdfa.ts
+++ b/addon/nodes/block-rdfa.ts
@@ -2,7 +2,7 @@ import { Node as PNode, NodeSpec } from 'prosemirror-model';
 import { getRdfaAttrs, rdfaAttrs } from '@lblod/ember-rdfa-editor';
 
 export const block_rdfa: NodeSpec = {
-  content: 'block*',
+  content: 'block+',
   group: 'block',
   attrs: {
     ...rdfaAttrs,
@@ -11,7 +11,7 @@ export const block_rdfa: NodeSpec = {
   defining: true,
   parseDOM: [
     {
-      tag: `div, address, article, aside, blockquote, details, dialog, dd, dt, fieldset, figcaption, figure, footer, form, header, hgroup, hr, main, nav, pre, section`,
+      tag: `p, div, address, article, aside, blockquote, details, dialog, dd, dt, fieldset, figcaption, figure, footer, form, header, hgroup, hr, main, nav, pre, section`,
       getAttrs(node: HTMLElement) {
         return getRdfaAttrs(node);
       },

--- a/addon/nodes/paragraph.ts
+++ b/addon/nodes/paragraph.ts
@@ -1,24 +1,24 @@
 import { NodeSpec } from 'prosemirror-model';
-import { getRdfaAttrs, PNode, rdfaAttrs } from '@lblod/ember-rdfa-editor';
+import { getRdfaAttrs } from '@lblod/ember-rdfa-editor';
 
 export const paragraph: NodeSpec = {
   content: 'inline*',
   group: 'block',
-  attrs: { ...rdfaAttrs },
   // defining: true,
+  consuming: false,
   parseDOM: [
     {
       tag: 'p',
       getAttrs(node: HTMLElement) {
         const myAttrs = getRdfaAttrs(node);
         if (myAttrs) {
-          return myAttrs;
+          return false;
         }
         return null;
       },
     },
   ],
-  toDOM(node: PNode) {
-    return ['p', node.attrs, 0];
+  toDOM() {
+    return ['p', {}, 0];
   },
 };

--- a/addon/nodes/paragraph.ts
+++ b/addon/nodes/paragraph.ts
@@ -5,7 +5,6 @@ export const paragraph: NodeSpec = {
   content: 'inline*',
   group: 'block',
   // defining: true,
-  consuming: false,
   parseDOM: [
     {
       tag: 'p',


### PR DESCRIPTION
Keeping paragraphs as structure-only nodes (without any data) makes for a much cleaner editing experience (no unexpected splits of rdfa content anymore)