### PR TITLE
Add plugin to auto generate attributes when they are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- addition of an attribute generation plugin which auto-generates specific missing attributes.
+
 ## [2.1.0] - 2023-02-06
 
 ### Fixed

--- a/addon/components/rdfa/rdfa-editor-with-debug.hbs
+++ b/addon/components/rdfa/rdfa-editor-with-debug.hbs
@@ -64,6 +64,7 @@
           @toolbarOptions={{@toolbarOptions}}
           @pasteBehaviour={{this.pasteBehaviour}}
           @devtools={{this.devtools}}
+          @generateDefaultAttributes={{@generateDefaultAttributes}}
         />
       </div>
     </div>

--- a/addon/components/rdfa/rdfa-editor-with-debug.ts
+++ b/addon/components/rdfa/rdfa-editor-with-debug.ts
@@ -15,6 +15,7 @@ import { NodeViewConstructor } from 'prosemirror-view';
 import { ProsePlugin } from '@lblod/ember-rdfa-editor';
 import { Schema } from 'prosemirror-model';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/option';
+import { DefaultAttrGenPuginOptions } from '@lblod/ember-rdfa-editor/plugins/default-attribute-value-generation';
 
 interface RdfaEditorDebugArgs {
   rdfaEditorInit: (rdfaDocument: ProseController) => void;
@@ -23,6 +24,7 @@ interface RdfaEditorDebugArgs {
   plugins?: ProsePlugin[];
   schema: Schema;
   widgets?: WidgetSpec[];
+  generateDefaultAttributes?: DefaultAttrGenPuginOptions;
   baseIRI: string;
 }
 

--- a/addon/components/rdfa/rdfa-editor.ts
+++ b/addon/components/rdfa/rdfa-editor.ts
@@ -20,6 +20,7 @@ import { Schema } from 'prosemirror-model';
 import { Plugin } from 'prosemirror-state';
 import { getOwner } from '@ember/application';
 import Owner from '@ember/owner';
+import { DefaultAttrGenPuginOptions } from '@lblod/ember-rdfa-editor/plugins/default-attribute-value-generation';
 
 /**
  *
@@ -73,6 +74,7 @@ interface RdfaEditorArgs {
   nodeViews?: (controller: ProseController) => {
     [node: string]: NodeViewConstructor;
   };
+  generateDefaultAttributes?: DefaultAttrGenPuginOptions;
   toolbarOptions?: ToolbarOptions;
   editorOptions?: EditorOptions;
 }
@@ -152,6 +154,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
       plugins: this.args.plugins,
       nodeViews: this.args.nodeViews,
       widgets: this.args.widgets,
+      generateDefaultAttributes: this.args.generateDefaultAttributes,
     });
     window.__PM = this.prosemirror;
     window.__PC = new ProseController(this.prosemirror);

--- a/addon/plugins/default-attribute-value-generation/index.ts
+++ b/addon/plugins/default-attribute-value-generation/index.ts
@@ -3,13 +3,15 @@ import { isNone } from '@lblod/ember-rdfa-editor/utils/option';
 import { MarkType, NodeType } from 'prosemirror-model';
 import { Plugin } from 'prosemirror-state';
 
-type PluginOptions = {
+export type DefaultAttrGenPuginOptions = {
   attribute: string;
   generator: () => unknown;
   types?: Set<NodeType | MarkType>;
 }[];
 
-export function defaultAttributeValueGeneration(options: PluginOptions) {
+export function defaultAttributeValueGeneration(
+  options: DefaultAttrGenPuginOptions
+) {
   return new Plugin({
     appendTransaction(transactions, oldState, newState) {
       if (transactions.some((transaction) => transaction.docChanged)) {

--- a/addon/plugins/default-attribute-value-generation/index.ts
+++ b/addon/plugins/default-attribute-value-generation/index.ts
@@ -1,0 +1,56 @@
+import { changedDescendants } from '@lblod/ember-rdfa-editor/utils/changed-descendants';
+import { isNone } from '@lblod/ember-rdfa-editor/utils/option';
+import { MarkType, NodeType } from 'prosemirror-model';
+import { Plugin } from 'prosemirror-state';
+
+type PluginOptions = {
+  attribute: string;
+  generator: () => unknown;
+  types?: Set<NodeType | MarkType>;
+}[];
+
+export function defaultAttributeValueGeneration(options: PluginOptions) {
+  return new Plugin({
+    appendTransaction(transactions, oldState, newState) {
+      if (transactions.some((transaction) => transaction.docChanged)) {
+        const tr = newState.tr;
+        changedDescendants(oldState.doc, newState.doc, 0, (node, pos) => {
+          let newAttrs = node.attrs;
+          let newMarks = node.marks;
+          options.forEach(({ attribute, generator, types }) => {
+            if (!node.isText) {
+              if (!types || types.has(node.type)) {
+                if (attribute in node.attrs && isNone(node.attrs[attribute])) {
+                  newAttrs = { ...node.attrs, [attribute]: generator() };
+                }
+              }
+            }
+
+            newMarks = node.marks.map((mark) => {
+              if (!types || types.has(mark.type)) {
+                if (attribute in mark.attrs && isNone(mark.attrs[attribute])) {
+                  return mark.type.create({
+                    ...mark.attrs,
+                    [attribute]: generator(),
+                  });
+                }
+              }
+              return mark;
+            });
+          });
+          if (node.isText) {
+            tr.replaceWith(
+              pos,
+              pos + node.nodeSize,
+              newState.schema.text(node.textContent, newMarks)
+            );
+          } else {
+            tr.setNodeMarkup(pos, null, newAttrs, newMarks);
+          }
+        });
+        return tr.steps.length ? tr : null;
+      }
+      return;
+    },
+  });
+}

--- a/addon/utils/changed-descendants.ts
+++ b/addon/utils/changed-descendants.ts
@@ -1,0 +1,29 @@
+import { PNode } from '..';
+
+// from https://github.com/ProseMirror/prosemirror-tables/blob/8ec1e96ae994c1585b07b1ca9dc3292f63e868e0/src/fixtables.ts#L24
+export function changedDescendants(
+  old: PNode,
+  cur: PNode,
+  offset: number,
+  f: (node: PNode, pos: number) => void
+): void {
+  const oldSize = old.childCount;
+  const curSize = cur.childCount;
+  outer: for (let i = 0, j = 0; i < curSize; i++) {
+    const child = cur.child(i);
+    for (let scan = j, e = Math.min(oldSize, i + 3); scan < e; scan++) {
+      if (old.child(scan) === child) {
+        j = scan + 1;
+        offset += child.nodeSize;
+        continue outer;
+      }
+    }
+    f(child, offset);
+    if (j < oldSize && old.child(j).sameMarkup(child)) {
+      changedDescendants(old.child(j), child, offset + 1, f);
+    } else {
+      child.nodesBetween(0, child.content.size, f, offset + 1);
+    }
+    offset += child.nodeSize;
+  }
+}


### PR DESCRIPTION
This PR adds a plugin which is able to fill in node and mark attributes when their value is null or undefined. Examples include the attribute `__rdfaId`. Users of this plugin can configure it with a list of options: each option must/can include the following:
- the attribute name (required)
- the generator function for the attribute (required)
- a set of node- and mark types the plugin should check for (optional), by default the plugin checks for all node and mark types.

Solves https://binnenland.atlassian.net/browse/GN-4009?atlOrigin=eyJpIjoiNDZhYjNmN2I5ZDg3NDcwM2I4NWRmZTQ5MTAzYjExNWYiLCJwIjoiaiJ9.