### PR TITLE
GN-4123: Inherit ordered list style correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Inherit ordered list style correctly 
+
 ## [3.2.1] - 2023-02-28
 
 ### Fixed

--- a/addon/components/plugins/list/ordered.hbs
+++ b/addon/components/plugins/list/ordered.hbs
@@ -5,7 +5,7 @@
       @title={{t 'ember-rdfa-editor.ordered-list.button-label'}}
       @optionsLabel={{t 'ember-rdfa-editor.ordered-list.options-label'}}
       @icon="ordered-list"
-      {{on "click" (fn this.toggle undefined)}}
+      {{on "click" (fn this.toggle 'decimal')}}
       @controller={{@controller}}
     >
       <:options as |Menu|>

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -217,6 +217,11 @@ $say-editor-highlight-hover-color: var(--au-gray-200) !default;
       margin-left: 0;
       padding-left: 0;
     }
+
+    & > ol:not([data-list-style]),
+    & > li > ol:not([data-list-style]) {
+      list-style-type: decimal;
+    }
   }
 
   ol,

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -221,27 +221,20 @@ $say-editor-highlight-hover-color: var(--au-gray-200) !default;
 
   ol,
   ol.numbered-list {
-    list-style-type: decimal;
-
-    &[data-list-style=decimal] {
-      ol {
-        list-style-type: decimal;
-      }
-      list-style-type: decimal !important;
+    &:not([data-list-style]) {
+      list-style-type: inherit;
     }
 
-    &[data-list-style=upper-roman] {
-      ol {
-        list-style-type: upper-roman;
-      }
-      list-style-type: upper-roman !important;
+    &[data-list-style='decimal'] {
+      list-style-type: decimal;
     }
 
-    &[data-list-style=lower-alpha] {
-      ol {
-        list-style-type: lower-alpha;
-      }
-      list-style-type: lower-alpha !important;
+    &[data-list-style='upper-roman'] {
+      list-style-type: upper-roman;
+    }
+
+    &[data-list-style='lower-alpha'] {
+      list-style-type: lower-alpha;
     }
 
     // Stop indenting


### PR DESCRIPTION
* Give `decimal` style by default when pressing on the "ordered list" menu button, without opening the button
* Fixup CSS 

### Before

https://user-images.githubusercontent.com/769698/222077169-a26d119b-ddfa-47d5-bd98-a357b09e2b2e.mp4

### After

https://user-images.githubusercontent.com/769698/222077191-c202887f-c49c-4f0f-bf5f-77c1897e1058.mp4

