### PR TITLE
Fix issue with parsing links from pasted html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix issue with parsing links from pasted html
+
 ## [3.2.0] - 2023-02-27
 
 ### Added

--- a/addon/plugins/link/nodes/link.ts
+++ b/addon/plugins/link/nodes/link.ts
@@ -20,6 +20,7 @@ const emberNodeConfig: (options: LinkOptions) => EmberNodeConfig = (
     group: 'inline',
     content: 'text*',
     atom: true,
+    defining: true,
     draggable: false,
     attrs: {
       ...rdfaAttrs,

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -149,6 +149,7 @@ export type EmberNodeConfig = {
   content?: string;
   atom: boolean;
   draggable?: boolean;
+  defining?: boolean;
   recreateUri?: boolean;
   uriAttributes?: string[];
   attrs?: {
@@ -177,6 +178,7 @@ export function createEmberNodeSpec(config: EmberNodeConfig): NodeSpec {
     content,
     atom,
     draggable,
+    defining,
     recreateUri,
     uriAttributes,
     attrs,
@@ -192,6 +194,7 @@ export function createEmberNodeSpec(config: EmberNodeConfig): NodeSpec {
     uriAttributes,
     attrs,
     draggable,
+    defining,
     parseDOM: parseDOM ?? [
       {
         tag: inline ? 'span' : 'div',


### PR DESCRIPTION
Ensures links are fully and correctly parsed by enabling `defining` on link nodes. Solves https://binnenland.atlassian.net/browse/GN-4122?atlOrigin=eyJpIjoiMzU2NGJhMTFiNDFlNGFlMzhlZWVkNWI5NTQxOGZlMmEiLCJwIjoiaiJ9.