### PR TITLE
fix(cursor): add workaround plugin for firefox bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Add padding to rdfa-toggle
 - Fix shrinking issue with toolbar groups
+- Fix disappearing cursor problems in firefox
 
 ### Deprecated
 - Usage of `Plugins::List::IndentationControls`, use `Plugins::Indentation::IndentationMenu` instead.

--- a/addon/plugins/firefox-cursor-fix/index.ts
+++ b/addon/plugins/firefox-cursor-fix/index.ts
@@ -68,7 +68,9 @@ export function firefoxCursorFix(): ProsePlugin {
                 wrapper.classList.add(
                   'ProseMirror-firefox-fake-cursor-wrapper'
                 );
+                const cursor = new Text('|');
                 const fakeCursor = document.createElement('span');
+                fakeCursor.append(cursor);
                 fakeCursor.classList.add('ProseMirror-firefox-fake-cursor');
                 wrapper.append(fakeCursor);
                 return wrapper;

--- a/addon/plugins/firefox-cursor-fix/index.ts
+++ b/addon/plugins/firefox-cursor-fix/index.ts
@@ -1,0 +1,85 @@
+import {
+  Decoration,
+  DecorationSet,
+  EditorState,
+  ProsePlugin,
+  SayView,
+  TextSelection,
+} from '@lblod/ember-rdfa-editor';
+import { gecko } from '@lblod/ember-rdfa-editor/utils/_private/browser';
+import { isNone } from '@lblod/ember-rdfa-editor/utils/_private/option';
+
+export function firefoxCursorFix(): ProsePlugin {
+  const firefoxCursorFix = new ProsePlugin({
+    props: {
+      handleDOMEvents: {
+        mousedown(view: SayView, event: MouseEvent) {
+          if (!gecko) {
+            return;
+          }
+          const clickedPos = view.posAtCoords({
+            left: event.clientX,
+            top: event.clientY,
+          });
+          console.log('clickpos', clickedPos);
+          if (isNone(clickedPos)) {
+            return;
+          }
+          const $pos = view.state.doc.resolve(clickedPos.pos);
+          let cur = $pos.nodeAfter;
+          let insertPos = $pos.pos;
+          while (cur && !cur.type.spec.needsFFKludge) {
+            cur = cur.firstChild;
+            insertPos++;
+          }
+          if (cur?.type.spec.needsFFKludge) {
+            event.preventDefault();
+            view.dispatch(
+              view.state.tr
+                .setSelection(
+                  new TextSelection(view.state.doc.resolve(insertPos))
+                )
+                .scrollIntoView()
+            );
+            return true;
+          }
+          return;
+        },
+      },
+      decorations(state: EditorState): DecorationSet | undefined {
+        if (!gecko) {
+          return;
+        }
+        const { $from, from, to } = state.selection;
+        if (from !== to) {
+          return;
+        }
+        const nextNode = $from.nodeAfter;
+        const prevNode = $from.nodeBefore;
+        if (
+          (nextNode?.type.spec.needsFFKludge && !prevNode) ||
+          prevNode?.type.spec.needsFFKludge
+        ) {
+          return DecorationSet.create(state.doc, [
+            Decoration.widget(
+              from,
+              () => {
+                const wrapper = document.createElement('span');
+                wrapper.classList.add(
+                  'ProseMirror-firefox-fake-cursor-wrapper'
+                );
+                const fakeCursor = document.createElement('span');
+                fakeCursor.classList.add('ProseMirror-firefox-fake-cursor');
+                wrapper.append(fakeCursor);
+                return wrapper;
+              },
+              { side: 1 }
+            ),
+          ]);
+        }
+        return;
+      },
+    },
+  });
+  return firefoxCursorFix;
+}

--- a/addon/plugins/link/nodes/link.ts
+++ b/addon/plugins/link/nodes/link.ts
@@ -27,6 +27,7 @@ const emberNodeConfig: (options: LinkOptions) => EmberNodeConfig = (
         default: interactive,
       },
     },
+    needsFFKludge: true,
     parseDOM: [
       {
         tag: 'a',

--- a/addon/utils/_private/browser.ts
+++ b/addon/utils/_private/browser.ts
@@ -1,0 +1,37 @@
+/**
+ * Taken from https://github.com/ProseMirror/prosemirror-view/blob/master/src/browser.ts
+ */
+const nav = typeof navigator != 'undefined' ? navigator : null;
+const doc = typeof document != 'undefined' ? document : null;
+const agent = (nav && nav.userAgent) || '';
+
+const ie_edge = /Edge\/(\d+)/.exec(agent);
+const ie_upto10 = /MSIE \d/.exec(agent);
+const ie_11up = /Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(agent);
+
+export const ie = !!(ie_upto10 || ie_11up || ie_edge);
+export const ie_version = ie_upto10
+  ? (document as unknown as { documentMode: unknown }).documentMode
+  : ie_11up
+  ? +ie_11up[1]
+  : ie_edge
+  ? +ie_edge[1]
+  : 0;
+export const gecko = !ie && /gecko\/(\d+)/i.test(agent);
+export const gecko_version =
+  gecko && +(/Firefox\/(\d+)/.exec(agent) || [0, 0])[1];
+
+const _chrome = !ie && /Chrome\/(\d+)/.exec(agent);
+export const chrome = !!_chrome;
+export const chrome_version = _chrome ? +_chrome[1] : 0;
+export const safari = !ie && !!nav && /Apple Computer/.test(nav.vendor);
+// Is true for both iOS and iPadOS for convenience
+export const ios =
+  safari && (/Mobile\/\w+/.test(agent) || (!!nav && nav.maxTouchPoints > 2));
+export const mac = ios || (nav ? /Mac/.test(nav.platform) : false);
+export const android = /Android \d/.test(agent);
+export const webkit =
+  !!doc && 'webkitFontSmoothing' in doc.documentElement.style;
+export const webkit_version = webkit
+  ? +(/\bAppleWebKit\/(\d+)/.exec(navigator.userAgent) || [0, 0])[1]
+  : 0;

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -182,6 +182,7 @@ export function createEmberNodeSpec(config: EmberNodeConfig): NodeSpec {
     attrs,
     parseDOM,
     toDOM,
+    ...passthrough
   } = config;
   return {
     inline,
@@ -236,6 +237,7 @@ export function createEmberNodeSpec(config: EmberNodeConfig): NodeSpec {
             : [[inline ? 'span' : 'div', { 'data-slot': 'true' }, 0]]),
         ];
       }),
+    ...passthrough,
   };
 }
 

--- a/app/styles/ember-rdfa-editor.scss
+++ b/app/styles/ember-rdfa-editor.scss
@@ -38,11 +38,11 @@
 }
 
 .ProseMirror-firefox-fake-cursor {
-  content: "";
   position: absolute;
-  background: black;
-  width: 0.2rem;
-  height: 1.9rem;
+  //background: black;
+  left: -0.2em;
+  font-size: 1.55em !important;
+  top: -0.25em;
   animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
 }
 

--- a/app/styles/ember-rdfa-editor.scss
+++ b/app/styles/ember-rdfa-editor.scss
@@ -31,6 +31,21 @@
   animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
 }
 
+.ProseMirror-firefox-fake-cursor-wrapper {
+  pointer-events: none;
+  position: relative;
+
+}
+
+.ProseMirror-firefox-fake-cursor {
+  content: "";
+  position: absolute;
+  background: black;
+  width: 0.2rem;
+  height: 1.9rem;
+  animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
+}
+
 @keyframes ProseMirror-cursor-blink {
   to {
     visibility: hidden;
@@ -40,6 +55,10 @@
 .ProseMirror-focused .ProseMirror-gapcursor {
   display: block;
 }
+
+.ProseMirror-focused .ProseMirror-firefox-fake-cursor {
+}
+
 // CUSTOM COMPONENTS
 @import 'ember-rdfa-editor/a-custom-components';
 
@@ -51,3 +70,4 @@
   display: inline-block;
   background: yellow;
 }
+

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -43,6 +43,7 @@ import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import { link, linkView } from '@lblod/ember-rdfa-editor/plugins/link';
 import { inject as service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
+import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-cursor-fix';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
@@ -54,7 +55,7 @@ export default class IndexController extends Controller {
     };
   }
 
-  @tracked plugins: Plugin[] = [tablePlugin, tableKeymap];
+  @tracked plugins: Plugin[] = [firefoxCursorFix(), tablePlugin, tableKeymap];
   @tracked nodeViews = (controller: SayController) => {
     return {
       link: linkView(this.linkOptions)(controller),


### PR DESCRIPTION
This plugin draws a fake cursor when it detects a position in front of or behind a node that has the `needsFFKludge` property on its spec.

It also adds a mousedown handler to handle the cases where one of these nodes is at the start of a line, and the user clicks to the left of the editor.
The expected behavior is that the cursor is put before that node, as it does automatically in chrome. 
Firefox doesn't seem to consider this position valid, so it never puts the cursor there. 
This is also why we have to intercept the raw mousedown and can't listen to selection changes or use any of the prosemirror
builtin selection handling props.

fixes https://binnenland.atlassian.net/browse/GN-4116