### PR TITLE
Add eslint-plugin-deprecation package to check for use of deprecated code.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
       legacyDecorators: true,
     },
   },
-  plugins: ['ember', '@typescript-eslint'],
+  plugins: ['ember', '@typescript-eslint', 'deprecation'],
   extends: [
     'eslint:recommended',
     'plugin:ember/recommended',
@@ -65,6 +65,7 @@ module.exports = {
         project: ['./tsconfig.json'],
       },
       rules: {
+        'deprecation/deprecation': 'warn',
         'ember/no-jquery': 'error',
         semi: 'off',
         '@typescript-eslint/no-unused-vars': [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A deprecation eslint rule using the eslint-plugin-deprecation package.
+
 ## [2.0.1] - 2023-02-02
 
 ### Fixed 

--- a/addon/utils/rdfa-parser/util.ts
+++ b/addon/utils/rdfa-parser/util.ts
@@ -123,7 +123,7 @@ export class Util<N> {
     if (xmlnsPrefixMappings) {
       for (const attribute in attributes) {
         if (attribute.startsWith('xmlns')) {
-          additionalPrefixes[attribute.substr(6)] = attributes[attribute];
+          additionalPrefixes[attribute.substring(6)] = attributes[attribute];
         }
       }
     }
@@ -174,8 +174,8 @@ export class Util<N> {
     let prefix: string | null = null;
     let local = '';
     if (colonIndex >= 0) {
-      prefix = term.substr(0, colonIndex);
-      local = term.substr(colonIndex + 1);
+      prefix = term.substring(0, colonIndex);
+      local = term.substring(colonIndex + 1);
     }
 
     // Expand default namespace
@@ -231,7 +231,7 @@ export class Util<N> {
     let href: string = baseIriValue;
     const fragmentIndex = href.indexOf('#');
     if (fragmentIndex >= 0) {
-      href = href.substr(0, fragmentIndex);
+      href = href.substring(0, fragmentIndex);
     }
     return this.dataFactory.namedNode(resolve(href, this.baseIRI.value), node);
   }
@@ -366,7 +366,7 @@ export class Util<N> {
 
     // Handle strict CURIEs
     if (term.length > 0 && term[0] === '[' && term[term.length - 1] === ']') {
-      term = term.substr(1, term.length - 2);
+      term = term.substring(1, term.length - 1);
 
       // Strict CURIEs MUST have a prefix separator
       if (term.indexOf(':') < 0) {
@@ -378,7 +378,7 @@ export class Util<N> {
     if (term.startsWith('_:')) {
       return allowBlankNode
         ? this.dataFactory.blankNode(
-            term.substr(2) || 'b_identity',
+            term.substring(2) || 'b_identity',
             activeTag.node
           )
         : null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,7 @@
         "ember-try": "^2.0.0",
         "eslint": "^8.24.0",
         "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-deprecation": "^1.3.3",
         "eslint-plugin-ember": "^11.1.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -3934,6 +3935,25 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.50.0.tgz",
+      "integrity": "sha512-gZIhzNRivy0RVqcxjKnQ+ipGc0qolilhBeNmvH+Dvu7Vymug+IfiYxTj2zM7mIlHsw6Q5aH7L7WmuTE3tZyzag==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "5.50.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -18201,6 +18221,21 @@
       "resolved": "https://registry.npmjs.org/eslint-formatter-kakoune/-/eslint-formatter-kakoune-1.0.0.tgz",
       "integrity": "sha512-Uk/TVLt6Nf6Xoz7C1iYuZjOSdJxe5aaauGRke8JhKeJwD66Y61/pY2FjtLP04Ooq9PwV34bzrkKkU2UZ5FtDRA==",
       "dev": true
+    },
+    "node_modules/eslint-plugin-deprecation": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.3.tgz",
+      "integrity": "sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "typescript": "^3.7.5 || ^4.0.0"
+      }
     },
     "node_modules/eslint-plugin-ember": {
       "version": "11.4.6",
@@ -35100,6 +35135,15 @@
         "tsutils": "^3.21.0"
       }
     },
+    "@typescript-eslint/experimental-utils": {
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.50.0.tgz",
+      "integrity": "sha512-gZIhzNRivy0RVqcxjKnQ+ipGc0qolilhBeNmvH+Dvu7Vymug+IfiYxTj2zM7mIlHsw6Q5aH7L7WmuTE3tZyzag==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "5.50.0"
+      }
+    },
     "@typescript-eslint/parser": {
       "version": "5.50.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.50.0.tgz",
@@ -46755,6 +46799,17 @@
       "resolved": "https://registry.npmjs.org/eslint-formatter-kakoune/-/eslint-formatter-kakoune-1.0.0.tgz",
       "integrity": "sha512-Uk/TVLt6Nf6Xoz7C1iYuZjOSdJxe5aaauGRke8JhKeJwD66Y61/pY2FjtLP04Ooq9PwV34bzrkKkU2UZ5FtDRA==",
       "dev": true
+    },
+    "eslint-plugin-deprecation": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.3.tgz",
+      "integrity": "sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^5.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      }
     },
     "eslint-plugin-ember": {
       "version": "11.4.6",

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "ember-try": "^2.0.0",
     "eslint": "^8.24.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-deprecation": "^1.3.3",
     "eslint-plugin-ember": "^11.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",


### PR DESCRIPTION
Addition of eslint rule to check for usage of deprecated code.

Additionally this PR replaces/removes the usage of the following deprecated code:
- `substr` is replaced by `substring`