### PR TITLE
Allow users to set a cursor by clicking in the margin of the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: Removal of the `RdfaEditorWithDebug` component, use `DebugTools` instead.
 - BREAKING: Removal of `toolbarOptions` argument of the editor component
 - BREAKING: Removal of `widgets` argument of the editor component
+- Allow users to set a cursor by clicking in the margin of the editor
 
 
 ### Fixed

--- a/app/styles/ember-rdfa-editor/_c-editor.scss
+++ b/app/styles/ember-rdfa-editor/_c-editor.scss
@@ -57,7 +57,6 @@ $say-annotation-width: $au-unit-huge * 1.5 !default;
 
   .say-container--paper & {
     background-color: $say-paper-background;
-    padding: $say-paper-padding;
     box-shadow: $say-paper-box-shadow;
   }
 }
@@ -68,6 +67,7 @@ $say-annotation-width: $au-unit-huge * 1.5 !default;
 }
 
 .say-editor__inner {
+  padding: $say-paper-padding;
   position: relative;
   min-height: $say-paper-min-height;
   white-space: break-spaces;


### PR DESCRIPTION
This PR improves cursor behaviour in the editor by allow users to click inside the margin (implemented by padding) to put a selection at the start of the current line. This also makes it easier to put a selection before an ember-node if that node is at the beginning of a line.