### PR TITLE
Add `linkPasteHandler` plugin which detects and converts links in pasted content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Addition of linkPasteHandler plugin which detects and converts links in pasted content
 
+### Changed
+- Use the new view pasteHTML method inside the Word paste handler.
+
 ## [3.2.0] - 2023-02-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Addition of linkPasteHandler plugin which detects and converts links in pasted content
+
 ## [3.2.0] - 2023-02-27
 
 ### Added

--- a/addon/core/paste-handler.ts
+++ b/addon/core/paste-handler.ts
@@ -1,4 +1,4 @@
-import { ProseParser, ProsePlugin } from '..';
+import { ProsePlugin } from '..';
 import { cleanDocx } from '../utils/_private/ce/paste-handler-helper-functions';
 
 export function pasteHandler(): ProsePlugin {
@@ -9,14 +9,7 @@ export function pasteHandler(): ProsePlugin {
         if (clipboardData?.getData('text/rtf')) {
           event.preventDefault();
           const cleanedHTML = cleanDocx(clipboardData.getData('text/html'));
-          const domParser = new DOMParser();
-          const { state } = view;
-          const slice = ProseParser.fromSchema(state.schema).parseSlice(
-            domParser.parseFromString(cleanedHTML, 'text/html')
-          );
-          const tr = view.state.tr;
-          tr.replaceSelection(slice);
-          view.dispatch(tr);
+          view.pasteHTML(cleanedHTML);
           return true;
         } else {
           return;

--- a/addon/plugins/code/nodes/code-block.ts
+++ b/addon/plugins/code/nodes/code-block.ts
@@ -1,7 +1,7 @@
 import { NodeSpec } from 'prosemirror-model';
 
 export const code_block: NodeSpec = {
-  content: 'text*',
+  content: 'inline*',
   marks: '',
   group: 'block',
   code: true,

--- a/addon/plugins/link/index.ts
+++ b/addon/plugins/link/index.ts
@@ -43,7 +43,6 @@ export function linkPasteHandler(linkType: NodeType | MarkType) {
   return new ProsePlugin({
     props: {
       transformPasted(slice, view) {
-        console.log('Transform pasted');
         return new Slice(
           linkifyFragment(slice.content, linkType, view.state.schema),
           slice.openStart,

--- a/addon/plugins/link/index.ts
+++ b/addon/plugins/link/index.ts
@@ -1,4 +1,12 @@
-import { PNode, ProsePlugin, SayView } from '@lblod/ember-rdfa-editor';
+import {
+  MarkType,
+  NodeType,
+  PNode,
+  ProsePlugin,
+  SayView,
+  Slice,
+} from '@lblod/ember-rdfa-editor';
+import linkifyFragment from '@lblod/ember-rdfa-editor/utils/_private/linkify-fragment';
 
 export { link as linkMark } from './mark/link';
 export { link, linkView } from './nodes/link';
@@ -30,3 +38,18 @@ export const linkHandler: ProsePlugin = new ProsePlugin({
     },
   },
 });
+
+export function linkPasteHandler(linkType: NodeType | MarkType) {
+  return new ProsePlugin({
+    props: {
+      transformPasted(slice, view) {
+        console.log('Transform pasted');
+        return new Slice(
+          linkifyFragment(slice.content, linkType, view.state.schema),
+          slice.openStart,
+          slice.openEnd
+        );
+      },
+    },
+  });
+}

--- a/addon/utils/_private/linkify-fragment.ts
+++ b/addon/utils/_private/linkify-fragment.ts
@@ -36,7 +36,6 @@ export default function linkifyFragment(
   const transformedContent: PNode[] = [];
   fragment.forEach((child) => {
     if (child.isText && child.text) {
-      console.log(child.text);
       const links = linkify.find(child.text);
       let pos = 0;
       for (const link of links) {

--- a/addon/utils/_private/linkify-fragment.ts
+++ b/addon/utils/_private/linkify-fragment.ts
@@ -59,6 +59,8 @@ export default function linkifyFragment(
       if (pos < child.text.length) {
         transformedContent.push(child.cut(pos, child.text.length));
       }
+    } else if (child.type === linkType) {
+      transformedContent.push(child);
     } else {
       transformedContent.push(
         child.copy(linkifyFragment(child.content, linkType, schema))

--- a/addon/utils/_private/linkify-fragment.ts
+++ b/addon/utils/_private/linkify-fragment.ts
@@ -1,0 +1,70 @@
+import { PNode } from '@lblod/ember-rdfa-editor';
+import { Fragment, MarkType, NodeType, Schema } from 'prosemirror-model';
+import * as linkify from 'linkifyjs';
+
+/**
+ *
+ * Modified from https://github.com/ProseMirror/prosemirror/issues/90
+ * This modified version is made to work with the linkifyjs (https://github.com/Hypercontext/linkifyjs) library
+ * 
+ * Copyright (C) 2015-2017 by Marijn Haverbeke <marijnh@gmail.com> and others
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+export default function linkifyFragment(
+  fragment: Fragment,
+  linkType: NodeType | MarkType,
+  schema: Schema
+) {
+  const transformedContent: PNode[] = [];
+  fragment.forEach((child) => {
+    if (child.isText && child.text) {
+      console.log(child.text);
+      const links = linkify.find(child.text);
+      let pos = 0;
+      for (const link of links) {
+        if (pos < link.start) {
+          transformedContent.push(child.cut(pos, link.start));
+        }
+        let linkNode: PNode;
+        if (linkType instanceof NodeType) {
+          linkNode = linkType.create(
+            { href: link.href },
+            child.cut(link.start, link.end)
+          );
+        } else {
+          linkNode = child
+            .cut(link.start, link.end)
+            .mark(linkType.create({ href: link.href }).addToSet(child.marks));
+        }
+        transformedContent.push(linkNode);
+        pos = link.end;
+      }
+      if (pos < child.text.length) {
+        transformedContent.push(child.cut(pos, child.text.length));
+      }
+    } else {
+      transformedContent.push(
+        child.copy(linkifyFragment(child.content, linkType, schema))
+      );
+    }
+  });
+  return Fragment.fromArray(transformedContent);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "handlebars": "^4.7.7",
         "handlebars-loader": "^1.7.2",
         "iter-tools": "^7.4.0",
+        "linkifyjs": "^4.1.0",
         "mdn-polyfills": "^5.16.0",
         "prosemirror-commands": "^1.5.0",
         "prosemirror-dropcursor": "^1.6.1",
@@ -22974,6 +22975,11 @@
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.0.tgz",
+      "integrity": "sha512-Ffv8VoY3+ixI1b3aZ3O+jM6x17cOsgwfB1Wq7pkytbo1WlyRp6ZO0YDMqiWT/gQPY/CmtiGuKfzDIVqxh1aCTA=="
     },
     "node_modules/livereload-js": {
       "version": "3.4.1",
@@ -50492,6 +50498,11 @@
       "requires": {
         "uc.micro": "^1.0.1"
       }
+    },
+    "linkifyjs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.0.tgz",
+      "integrity": "sha512-Ffv8VoY3+ixI1b3aZ3O+jM6x17cOsgwfB1Wq7pkytbo1WlyRp6ZO0YDMqiWT/gQPY/CmtiGuKfzDIVqxh1aCTA=="
     },
     "livereload-js": {
       "version": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "handlebars": "^4.7.7",
     "handlebars-loader": "^1.7.2",
     "iter-tools": "^7.4.0",
+    "linkifyjs": "^4.1.0",
     "mdn-polyfills": "^5.16.0",
     "prosemirror-commands": "^1.5.0",
     "prosemirror-dropcursor": "^1.6.1",

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -40,13 +40,55 @@ import {
 import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
 import { inline_rdfa } from '@lblod/ember-rdfa-editor/marks';
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
-import { link, linkView } from '@lblod/ember-rdfa-editor/plugins/link';
+import {
+  link,
+  linkPasteHandler,
+  linkView,
+} from '@lblod/ember-rdfa-editor/plugins/link';
 import { inject as service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
   @service declare intl: IntlService;
+  schema = new Schema({
+    nodes: {
+      doc,
+      paragraph,
+
+      repaired_block,
+
+      list_item,
+      ordered_list,
+      bullet_list,
+      placeholder,
+      ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+      heading,
+      blockquote,
+
+      horizontal_rule,
+      code_block,
+
+      text,
+
+      image,
+
+      hard_break,
+      invisible_rdfa,
+      block_rdfa,
+      link: link(this.linkOptions),
+    },
+    marks: {
+      inline_rdfa,
+      code,
+      em,
+      strong,
+      underline,
+      strikethrough,
+      subscript,
+      superscript,
+    },
+  });
 
   get linkOptions() {
     return {
@@ -54,53 +96,16 @@ export default class IndexController extends Controller {
     };
   }
 
-  @tracked plugins: Plugin[] = [tablePlugin, tableKeymap];
+  @tracked plugins: Plugin[] = [
+    tablePlugin,
+    tableKeymap,
+    linkPasteHandler(this.schema.nodes.link),
+  ];
   @tracked nodeViews = (controller: SayController) => {
     return {
       link: linkView(this.linkOptions)(controller),
     };
   };
-
-  get schema() {
-    return new Schema({
-      nodes: {
-        doc,
-        paragraph,
-
-        repaired_block,
-
-        list_item,
-        ordered_list,
-        bullet_list,
-        placeholder,
-        ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
-        heading,
-        blockquote,
-
-        horizontal_rule,
-        code_block,
-
-        text,
-
-        image,
-
-        hard_break,
-        invisible_rdfa,
-        block_rdfa,
-        link: link(this.linkOptions),
-      },
-      marks: {
-        inline_rdfa,
-        code,
-        em,
-        strong,
-        underline,
-        strikethrough,
-        subscript,
-        superscript,
-      },
-    });
-  }
 
   get showRdfaBlocks() {
     return this.rdfaEditor?.showRdfaBlocks;

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -50,59 +50,60 @@ import {
 import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
 import { inline_rdfa } from '@lblod/ember-rdfa-editor/marks';
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
-import { link, linkView } from '@lblod/ember-rdfa-editor/plugins/link';
+import {
+  link,
+  linkPasteHandler,
+  linkView,
+} from '@lblod/ember-rdfa-editor/plugins/link';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
+  schema = new Schema({
+    nodes: {
+      doc,
+      paragraph,
+
+      repaired_block,
+
+      list_item,
+      ordered_list,
+      bullet_list,
+      placeholder,
+      ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+      heading,
+      blockquote,
+
+      horizontal_rule,
+      code_block,
+
+      text,
+
+      image,
+
+      hard_break,
+      invisible_rdfa,
+      block_rdfa,
+      card,
+      counter,
+      dropdown,
+      link: link(this.linkOptions),
+    },
+    marks: {
+      inline_rdfa,
+      code,
+      em,
+      strong,
+      underline,
+      strikethrough,
+      subscript,
+      superscript,
+    },
+  });
 
   get linkOptions() {
     return {
       interactive: true,
     };
-  }
-
-  get schema() {
-    return new Schema({
-      nodes: {
-        doc,
-        paragraph,
-
-        repaired_block,
-
-        list_item,
-        ordered_list,
-        bullet_list,
-        placeholder,
-        ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
-        heading,
-        blockquote,
-
-        horizontal_rule,
-        code_block,
-
-        text,
-
-        image,
-
-        hard_break,
-        invisible_rdfa,
-        block_rdfa,
-        card,
-        counter,
-        dropdown,
-        link: link(this.linkOptions),
-      },
-      marks: {
-        inline_rdfa,
-        code,
-        em,
-        strong,
-        underline,
-        strikethrough,
-        subscript,
-        superscript,
-      },
-    });
   }
 
   @tracked nodeViews: (
@@ -119,6 +120,7 @@ export default class IndexController extends Controller {
     highlight({ testKey: 'yeet' }),
     tablePlugin,
     tableKeymap,
+    linkPasteHandler(this.schema.nodes.link),
   ];
 
   @action


### PR DESCRIPTION
- Addition of a `linkPasteHandler` plugin which detects plain text links inside pasted content and converts them to a link node or adds a link mark.
- Use the new view `pasteHTML` method inside the Word paste handler.

Solution to https://binnenland.atlassian.net/browse/GN-4121?atlOrigin=eyJpIjoiMDM3NzdkM2E3ZTk2NDQxN2FjMWRkNjY3OGNiZDhlNjkiLCJwIjoiaiJ9.