### PR TITLE
Addition of a responsive toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added:
+- Addition of a `ResponsiveToolbar` component which takes into account container and screen size.
+
 ### Fixed:
 - embedded-editor: only set data-placeholder when placeholder argument is supplied
 ### Dependencies

--- a/addon/components/responsive-toolbar.hbs
+++ b/addon/components/responsive-toolbar.hbs
@@ -7,7 +7,7 @@
       ) to="main"}}
       <Velcro @placement="bottom-end" @offsetOptions={{hash mainAxis=10}} as |velcro|>
         {{#if this.main.enableDropdown}}
-          <Toolbar::Group class="say-toolbar__more" data-ignore-resize {{velcro.hook}}>
+          <Toolbar::Group data-ignore-resize {{velcro.hook}}>
             <Toolbar::Button 
               @icon="three-dots" 
               {{on 'click' this.toggleMainDropdown}} 
@@ -38,7 +38,7 @@
       ) to='side'}}
       <Velcro @placement="bottom-end" @offsetOptions={{hash mainAxis=10}} as |velcro|>
         {{#if this.side.enableDropdown}}
-          <Toolbar::Group class="say-toolbar__more" data-ignore-resize {{velcro.hook}}>
+          <Toolbar::Group data-ignore-resize {{velcro.hook}}>
             <Toolbar::Button 
               @icon="nav-down" 
               {{on 'click' this.toggleSideDropdown}}
@@ -47,7 +47,7 @@
           </Toolbar::Group>
         {{/if}}
         <div 
-          class="say-toolbar__main-dropdown" 
+          class="say-toolbar__side-dropdown" 
           data-ignore-resize 
           data-hidden={{if this.side.showDropdown 'false' 'true'}} 
           {{velcro.loop}} 

--- a/addon/components/responsive-toolbar.hbs
+++ b/addon/components/responsive-toolbar.hbs
@@ -1,28 +1,59 @@
-<div class='say-toolbar' >
+<div class='say-toolbar' {{this.setUpToolbar}}>
   {{#if (has-block 'main')}}
-    <div class="say-toolbar__main au-u-flex" {{this.setUpMainToolbar}}>
+            <Velcro @placement="bottom" @offsetOptions={{hash mainAxis=10}} as |velcro|>
+      <div class="say-toolbar__main" {{this.setUpMainToolbar}}  {{velcro.hook}}>
+        {{yield (hash
+        Group=(component "toolbar/group")
+        Spacer=(component "toolbar/spacer")
+        Divider=(component "toolbar/divider")
+        ) to="main"}}
+          <Toolbar::Group class="say-toolbar__more" data-ignore-resize data-hidden={{if this.showMainOptionsButton 'false' 'true'}}>
+            <Toolbar::Button @icon="three-dots" {{on 'click' this.toggleMainOptions}}/>
+          </Toolbar::Group>
+          <div
+              class="say-toolbar__main-dropdown"
+              data-ignore-resize
+              data-hidden={{if (and this.showMainOptionsButton this.showMainOptionsDropdown) 'false' 'true'}}
+              {{velcro.loop}}
+          >
+              {{yield (hash
+                Group=(component "toolbar/group")
+                Spacer=(component "toolbar/spacer")
+                Divider=(component "toolbar/divider")
+                ) to="main"}}
+          </div>
+        
+      </div>
+</Velcro>
+  {{/if}}
+  {{#if (has-block 'side')}}
+              <Velcro @placement="bottom" @offsetOptions={{hash mainAxis=10}} as |velcro|>
+
+    <div class="say-toolbar__side" {{this.setUpSideToolbar}} {{velcro.hook}}>
       {{yield (hash
       Group=(component "toolbar/group")
       Spacer=(component "toolbar/spacer")
       Divider=(component "toolbar/divider")
-      ) to="main"}}
+      ) to='side'}}
+
+        {{#if this.showSideOptionsButton}}
+        <Toolbar::Group class="say-toolbar__more" data-ignore-resize>
+          <Toolbar::Button @icon="nav-down"/>
+        </Toolbar::Group>
+        {{/if}}
+        <div
+              class="say-toolbar__main-dropdown"
+              data-ignore-resize
+              data-hidden={{if this.showSideOptionsButton 'false' 'true'}}
+              {{velcro.loop}}
+          >
+              {{yield (hash
+                Group=(component "toolbar/group")
+                Spacer=(component "toolbar/spacer")
+                Divider=(component "toolbar/divider")
+                ) to="side"}}
+          </div>
     </div>
-    <Toolbar::Group class="say-toolbar__more">
-      <Toolbar::Button @icon="three-dots"/>
-    </Toolbar::Group>
-  {{/if}}
-  {{#if (has-block 'side')}}
-    <div class="au-u-flex say-toolbar__side" {{this.setUpSideToolbar}}>
-      <div class="au-u-flex" {{this.setUpToolbar}}>
-          {{yield (hash
-          Group=(component "toolbar/group")
-          Spacer=(component "toolbar/spacer")
-          Divider=(component "toolbar/divider")
-          ) to='side'}}
-      </div>
-    </div>
-    <Toolbar::Group class="say-toolbar__more">
-        <Toolbar::Button @icon="nav-down"/>
-    </Toolbar::Group>
+              </Velcro>
   {{/if}}
 </div>

--- a/addon/components/responsive-toolbar.hbs
+++ b/addon/components/responsive-toolbar.hbs
@@ -1,0 +1,28 @@
+<div class='say-toolbar' >
+  {{#if (has-block 'main')}}
+    <div class="say-toolbar__main au-u-flex" {{this.setUpMainToolbar}}>
+      {{yield (hash
+      Group=(component "toolbar/group")
+      Spacer=(component "toolbar/spacer")
+      Divider=(component "toolbar/divider")
+      ) to="main"}}
+    </div>
+    <Toolbar::Group class="say-toolbar__more">
+      <Toolbar::Button @icon="three-dots"/>
+    </Toolbar::Group>
+  {{/if}}
+  {{#if (has-block 'side')}}
+    <div class="au-u-flex say-toolbar__side" {{this.setUpSideToolbar}}>
+      <div class="au-u-flex" {{this.setUpToolbar}}>
+          {{yield (hash
+          Group=(component "toolbar/group")
+          Spacer=(component "toolbar/spacer")
+          Divider=(component "toolbar/divider")
+          ) to='side'}}
+      </div>
+    </div>
+    <Toolbar::Group class="say-toolbar__more">
+        <Toolbar::Button @icon="nav-down"/>
+    </Toolbar::Group>
+  {{/if}}
+</div>

--- a/addon/components/responsive-toolbar.hbs
+++ b/addon/components/responsive-toolbar.hbs
@@ -8,7 +8,11 @@
       <Velcro @placement="bottom-end" @offsetOptions={{hash mainAxis=10}} as |velcro|>
         {{#if this.main.enableDropdown}}
           <Toolbar::Group class="say-toolbar__more" data-ignore-resize {{velcro.hook}}>
-            <Toolbar::Button @icon="three-dots" {{on 'click' this.toggleMainDropdown}} />
+            <Toolbar::Button 
+              @icon="three-dots" 
+              {{on 'click' this.toggleMainDropdown}} 
+              @active={{this.main.showDropdown}}
+            />
           </Toolbar::Group>
         {{/if}}
         <div 
@@ -35,7 +39,11 @@
       <Velcro @placement="bottom-end" @offsetOptions={{hash mainAxis=10}} as |velcro|>
         {{#if this.side.enableDropdown}}
           <Toolbar::Group class="say-toolbar__more" data-ignore-resize {{velcro.hook}}>
-            <Toolbar::Button @icon="nav-down" {{on 'click' this.toggleSideDropdown}}/>
+            <Toolbar::Button 
+              @icon="nav-down" 
+              {{on 'click' this.toggleSideDropdown}}
+              @active={{this.side.showDropdown}}
+            />
           </Toolbar::Group>
         {{/if}}
         <div 

--- a/addon/components/responsive-toolbar.hbs
+++ b/addon/components/responsive-toolbar.hbs
@@ -1,59 +1,56 @@
 <div class='say-toolbar' {{this.setUpToolbar}}>
   {{#if (has-block 'main')}}
-            <Velcro @placement="bottom" @offsetOptions={{hash mainAxis=10}} as |velcro|>
-      <div class="say-toolbar__main" {{this.setUpMainToolbar}}  {{velcro.hook}}>
-        {{yield (hash
-        Group=(component "toolbar/group")
-        Spacer=(component "toolbar/spacer")
-        Divider=(component "toolbar/divider")
-        ) to="main"}}
-          <Toolbar::Group class="say-toolbar__more" data-ignore-resize data-hidden={{if this.showMainOptionsButton 'false' 'true'}}>
-            <Toolbar::Button @icon="three-dots" {{on 'click' this.toggleMainOptions}}/>
-          </Toolbar::Group>
-          <div
-              class="say-toolbar__main-dropdown"
-              data-ignore-resize
-              data-hidden={{if (and this.showMainOptionsButton this.showMainOptionsDropdown) 'false' 'true'}}
-              {{velcro.loop}}
-          >
-              {{yield (hash
-                Group=(component "toolbar/group")
-                Spacer=(component "toolbar/spacer")
-                Divider=(component "toolbar/divider")
-                ) to="main"}}
-          </div>
-        
-      </div>
-</Velcro>
-  {{/if}}
-  {{#if (has-block 'side')}}
-              <Velcro @placement="bottom" @offsetOptions={{hash mainAxis=10}} as |velcro|>
-
-    <div class="say-toolbar__side" {{this.setUpSideToolbar}} {{velcro.hook}}>
+    <div class="say-toolbar__main" {{this.setUpMainToolbar}}>
       {{yield (hash
       Group=(component "toolbar/group")
-      Spacer=(component "toolbar/spacer")
+      Divider=(component "toolbar/divider")
+      ) to="main"}}
+      <Velcro @placement="bottom-end" @offsetOptions={{hash mainAxis=10}} as |velcro|>
+        {{#if this.main.enableDropdown}}
+          <Toolbar::Group class="say-toolbar__more" data-ignore-resize {{velcro.hook}}>
+            <Toolbar::Button @icon="three-dots" {{on 'click' this.toggleMainDropdown}} />
+          </Toolbar::Group>
+        {{/if}}
+        <div 
+          class="say-toolbar__main-dropdown" 
+          data-ignore-resize 
+          data-hidden={{if this.main.showDropdown 'false' 'true'}} 
+          {{velcro.loop}} 
+          {{this.setUpMainDropdown}}
+        >
+          {{yield (hash
+          Group=(component "toolbar/group")
+          Divider=(component "toolbar/divider")
+          ) to="main"}}
+        </div>
+      </Velcro>
+    </div>
+  {{/if}}
+  {{#if (has-block 'side')}}
+    <div class="say-toolbar__side" {{this.setUpSideToolbar}}>
+      {{yield (hash
+      Group=(component "toolbar/group")
       Divider=(component "toolbar/divider")
       ) to='side'}}
-
-        {{#if this.showSideOptionsButton}}
-        <Toolbar::Group class="say-toolbar__more" data-ignore-resize>
-          <Toolbar::Button @icon="nav-down"/>
-        </Toolbar::Group>
+      <Velcro @placement="bottom-end" @offsetOptions={{hash mainAxis=10}} as |velcro|>
+        {{#if this.side.enableDropdown}}
+          <Toolbar::Group class="say-toolbar__more" data-ignore-resize {{velcro.hook}}>
+            <Toolbar::Button @icon="nav-down" {{on 'click' this.toggleSideDropdown}}/>
+          </Toolbar::Group>
         {{/if}}
-        <div
-              class="say-toolbar__main-dropdown"
-              data-ignore-resize
-              data-hidden={{if this.showSideOptionsButton 'false' 'true'}}
-              {{velcro.loop}}
-          >
-              {{yield (hash
-                Group=(component "toolbar/group")
-                Spacer=(component "toolbar/spacer")
-                Divider=(component "toolbar/divider")
-                ) to="side"}}
-          </div>
+        <div 
+          class="say-toolbar__main-dropdown" 
+          data-ignore-resize 
+          data-hidden={{if this.side.showDropdown 'false' 'true'}} 
+          {{velcro.loop}} 
+          {{this.setUpSideDropdown}}
+        >
+          {{yield (hash
+          Group=(component "toolbar/group")
+          Divider=(component "toolbar/divider")
+          ) to="side"}}
+        </div>
+      </Velcro>
     </div>
-              </Velcro>
   {{/if}}
 </div>

--- a/addon/components/responsive-toolbar.ts
+++ b/addon/components/responsive-toolbar.ts
@@ -3,25 +3,22 @@ import Component from '@glimmer/component';
 import { modifier } from 'ember-modifier';
 import { tracked } from 'tracked-built-ins';
 
+type ToolbarSection = {
+  reference?: HTMLElement;
+  dropdown?: HTMLElement;
+  enableDropdown: boolean;
+  showDropdown: boolean;
+};
+
 export default class ResponsiveToolbar extends Component {
   toolbar?: HTMLElement;
 
-  main: {
-    toolbar?: HTMLElement;
-    dropdown?: HTMLElement;
-    enableDropdown: boolean;
-    showDropdown: boolean;
-  } = tracked({
+  main: ToolbarSection = tracked({
     enableDropdown: false,
     showDropdown: false,
   });
 
-  side: {
-    toolbar?: HTMLElement;
-    dropdown?: HTMLElement;
-    enableDropdown: boolean;
-    showDropdown: boolean;
-  } = tracked({
+  side: ToolbarSection = tracked({
     enableDropdown: false,
     showDropdown: false,
   });
@@ -37,7 +34,7 @@ export default class ResponsiveToolbar extends Component {
 
   setUpMainToolbar = modifier(
     (element: HTMLElement) => {
-      this.main.toolbar = element;
+      this.main.reference = element;
       // Call handleResize to ensure the toolbar is correctly initialized
       this.handleResize();
     },
@@ -46,7 +43,7 @@ export default class ResponsiveToolbar extends Component {
 
   setUpSideToolbar = modifier(
     (element: HTMLElement) => {
-      this.side.toolbar = element;
+      this.side.reference = element;
       // Call handleResize to ensure the toolbar is correctly initialized
       this.handleResize();
     },
@@ -87,13 +84,13 @@ export default class ResponsiveToolbar extends Component {
     }
   }
 
-  isOverflowing = () => {
+  get isOverflowing() {
     if (this.toolbar) {
       return this.toolbar?.scrollWidth > this.toolbar?.offsetWidth;
     } else {
       return false;
     }
-  };
+  }
 
   handleResize() {
     requestAnimationFrame(() => {
@@ -101,8 +98,8 @@ export default class ResponsiveToolbar extends Component {
       this.side.enableDropdown = false;
       if (this.toolbar) {
         const toolbarChildren = [
-          ...(this.side.toolbar?.children ?? []),
-          ...(this.main.toolbar?.children ?? []),
+          ...(this.side.reference?.children ?? []),
+          ...(this.main.reference?.children ?? []),
         ];
         for (const child of toolbarChildren) {
           if (!child.hasAttribute('data-ignore-resize')) {
@@ -116,10 +113,10 @@ export default class ResponsiveToolbar extends Component {
         for (const child of dropdownChildren) {
           child.setAttribute('data-hidden', 'true');
         }
-        if (this.side.toolbar && this.side.dropdown) {
-          let i = this.side.toolbar.childElementCount - 1;
-          while (i >= 0 && this.isOverflowing()) {
-            const toolbarChild = this.side.toolbar.children[i];
+        if (this.side.reference && this.side.dropdown) {
+          let i = this.side.reference.childElementCount - 1;
+          while (i >= 0 && this.isOverflowing) {
+            const toolbarChild = this.side.reference.children[i];
             if (!toolbarChild.hasAttribute('data-ignore-resize')) {
               const dropdownChild = this.side.dropdown.children[i];
               this.side.enableDropdown = true;
@@ -129,10 +126,10 @@ export default class ResponsiveToolbar extends Component {
             i--;
           }
         }
-        if (this.main.toolbar && this.main.dropdown) {
-          let i = this.main.toolbar.childElementCount - 1;
-          while (i >= 0 && this.isOverflowing()) {
-            const toolbarChild = this.main.toolbar.children[i];
+        if (this.main.reference && this.main.dropdown) {
+          let i = this.main.reference.childElementCount - 1;
+          while (i >= 0 && this.isOverflowing) {
+            const toolbarChild = this.main.reference.children[i];
             if (!toolbarChild.hasAttribute('data-ignore-resize')) {
               const dropdownChild = this.main.dropdown.children[i];
               this.main.enableDropdown = true;

--- a/addon/components/responsive-toolbar.ts
+++ b/addon/components/responsive-toolbar.ts
@@ -1,59 +1,99 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { modifier } from 'ember-modifier';
 import { tracked } from 'tracked-built-ins';
 
 export default class ResponsiveToolbar extends Component {
   toolbar?: HTMLElement;
-  toolbarMain?: HTMLElement;
-  toolbarSide?: HTMLElement;
+  mainToolbar?: HTMLElement;
+  sideToolbar?: HTMLElement;
+
+  @tracked showSideOptionsButton = false;
+  @tracked showMainOptionsButton = false;
+
+  @tracked showMainOptionsDropdown = false;
+
+  setUpToolbar = modifier(
+    (element: HTMLElement) => {
+      const observer = new ResizeObserver(this.handleResize.bind(this));
+      observer.observe(element);
+      this.toolbar = element;
+    },
+    { eager: false }
+  );
 
   setUpMainToolbar = modifier(
     (element: HTMLElement) => {
-      const observer = new IntersectionObserver(
-        this.handleToolbarIntersection.bind(this),
-        {
-          root: element,
-          threshold: 1,
-        }
-      );
-      for (const child of element.children) {
-        child.setAttribute('data-index', '');
-        observer.observe(child);
-      }
-      this.toolbarMain = tracked(element);
+      this.mainToolbar = element;
+      // Call handleResize to ensure the toolbar is correctly initialized
+      this.handleResize();
     },
     { eager: false }
   );
 
   setUpSideToolbar = modifier(
     (element: HTMLElement) => {
-      const observer = new IntersectionObserver(
-        this.handleToolbarIntersection.bind(this),
-        {
-          root: element,
-          threshold: 1,
-        }
-      );
-      for (const child of element.children) {
-        child.setAttribute('data-index', '');
-        observer.observe(child);
-      }
-      this.toolbarSide = element;
+      this.sideToolbar = element;
+      // Call handleResize to ensure the toolbar is correctly initialized
+      this.handleResize();
     },
     { eager: false }
   );
 
-  get showMainToolbarOptions() {
-    console.log('get');
-    return this.toolbarMain?.querySelector("[data-hidden='true']");
+  @action
+  toggleMainOptions() {
+    this.showMainOptionsDropdown = !this.showMainOptionsDropdown;
   }
 
-  handleToolbarIntersection(entries: IntersectionObserverEntry[]) {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        entry.target.setAttribute('data-hidden', 'false');
-      } else {
-        entry.target.setAttribute('data-hidden', 'true');
+  isOverflowing = () => {
+    if (this.toolbar) {
+      return this.toolbar?.scrollWidth > this.toolbar?.offsetWidth;
+    } else {
+      return false;
+    }
+  };
+
+  handleResize() {
+    requestAnimationFrame(() => {
+      this.showSideOptionsButton = false;
+      this.showMainOptionsButton = false;
+      if (this.toolbar) {
+        if (this.sideToolbar) {
+          for (const child of this.sideToolbar.children) {
+            if (!child.hasAttribute('data-ignore-resize')) {
+              child.removeAttribute('data-hidden');
+            }
+          }
+        }
+        if (this.mainToolbar) {
+          for (const child of this.mainToolbar.children) {
+            if (!child.hasAttribute('data-ignore-resize')) {
+              child.removeAttribute('data-hidden');
+            }
+          }
+        }
+        if (this.sideToolbar) {
+          let i = this.sideToolbar.childElementCount - 1;
+          while (i >= 0 && this.isOverflowing()) {
+            const child = this.sideToolbar.children[i];
+            if (!child.hasAttribute('data-ignore-resize')) {
+              this.showSideOptionsButton = true;
+              child.setAttribute('data-hidden', 'true');
+            }
+            i--;
+          }
+        }
+        if (this.mainToolbar) {
+          let i = this.mainToolbar.childElementCount - 1;
+          while (i >= 0 && this.isOverflowing()) {
+            const child = this.mainToolbar.children[i];
+            if (!child.hasAttribute('data-ignore-resize')) {
+              this.showMainOptionsButton = true;
+              child.setAttribute('data-hidden', 'true');
+            }
+            i--;
+          }
+        }
       }
     });
   }

--- a/addon/components/responsive-toolbar.ts
+++ b/addon/components/responsive-toolbar.ts
@@ -1,0 +1,60 @@
+import Component from '@glimmer/component';
+import { modifier } from 'ember-modifier';
+import { tracked } from 'tracked-built-ins';
+
+export default class ResponsiveToolbar extends Component {
+  toolbar?: HTMLElement;
+  toolbarMain?: HTMLElement;
+  toolbarSide?: HTMLElement;
+
+  setUpMainToolbar = modifier(
+    (element: HTMLElement) => {
+      const observer = new IntersectionObserver(
+        this.handleToolbarIntersection.bind(this),
+        {
+          root: element,
+          threshold: 1,
+        }
+      );
+      for (const child of element.children) {
+        child.setAttribute('data-index', '');
+        observer.observe(child);
+      }
+      this.toolbarMain = tracked(element);
+    },
+    { eager: false }
+  );
+
+  setUpSideToolbar = modifier(
+    (element: HTMLElement) => {
+      const observer = new IntersectionObserver(
+        this.handleToolbarIntersection.bind(this),
+        {
+          root: element,
+          threshold: 1,
+        }
+      );
+      for (const child of element.children) {
+        child.setAttribute('data-index', '');
+        observer.observe(child);
+      }
+      this.toolbarSide = element;
+    },
+    { eager: false }
+  );
+
+  get showMainToolbarOptions() {
+    console.log('get');
+    return this.toolbarMain?.querySelector("[data-hidden='true']");
+  }
+
+  handleToolbarIntersection(entries: IntersectionObserverEntry[]) {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.setAttribute('data-hidden', 'false');
+      } else {
+        entry.target.setAttribute('data-hidden', 'true');
+      }
+    });
+  }
+}

--- a/addon/components/responsive-toolbar.ts
+++ b/addon/components/responsive-toolbar.ts
@@ -114,21 +114,17 @@ export default class ResponsiveToolbar extends Component {
           ...(this.main.dropdown?.children ?? []),
         ];
         for (const child of dropdownChildren) {
-          if (!child.hasAttribute('data-ignore-resize')) {
-            child.setAttribute('data-hidden', 'true');
-          }
+          child.setAttribute('data-hidden', 'true');
         }
         if (this.side.toolbar && this.side.dropdown) {
           let i = this.side.toolbar.childElementCount - 1;
           while (i >= 0 && this.isOverflowing()) {
-            const child = this.side.toolbar.children[i];
-            if (!child.hasAttribute('data-ignore-resize')) {
+            const toolbarChild = this.side.toolbar.children[i];
+            if (!toolbarChild.hasAttribute('data-ignore-resize')) {
+              const dropdownChild = this.side.dropdown.children[i];
               this.side.enableDropdown = true;
-              child.setAttribute('data-hidden', 'true');
-              this.side.dropdown.children[i].setAttribute(
-                'data-hidden',
-                'false'
-              );
+              toolbarChild.setAttribute('data-hidden', 'true');
+              dropdownChild.setAttribute('data-hidden', 'false');
             }
             i--;
           }
@@ -136,14 +132,12 @@ export default class ResponsiveToolbar extends Component {
         if (this.main.toolbar && this.main.dropdown) {
           let i = this.main.toolbar.childElementCount - 1;
           while (i >= 0 && this.isOverflowing()) {
-            const child = this.main.toolbar.children[i];
-            if (!child.hasAttribute('data-ignore-resize')) {
+            const toolbarChild = this.main.toolbar.children[i];
+            if (!toolbarChild.hasAttribute('data-ignore-resize')) {
+              const dropdownChild = this.main.dropdown.children[i];
               this.main.enableDropdown = true;
-              child.setAttribute('data-hidden', 'true');
-              this.main.dropdown.children[i].setAttribute(
-                'data-hidden',
-                'false'
-              );
+              toolbarChild.setAttribute('data-hidden', 'true');
+              dropdownChild.setAttribute('data-hidden', 'false');
             }
             i--;
           }

--- a/addon/components/toolbar/group.hbs
+++ b/addon/components/toolbar/group.hbs
@@ -1,3 +1,3 @@
-<div class='say-toolbar__group'>
+<div class='say-toolbar__group' ...attributes>
   {{yield}}
 </div>

--- a/app/components/responsive-toolbar.js
+++ b/app/components/responsive-toolbar.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/components/responsive-toolbar';

--- a/app/styles/ember-rdfa-editor/_c-toolbar.scss
+++ b/app/styles/ember-rdfa-editor/_c-toolbar.scss
@@ -25,7 +25,29 @@ $say-toolbar-height: 44px !default;
     border-bottom: 0;
     border-top: 1px solid $say-toolbar-border;
   }
+
+  *[data-hidden='true'] {
+    visibility: hidden;
+    pointer-events: none;
+    order: 100;
+  }
+
+  .say-toolbar__main {
+    min-width: 0;
+    flex-shrink: 1;
+    flex-grow: 1;
+  }
+
+  .say-toolbar__side {
+    min-width: 0;
+    flex-shrink: 200;
+  }
+
+  .say-toolbar__more {
+    position: sticky;
+  }
 }
+
 
 .say-toolbar img {
   max-width: inherit;

--- a/app/styles/ember-rdfa-editor/_c-toolbar.scss
+++ b/app/styles/ember-rdfa-editor/_c-toolbar.scss
@@ -58,10 +58,6 @@ $say-toolbar-height: 44px !default;
   z-index: 1;
 }
 
-.say-toolbar__side-dropdown {
-  flex-direction: column;
-}
-
 
 
 .say-toolbar img {

--- a/app/styles/ember-rdfa-editor/_c-toolbar.scss
+++ b/app/styles/ember-rdfa-editor/_c-toolbar.scss
@@ -47,28 +47,19 @@ $say-toolbar-height: 44px !default;
 
 
 
-.say-toolbar__main-dropdown {
+.say-toolbar__main-dropdown, .say-toolbar__side-dropdown {
   display: flex;
   justify-content: start;
   flex-wrap: wrap;
   min-height: $say-toolbar-height; // Fixes height bug on Safari
   border-radius: $au-unit-tiny;
   padding: 0.1rem $au-unit-tiny 0; // Visually center the text in the pill
-  margin: 0 1rem;
   background-color: $say-toolbar-background;
   z-index: 1;
 }
 
 .say-toolbar__side-dropdown {
-  display: flex;
   flex-direction: column;
-  justify-content: start;
-  flex-wrap: wrap;
-  border-radius: $au-unit-tiny;
-  padding: 0.1rem $au-unit-tiny 0; // Visually center the text in the pill
-  margin: 0 1rem;
-  background-color: $say-toolbar-background;
-  z-index: 1;
 }
 
 
@@ -92,6 +83,12 @@ $say-toolbar-height: 44px !default;
 
 .say-toolbar__group + .say-toolbar__group {
   border-left: 1px solid var(--au-gray-300);
+}
+
+.say-toolbar__main-dropdown, .say-toolbar__side-dropdown {
+  .say-toolbar__group + .say-toolbar__group {
+    border-left: 0;
+  }
 }
 
 .say-toolbar__button {

--- a/app/styles/ember-rdfa-editor/_c-toolbar.scss
+++ b/app/styles/ember-rdfa-editor/_c-toolbar.scss
@@ -26,27 +26,51 @@ $say-toolbar-height: 44px !default;
     border-top: 1px solid $say-toolbar-border;
   }
 
-  *[data-hidden='true'] {
-    visibility: hidden;
-    pointer-events: none;
-    order: 100;
-  }
+
 
   .say-toolbar__main {
-    min-width: 0;
-    flex-shrink: 1;
+    display: flex;
     flex-grow: 1;
+    flex-shrink: 1;
   }
 
   .say-toolbar__side {
-    min-width: 0;
-    flex-shrink: 200;
+    display: flex;
+    align-items: center;
+    flex-shrink: 1;
   }
-
-  .say-toolbar__more {
-    position: sticky;
+  
+  *[data-hidden='true'] {
+    display: none;
   }
 }
+
+
+
+.say-toolbar__main-dropdown {
+  display: flex;
+  justify-content: start;
+  flex-wrap: wrap;
+  min-height: $say-toolbar-height; // Fixes height bug on Safari
+  border-radius: $au-unit-tiny;
+  padding: 0.1rem $au-unit-tiny 0; // Visually center the text in the pill
+  margin: 0 1rem;
+  background-color: $say-toolbar-background;
+  z-index: 1;
+}
+
+.say-toolbar__side-dropdown {
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+  flex-wrap: wrap;
+  border-radius: $au-unit-tiny;
+  padding: 0.1rem $au-unit-tiny 0; // Visually center the text in the pill
+  margin: 0 1rem;
+  background-color: $say-toolbar-background;
+  z-index: 1;
+}
+
 
 
 .say-toolbar img {

--- a/tests/dummy/app/components/sample-toolbar-responsive.hbs
+++ b/tests/dummy/app/components/sample-toolbar-responsive.hbs
@@ -1,0 +1,40 @@
+<ResponsiveToolbar>
+  <:main as |Tb|>
+    <Tb.Group>
+      <Plugins::History::Undo @controller={{@controller}}/>
+      <Plugins::History::Redo @controller={{@controller}}/>
+    </Tb.Group>
+    <Tb.Group>
+      <Plugins::TextStyle::Bold @controller={{@controller}}/>
+      <Plugins::TextStyle::Italic @controller={{@controller}}/>
+      <Plugins::TextStyle::Strikethrough @controller={{@controller}}/>
+      <Plugins::TextStyle::Underline @controller={{@controller}}/>
+      <Tb.Divider/>
+      <Plugins::TextStyle::Subscript @controller={{@controller}}/>
+      <Plugins::TextStyle::Superscript @controller={{@controller}}/>
+      <CodeMark::ToolbarButton @controller={{@controller}}/>
+    </Tb.Group>
+    <Tb.Group>
+      <Plugins::List::Unordered @controller={{@controller}}/>
+      <Plugins::List::Ordered @controller={{@controller}}/>
+    </Tb.Group>
+    <Tb.Group>
+      <Plugins::Indentation::IndentationMenu @controller={{@controller}}/>
+    </Tb.Group>
+    <Tb.Group>
+      <Plugins::Link::LinkMenu @controller={{@controller}}/>
+    </Tb.Group>
+    <Tb.Group>
+      <Plugins::Table::TableMenu @controller={{@controller}}/>
+    </Tb.Group>
+    <Tb.Group>
+      <Plugins::Heading::HeadingMenu @controller={{@controller}}/>
+    </Tb.Group>
+  </:main>
+  <:side as |Tb|>
+    <Tb.Group>
+      <Plugins::Formatting::FormattingToggle @controller={{@controller}}/>
+      <Plugins::RdfaBlockRender::RdfaBlocksToggle @controller={{@controller}}/>
+    </Tb.Group>
+  </:side>
+</ResponsiveToolbar>

--- a/tests/dummy/app/components/sample-toolbar-responsive.hbs
+++ b/tests/dummy/app/components/sample-toolbar-responsive.hbs
@@ -34,6 +34,8 @@
   <:side as |Tb|>
     <Tb.Group>
       <Plugins::Formatting::FormattingToggle @controller={{@controller}}/>
+    </Tb.Group>
+    <Tb.Group>
       <Plugins::RdfaBlockRender::RdfaBlocksToggle @controller={{@controller}}/>
     </Tb.Group>
   </:side>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -14,7 +14,7 @@
       @showRdfaBlocks={{this.showRdfaBlocks}}
     >
       <:top>
-        <SampleToolbar @controller={{this.rdfaEditor}}/>
+        <SampleToolbarResponsive @controller={{this.rdfaEditor}}/>
       </:top>
       <:default>
         <Editor

--- a/tests/dummy/app/templates/plugins.hbs
+++ b/tests/dummy/app/templates/plugins.hbs
@@ -14,7 +14,7 @@
       @showRdfaBlocks={{this.showRdfaBlocks}}
     >
       <:top>
-        <SampleToolbar @controller={{this.rdfaEditor}}/>
+        <SampleToolbarResponsive @controller={{this.rdfaEditor}}/>
       </:top>
       <:default>
         <Editor


### PR DESCRIPTION
This PR introduces the `ResponsiveToolbar` component, a modified version of the current `Toolbar` component which takes screen and container widths into account. 
The new toolbar component consists of two main sections:
- A `main` section which will typically contain often used controls such as text styling controls, table controls, history controls etc.
- A `side` section which can include additional controls. It will typically contain additional information and formatting controls.

Both of these sections are collapsible. If the controls of a section no longer fit in the available space, they are moved to a collapsible dropdown. The toolbar will first try to collapse the `side` section, and afterwards the `main` section

The component should be used in the following manner:

```
<ResponsiveToolbar>
<:main>
{{!-- A list of main controls --}}
</:main>
<:side>
{{!-- A list of side controls --}}
</:side>
<ResponsiveToolbar>
```

The toolbar will collapse each direct child of the `main` and `side` sections separately. If you do not wish a specific child to be collapsed, you may add the `data-ignore-resize` attribute.

This PR is a solution to https://binnenland.atlassian.net/browse/GN-4120?atlOrigin=eyJpIjoiYzk4MDcxZmNhZTJjNDJiNjkxYjQwOTM4YTNmYjFiNmIiLCJwIjoiaiJ9.