### PR TITLE
Add functionality to support an embedded view and allow widgets to perform actions on either the outer or inner view

### DIFF
--- a/addon/components/plugins/subscript/button.ts
+++ b/addon/components/plugins/subscript/button.ts
@@ -10,11 +10,14 @@ export default class SubscriptButton extends Component<Args> {
     return this.args.controller;
   }
   get isActive() {
-    return this.controller.isMarkActive(this.controller.schema.marks.subscript);
+    return this.controller.isMarkActive(
+      this.controller.schema.marks.subscript,
+      true
+    );
   }
 
   @action
   toggle() {
-    this.controller.toggleMark('subscript');
+    this.controller.toggleMark('subscript', true);
   }
 }

--- a/addon/components/plugins/superscript/button.ts
+++ b/addon/components/plugins/superscript/button.ts
@@ -11,12 +11,13 @@ export default class SuperscriptButton extends Component<Args> {
   }
   get isActive() {
     return this.controller.isMarkActive(
-      this.controller.schema.marks.superscript
+      this.controller.schema.marks.superscript,
+      true
     );
   }
 
   @action
   toggle() {
-    this.controller.toggleMark('superscript');
+    this.controller.toggleMark('superscript', true);
   }
 }

--- a/addon/components/plugins/table/table-menu.hbs
+++ b/addon/components/plugins/table/table-menu.hbs
@@ -1,3 +1,4 @@
+{{#unless @controller.inEmbeddedView}}
 <Rdfa::ToolbarDropdown
   @controller={{@controller}}
   @icon="table"
@@ -106,3 +107,4 @@
     {{on 'click' this.insertRowBelow}}
   />
 {{/if}}
+{{/unless}}

--- a/addon/components/rdfa/editor-toolbar.ts
+++ b/addon/components/rdfa/editor-toolbar.ts
@@ -27,20 +27,27 @@ export default class EditorToolbar extends Component<Args> {
   @tracked tableAddColumns = 2;
 
   get isBold() {
-    return this.controller.isMarkActive(this.controller.schema.marks.strong);
+    return this.controller.isMarkActive(
+      this.controller.schema.marks.strong,
+      true
+    );
   }
 
   get isItalic() {
-    return this.controller.isMarkActive(this.controller.schema.marks.em);
+    return this.controller.isMarkActive(this.controller.schema.marks.em, true);
   }
 
   get isUnderline() {
-    return this.controller.isMarkActive(this.controller.schema.marks.underline);
+    return this.controller.isMarkActive(
+      this.controller.schema.marks.underline,
+      true
+    );
   }
 
   get isStrikethrough() {
     return this.controller.isMarkActive(
-      this.controller.schema.marks.strikethrough
+      this.controller.schema.marks.strikethrough,
+      true
     );
   }
 
@@ -55,20 +62,23 @@ export default class EditorToolbar extends Component<Args> {
   get canInsertList() {
     return (
       this.controller.checkCommand(
-        wrapInList(this.controller.schema.nodes.bullet_list)
+        wrapInList(this.controller.schema.nodes.bullet_list),
+        true
       ) || this.isInList
     );
   }
 
   get canIndent() {
     return this.controller.checkCommand(
-      sinkListItem(this.controller.schema.nodes.list_item)
+      sinkListItem(this.controller.schema.nodes.list_item),
+      true
     );
   }
 
   get canUnindent() {
     return this.controller.checkCommand(
-      liftListItem(this.controller.schema.nodes.list_item)
+      liftListItem(this.controller.schema.nodes.list_item),
+      true
     );
   }
 
@@ -76,7 +86,8 @@ export default class EditorToolbar extends Component<Args> {
   insertIndent() {
     this.controller.focus();
     this.controller.doCommand(
-      sinkListItem(this.controller.schema.nodes.list_item)
+      sinkListItem(this.controller.schema.nodes.list_item),
+      true
     );
   }
 
@@ -84,13 +95,14 @@ export default class EditorToolbar extends Component<Args> {
   insertUnindent() {
     this.controller.focus();
     this.controller.doCommand(
-      liftListItem(this.controller.schema.nodes.list_item)
+      liftListItem(this.controller.schema.nodes.list_item),
+      true
     );
   }
 
   @action
   toggleItalic() {
-    this.controller.toggleMark('em');
+    this.controller.toggleMark('em', true);
   }
 
   @action
@@ -102,7 +114,8 @@ export default class EditorToolbar extends Component<Args> {
       }
     } else {
       this.controller.checkAndDoCommand(
-        wrapInList(this.controller.schema.nodes.bullet_list)
+        wrapInList(this.controller.schema.nodes.bullet_list),
+        true
       );
     }
   }
@@ -111,23 +124,24 @@ export default class EditorToolbar extends Component<Args> {
   toggleOrderedList() {
     this.controller.focus();
     this.controller.checkAndDoCommand(
-      wrapInList(this.controller.schema.nodes.ordered_list)
+      wrapInList(this.controller.schema.nodes.ordered_list),
+      true
     );
   }
 
   @action
   toggleBold() {
-    this.controller.toggleMark('strong');
+    this.controller.toggleMark('strong', true);
   }
 
   @action
   toggleUnderline() {
-    this.controller.toggleMark('underline');
+    this.controller.toggleMark('underline', true);
   }
 
   @action
   toggleStrikethrough() {
-    this.controller.toggleMark('strikethrough');
+    this.controller.toggleMark('strikethrough', true);
   }
 
   @action

--- a/addon/core/prosemirror.ts
+++ b/addon/core/prosemirror.ts
@@ -226,7 +226,6 @@ export class ProseController {
   }
 
   toggleMark(name: string, includeEmbeddedView = false) {
-    console.log('Embedded view: ', this.pm.embeddedView);
     this.focus(includeEmbeddedView);
     this.doCommand(
       toggleMarkAddFirst(this.schema.marks[name]),

--- a/addon/core/prosemirror.ts
+++ b/addon/core/prosemirror.ts
@@ -323,6 +323,14 @@ export class ProseController {
     return this.pm.view;
   }
 
+  getState(includeEmbeddedView = false) {
+    return this.pm.getState(includeEmbeddedView);
+  }
+
+  getView(includeEmbeddedView = false) {
+    return this.pm.getView(includeEmbeddedView);
+  }
+
   get htmlContent(): string {
     const fragment = DOMSerializer.fromSchema(this.schema).serializeFragment(
       this.pm.state.doc.content,

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -27,3 +27,5 @@ export * from 'prosemirror-history';
 export type InlineDecorationSpec = NonNullable<
   Parameters<typeof Decoration.inline>[3]
 >;
+
+export { RdfaEditorView } from '@lblod/ember-rdfa-editor/core/prosemirror';


### PR DESCRIPTION
This PR allows widgets to perform actions on embedded views when they are in focus. This is .e.g useful to allow the toggling of marks inside a variable-node, which is essentially an embedded prosemirror-view.

If the widgets have the desire to perform actions on an embedded view if one is focused, they can pass the optional `includeEmbeddedView` parameter to several controller methods. By default, this parameter is false.
Methods for which the `includeEmbeddedView` parameter  can be used:
- `toggleMark`
- `doCommand`
- `checkCommand`
- `checkAndDoCommand`
- `isMarkActive`
- `withTransaction`

The controller also provides two additional methods:
- `setEmbeddedView(view: RdfaEditorView)`
- `clearEmbeddedView`

This PR also includes a modified version of the `EditorView` class, called `RdfaEditorView`, which includes a tracked versioned of `state`.