### PR TITLE
Disable toolbar buttons when not applicable instead of hiding them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- Disable toolbar buttons when not applicable instead of hiding them
 ### Dependencies
 - Bumps `tracked-built-ins` from 3.1.0 to 3.1.1
 

--- a/addon/components/plugins/heading/heading-menu.hbs
+++ b/addon/components/plugins/heading/heading-menu.hbs
@@ -1,9 +1,9 @@
-{{#if this.enabled}}
 <Toolbar::Dropdown
   @label={{this.currentStyle}}
   @icon="nav-down"
   @iconSize="small"
   @controller={{@controller}}
+  @disabled={{not this.enabled}}
   as |Menu|
 >
   <Menu.Item
@@ -29,4 +29,3 @@
     </Menu.Item>
   {{/each}}
 </Toolbar::Dropdown>
-{{/if}}

--- a/addon/components/plugins/indentation/indentation-menu.hbs
+++ b/addon/components/plugins/indentation/indentation-menu.hbs
@@ -1,16 +1,14 @@
 {{#if @controller}}
-  {{#if this.enabled}}
-    <Toolbar::Button
-      @title={{t 'ember-rdfa-editor.unindent'}}
-      @icon='reverse-indent'
-      {{on 'click' this.insertUnindent}}
-      @disabled={{not this.canUnindent}}
-    />
-    <Toolbar::Button
-      @title={{t 'ember-rdfa-editor.indent'}}
-      @icon='indent'
-      {{on 'click' this.insertIndent}}
-      @disabled={{not this.canIndent}}
-    />
-  {{/if}}
+  <Toolbar::Button
+    @title={{t 'ember-rdfa-editor.unindent'}}
+    @icon='reverse-indent'
+    {{on 'click' this.insertUnindent}}
+    @disabled={{not this.canUnindent}}
+  />
+  <Toolbar::Button
+    @title={{t 'ember-rdfa-editor.indent'}}
+    @icon='indent'
+    {{on 'click' this.insertIndent}}
+    @disabled={{not this.canIndent}}
+  />
 {{/if}}

--- a/addon/components/plugins/indentation/indentation-menu.ts
+++ b/addon/components/plugins/indentation/indentation-menu.ts
@@ -18,10 +18,6 @@ export default class IndentationMenuComponent extends Component<Args> {
     return this.controller.schema;
   }
 
-  get enabled() {
-    return this.canIndent || this.canUnindent;
-  }
-
   get indentCommand() {
     return chainCommands(
       sinkListItem(this.schema.nodes.list_item),

--- a/addon/components/plugins/link/link-menu.hbs
+++ b/addon/components/plugins/link/link-menu.hbs
@@ -1,9 +1,8 @@
 {{#if @controller}}
-  {{#if this.canInsert}}
-    <Toolbar::Button
-      @title={{t "ember-rdfa-editor.link.insert"}}
-      @icon='link'
-      {{on 'click' this.insert}}
-    />
-  {{/if}}
+  <Toolbar::Button
+    @title={{t "ember-rdfa-editor.link.insert"}}
+    @icon='link'
+    {{on 'click' this.insert}}
+    @disabled={{not this.canInsert}}
+  />
 {{/if}}

--- a/addon/components/plugins/list/indentation-controls.hbs
+++ b/addon/components/plugins/list/indentation-controls.hbs
@@ -1,16 +1,14 @@
 {{#if @controller}}
-  {{#if this.canUnindent}}
-    <Toolbar::Button
-      @title={{t 'ember-rdfa-editor.unindent-list'}}
-      @icon='reverse-indent'
-      {{on 'click' this.insertUnindent}}
-    />
-  {{/if}}
-  {{#if this.canIndent}}
-    <Toolbar::Button
-      @title={{t 'ember-rdfa-editor.indent-list'}}
-      @icon='indent'
-      {{on 'click' this.insertIndent}}
-    />
-  {{/if}}
+  <Toolbar::Button
+    @title={{t 'ember-rdfa-editor.unindent-list'}}
+    @icon='reverse-indent'
+    {{on 'click' this.insertUnindent}}
+    @disabled={{not this.canUnindent}}
+  />
+  <Toolbar::Button
+    @title={{t 'ember-rdfa-editor.indent-list'}}
+    @icon='indent'
+    {{on 'click' this.insertIndent}}
+    @disabled={{not this.canUnindent}}
+  />
 {{/if}}

--- a/addon/components/plugins/list/ordered.hbs
+++ b/addon/components/plugins/list/ordered.hbs
@@ -1,23 +1,22 @@
 {{#if @controller}}
-  {{#if this.canToggle}}
-    <Toolbar::Button
-      @active={{this.isActive}}
-      @title={{t 'ember-rdfa-editor.ordered-list.button-label'}}
-      @optionsLabel={{t 'ember-rdfa-editor.ordered-list.options-label'}}
-      @icon="ordered-list"
-      {{on "click" (fn this.toggle undefined)}}
-      @controller={{@controller}}
-    >
-      <:options as |Menu|>
-        {{#each this.styles as |style|}}
-          <Menu.Item disabled={{this.styleIsActive style.name}} @menuAction={{(fn this.setStyle style.name)}}>
-            {{#if (this.styleIsActive style.name)}}
-              <AuIcon @icon='check' @ariaHidden={{true}} />
-            {{/if}}
-            {{style.description}}
-          </Menu.Item>
-        {{/each}}
-      </:options>
-    </Toolbar::Button>
-  {{/if}}
+  <Toolbar::Button
+    @active={{this.isActive}}
+    @title={{t 'ember-rdfa-editor.ordered-list.button-label'}}
+    @optionsLabel={{t 'ember-rdfa-editor.ordered-list.options-label'}}
+    @icon="ordered-list"
+    {{on "click" (fn this.toggle undefined)}}
+    @controller={{@controller}}
+    @disabled={{not this.canToggle}}
+  >
+    <:options as |Menu|>
+      {{#each this.styles as |style|}}
+        <Menu.Item disabled={{this.styleIsActive style.name}} @menuAction={{(fn this.setStyle style.name)}}>
+          {{#if (this.styleIsActive style.name)}}
+            <AuIcon @icon='check' @ariaHidden={{true}} />
+          {{/if}}
+          {{style.description}}
+        </Menu.Item>
+      {{/each}}
+    </:options>
+  </Toolbar::Button>
 {{/if}}

--- a/addon/components/plugins/list/unordered.hbs
+++ b/addon/components/plugins/list/unordered.hbs
@@ -1,10 +1,9 @@
 {{#if @controller}}
-  {{#if this.canToggle}}
-    <Toolbar::Button
-      @active={{this.isActive}}
-      @title={{t 'ember-rdfa-editor.unordered-list'}}
-      @icon='unordered-list'
-      {{on 'click' this.toggle}}
-    />
-  {{/if}}
+  <Toolbar::Button
+    @active={{this.isActive}}
+    @title={{t 'ember-rdfa-editor.unordered-list'}}
+    @icon='unordered-list'
+    {{on 'click' this.toggle}}
+    @disabled={{not this.canToggle}}
+  />
 {{/if}}

--- a/addon/components/plugins/table/table-menu.hbs
+++ b/addon/components/plugins/table/table-menu.hbs
@@ -1,9 +1,9 @@
-{{#unless @controller.inEmbeddedView}}
 <Toolbar::Dropdown
   @controller={{@controller}}
   @icon="table"
   @label={{t 'ember-rdfa-editor.table-options'}}
   @hideLabel={{true}}
+  @disabled={{@controller.inEmbeddedView}}
   as |Menu|
 >
   {{#if this.isInTable}}
@@ -106,17 +106,15 @@
     </Menu.Item>
   {{/if}}
 </Toolbar::Dropdown>
-{{#if this.isInTable}}
-
-  <Toolbar::Button
-    @title={{t 'ember-rdfa-editor.add-column-after'}}
-    @icon='table-column-end-add'
-    {{on 'click' this.insertColumnAfter}}
-  />
-  <Toolbar::Button
-    @title={{t 'ember-rdfa-editor.add-row-below'}}
-    @icon='table-row-end-add'
-    {{on 'click' this.insertRowBelow}}
-  />
-{{/if}}
-{{/unless}}
+<Toolbar::Button
+  @title={{t 'ember-rdfa-editor.add-column-after'}}
+  @icon='table-column-end-add'
+  {{on 'click' this.insertColumnAfter}}
+  @disabled={{not this.isInTable}}
+/>
+<Toolbar::Button
+  @title={{t 'ember-rdfa-editor.add-row-below'}}
+  @icon='table-row-end-add'
+  {{on 'click' this.insertRowBelow}}
+  @disabled={{not this.isInTable}}
+/>

--- a/addon/components/toolbar/button.hbs
+++ b/addon/components/toolbar/button.hbs
@@ -13,7 +13,7 @@
 
   </button>
   {{#if (has-block "options")}}
-    <Toolbar::Dropdown @icon={{this.optionsIcon}} @iconSize="" @controller={{@controller}} class="options"
+    <Toolbar::Dropdown @disabled={{@disabled}} @icon={{this.optionsIcon}} @iconSize="" @controller={{@controller}} class="options"
                        title={{@optionsLabel}} as |Menu|>
       {{yield Menu to="options"}}
     </Toolbar::Dropdown>

--- a/addon/components/toolbar/dropdown.hbs
+++ b/addon/components/toolbar/dropdown.hbs
@@ -8,6 +8,7 @@
     type='button'
     {{on 'click' this.toggleDropdown}}
     title={{@label}}
+    disabled={{@disabled}}
   >
     <span class={{if @hideLabel 'au-u-hidden-visually' ''}}>{{@label}}</span>
     {{#if @icon}}

--- a/app/styles/ember-rdfa-editor/_c-dropdown.scss
+++ b/app/styles/ember-rdfa-editor/_c-dropdown.scss
@@ -57,6 +57,12 @@ $say-smaller-font-size: 1.4rem !default;
     background-color: var(--au-gray-300);
     box-shadow: inset 0 -0.3rem 0 0 var(--au-gray-400);
   }
+
+  &:disabled {
+    color: var(--au-gray-400);
+    background-color: var(--au-gray-100);
+    cursor: not-allowed;
+  }
 }
 
 .say-dropdown__button img {

--- a/app/styles/ember-rdfa-editor/_c-dropdown.scss
+++ b/app/styles/ember-rdfa-editor/_c-dropdown.scss
@@ -60,7 +60,6 @@ $say-smaller-font-size: 1.4rem !default;
 
   &:disabled {
     color: var(--au-gray-400);
-    background-color: var(--au-gray-100);
     cursor: not-allowed;
   }
 }

--- a/app/styles/ember-rdfa-editor/_c-toolbar.scss
+++ b/app/styles/ember-rdfa-editor/_c-toolbar.scss
@@ -92,7 +92,6 @@ $say-toolbar-height: 44px !default;
     }
     &.is-disabled {
       color: var(--au-gray-400);
-      background-color: var(--au-gray-100);
       cursor: not-allowed;
     }
   }


### PR DESCRIPTION
Solves https://binnenland.atlassian.net/browse/GN-4119?atlOrigin=eyJpIjoiNTAyZThmNTg5OTE0NGU1ODkwMTgzNTY0MWUyMTRlYzgiLCJwIjoiaiJ9.

Probably needs some design improvements on how disabled buttons are visualized as it looks a bit weird now. Maybe a better approach is to keep the same color on each toolbar button but only change the color on hover on enabled buttons.