### PR TITLE
Resizable images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 - Addition of a `ResponsiveToolbar` component which takes into account container and screen size.
 - Addition of a color highlighting mark and toolbar menu
+- Support for resizable images
+- Addition of an optional stopEvent attribute which can be provided when configuring an ember-node, it can be used to override the default behaviour of the stopEvent attribute of the ember-node node-view.
 
 ### Fixed:
 - embedded-editor: only set data-placeholder when placeholder argument is supplied

--- a/addon/components/plugins/image/node.hbs
+++ b/addon/components/plugins/image/node.hbs
@@ -1,0 +1,46 @@
+{{! template-lint-disable no-invalid-interactive }}
+<span class='say-image' {{this.setUpImageContainer}} style={{this.style}}>
+  <img
+    src={{@node.attrs.src}}
+    alt={{@node.attrs.alt}}
+    {{on 'click' this.select}}
+    {{this.setUpImage}}
+    style={{this.style}}
+  />
+  <div class='say-image__resizer'>
+    {{!-- Corner handles --}}
+    <div
+      class='say-image__resize__handle say-image__resize__handle-top-left'
+      {{this.setUpHandle 'topLeft'}}
+    />
+    <div
+      class='say-image__resize__handle say-image__resize__handle-top-right'
+      {{this.setUpHandle 'topRight'}}
+    />
+    <div
+      class='say-image__resize__handle say-image__resize__handle-bottom-right'
+      {{this.setUpHandle 'bottomRight'}}
+    />
+    <div
+      class='say-image__resize__handle say-image__resize__handle-bottom-left'
+      {{this.setUpHandle 'bottomLeft'}}
+    />
+    {{!-- Side handles --}}
+    <div
+      class='say-image__resize__handle say-image__resize__handle-top'
+      {{this.setUpHandle 'top'}}
+    />
+    <div
+      class='say-image__resize__handle say-image__resize__handle-right'
+      {{this.setUpHandle 'right'}}
+    />
+    <div
+      class='say-image__resize__handle say-image__resize__handle-bottom'
+      {{this.setUpHandle 'bottom'}}
+    />
+    <div
+      class='say-image__resize__handle say-image__resize__handle-left'
+      {{this.setUpHandle 'left'}}
+    />
+  </div>
+</span>

--- a/addon/components/plugins/image/node.ts
+++ b/addon/components/plugins/image/node.ts
@@ -1,0 +1,241 @@
+/**
+ * Inspired by https://gitlab.com/emergence-engineering/prosemirror-image-plugin
+ *
+ * MIT License
+ *
+ * Copyright (c) 2022 emergence-engineering
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
+import { NodeSelection } from 'prosemirror-state';
+import { modifier } from 'ember-modifier';
+import {
+  ResizeFunction,
+  updateHeight,
+  updateSize,
+  updateWidth,
+} from '@lblod/ember-rdfa-editor/plugins/image/utils/resize-functions';
+
+const MIN_SURFACE = 625;
+
+type Size = {
+  width: number;
+  height: number;
+};
+
+type Position = {
+  x: number;
+  y: number;
+};
+
+type HandleType =
+  | 'topLeft'
+  | 'topRight'
+  | 'bottomRight'
+  | 'bottomLeft'
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left';
+
+type Handle = {
+  direction: -1 | 1;
+  resizeFunction: ResizeFunction;
+};
+
+const HANDLES: Record<HandleType, Handle> = {
+  topLeft: {
+    direction: 1,
+    resizeFunction: updateSize,
+  },
+  topRight: {
+    direction: -1,
+    resizeFunction: updateSize,
+  },
+  bottomRight: {
+    direction: -1,
+    resizeFunction: updateSize,
+  },
+  bottomLeft: {
+    direction: 1,
+    resizeFunction: updateSize,
+  },
+  top: {
+    direction: 1,
+    resizeFunction: updateHeight,
+  },
+  right: {
+    direction: -1,
+    resizeFunction: updateWidth,
+  },
+  bottom: {
+    direction: -1,
+    resizeFunction: updateHeight,
+  },
+  left: {
+    direction: 1,
+    resizeFunction: updateWidth,
+  },
+};
+
+type ResizeState = {
+  handle: Handle;
+  initialPosition: Position;
+  initialSize: Size;
+};
+
+export default class ImageNode extends Component<EmberNodeArgs> {
+  handleReferences: Partial<Record<HandleType, HTMLElement>> = {};
+  imageContainer?: HTMLElement;
+  image?: HTMLElement;
+
+  resizeState?: ResizeState;
+
+  setUpHandle = modifier(
+    (element: HTMLElement, [position]: [HandleType]) => {
+      this.handleReferences[position] = element;
+      element.addEventListener('mousedown', this.onMouseDown);
+    },
+    {
+      eager: false,
+    }
+  );
+
+  setUpImageContainer = modifier(
+    (element: HTMLElement) => {
+      this.imageContainer = element;
+    },
+    { eager: false }
+  );
+  setUpImage = modifier(
+    (element: HTMLElement) => {
+      this.image = element;
+    },
+    { eager: false }
+  );
+
+  get node() {
+    return this.args.node;
+  }
+
+  get controller() {
+    return this.args.controller;
+  }
+
+  get width() {
+    return this.args.node.attrs.width as number;
+  }
+
+  get height() {
+    return this.args.node.attrs.height as number;
+  }
+
+  get style() {
+    const widthStyle = this.width ? `width: ${this.width}px;` : '';
+    const heightStyle = this.height ? `height: ${this.height}px;` : '';
+    return widthStyle + heightStyle;
+  }
+
+  @action
+  select(event: InputEvent) {
+    event.preventDefault();
+    if (!this.args.selected) {
+      this.args.controller.withTransaction((tr) => {
+        return tr.setSelection(
+          NodeSelection.create(tr.doc, this.args.getPos())
+        );
+      });
+    }
+  }
+
+  onMouseDown = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const handleType = Object.keys(this.handleReferences).find(
+      (key: HandleType) => this.handleReferences[key] === event.target
+    ) as HandleType | undefined;
+    if (this.image && handleType) {
+      this.handleReferences;
+      this.resizeState = {
+        handle: HANDLES[handleType],
+        initialPosition: { x: event.clientX, y: event.clientY },
+        initialSize: {
+          height: this.image.clientHeight,
+          width: this.image.clientWidth,
+        },
+      };
+      document.addEventListener('mousemove', this.onMouseMove);
+      document.addEventListener('mouseup', this.onMouseUp);
+    }
+  };
+
+  onMouseMove = (event: MouseEvent) => {
+    event.preventDefault();
+    if (this.resizeState && this.image && this.imageContainer) {
+      const { initialPosition, initialSize, handle } = this.resizeState;
+      const aspectRatio = initialSize.height / initialSize.width;
+
+      const dX = (initialPosition.x - event.clientX) * handle.direction;
+      const dY = (initialPosition.y - event.clientY) * handle.direction;
+
+      let newWidth = initialSize.width;
+      let newHeight = initialSize.height;
+      switch (handle.resizeFunction) {
+        case updateSize:
+          newWidth = initialSize.width + dX;
+          newHeight = newWidth * aspectRatio;
+          break;
+        case updateWidth:
+          newWidth = initialSize.width + dX;
+          break;
+        case updateHeight:
+          newHeight = initialSize.height + dY;
+          break;
+      }
+
+      if (newWidth * newHeight >= MIN_SURFACE) {
+        handle.resizeFunction(this.imageContainer, newWidth, newHeight);
+        handle.resizeFunction(this.image, newWidth, newHeight);
+      }
+    }
+  };
+
+  onMouseUp = () => {
+    document.removeEventListener('mousemove', this.onMouseMove);
+    document.removeEventListener('mouseup', this.onMouseUp);
+    if (this.image) {
+      const { clientWidth, clientHeight } = this.image;
+      const pos = this.args.getPos();
+      if (pos) {
+        this.controller.withTransaction((tr) => {
+          return tr
+            .setNodeAttribute(pos, 'width', clientWidth)
+            .setNodeAttribute(pos, 'height', clientHeight);
+        });
+      }
+    }
+    this.resizeState = undefined;
+  };
+}

--- a/addon/components/plugins/image/node.ts
+++ b/addon/components/plugins/image/node.ts
@@ -162,11 +162,12 @@ export default class ImageNode extends Component<EmberNodeArgs> {
   select(event: InputEvent) {
     event.preventDefault();
     if (!this.args.selected) {
-      this.args.controller.withTransaction((tr) => {
-        return tr.setSelection(
-          NodeSelection.create(tr.doc, this.args.getPos())
-        );
-      });
+      const pos = this.args.getPos();
+      if (pos !== undefined) {
+        this.args.controller.withTransaction((tr) => {
+          return tr.setSelection(NodeSelection.create(tr.doc, pos));
+        });
+      }
     }
   }
 
@@ -228,7 +229,7 @@ export default class ImageNode extends Component<EmberNodeArgs> {
     if (this.image) {
       const { clientWidth, clientHeight } = this.image;
       const pos = this.args.getPos();
-      if (pos) {
+      if (pos !== undefined) {
         this.controller.withTransaction((tr) => {
           return tr
             .setNodeAttribute(pos, 'width', clientWidth)

--- a/addon/components/plugins/image/node.ts
+++ b/addon/components/plugins/image/node.ts
@@ -50,7 +50,7 @@ type Position = {
   y: number;
 };
 
-type HandleType =
+type HandlePosition =
   | 'topLeft'
   | 'topRight'
   | 'bottomRight'
@@ -65,7 +65,7 @@ type Handle = {
   resizeFunction: ResizeFunction;
 };
 
-const HANDLES: Record<HandleType, Handle> = {
+const HANDLES: Record<HandlePosition, Handle> = {
   topLeft: {
     direction: 1,
     resizeFunction: updateSize,
@@ -107,16 +107,18 @@ type ResizeState = {
 };
 
 export default class ImageNode extends Component<EmberNodeArgs> {
-  handleReferences: Partial<Record<HandleType, HTMLElement>> = {};
+  handleReferences: Partial<Record<HandlePosition, HTMLElement>> = {};
   imageContainer?: HTMLElement;
   image?: HTMLElement;
 
   resizeState?: ResizeState;
 
   setUpHandle = modifier(
-    (element: HTMLElement, [position]: [HandleType]) => {
+    (element: HTMLElement, [position]: [HandlePosition]) => {
       this.handleReferences[position] = element;
-      element.addEventListener('mousedown', this.onMouseDown);
+      element.addEventListener('mousedown', (event) =>
+        this.onMouseDown(event, position)
+      );
     },
     {
       eager: false,
@@ -171,16 +173,13 @@ export default class ImageNode extends Component<EmberNodeArgs> {
     }
   }
 
-  onMouseDown = (event: MouseEvent) => {
+  onMouseDown = (event: MouseEvent, handlePosition: HandlePosition) => {
     event.preventDefault();
     event.stopPropagation();
-    const handleType = Object.keys(this.handleReferences).find(
-      (key: HandleType) => this.handleReferences[key] === event.target
-    ) as HandleType | undefined;
-    if (this.image && handleType) {
+    if (this.image && handlePosition) {
       this.handleReferences;
       this.resizeState = {
-        handle: HANDLES[handleType],
+        handle: HANDLES[handlePosition],
         initialPosition: { x: event.clientX, y: event.clientY },
         initialSize: {
           height: this.image.clientHeight,

--- a/addon/components/plugins/image/node.ts
+++ b/addon/components/plugins/image/node.ts
@@ -31,12 +31,7 @@ import Component from '@glimmer/component';
 import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import { NodeSelection } from 'prosemirror-state';
 import { modifier } from 'ember-modifier';
-import {
-  ResizeFunction,
-  updateHeight,
-  updateSize,
-  updateWidth,
-} from '@lblod/ember-rdfa-editor/plugins/image/utils/resize-functions';
+import { updateSize } from '@lblod/ember-rdfa-editor/plugins/image/utils/resize-functions';
 
 const MIN_SURFACE = 625;
 
@@ -62,41 +57,46 @@ type HandlePosition =
 
 type Handle = {
   direction: -1 | 1;
-  resizeFunction: ResizeFunction;
+  updatesWidth?: boolean;
+  updatesHeight?: boolean;
 };
 
 const HANDLES: Record<HandlePosition, Handle> = {
   topLeft: {
     direction: 1,
-    resizeFunction: updateSize,
+    updatesWidth: true,
+    updatesHeight: true,
   },
   topRight: {
     direction: -1,
-    resizeFunction: updateSize,
+    updatesWidth: true,
+    updatesHeight: true,
   },
   bottomRight: {
     direction: -1,
-    resizeFunction: updateSize,
+    updatesWidth: true,
+    updatesHeight: true,
   },
   bottomLeft: {
     direction: 1,
-    resizeFunction: updateSize,
+    updatesWidth: true,
+    updatesHeight: true,
   },
   top: {
     direction: 1,
-    resizeFunction: updateHeight,
+    updatesHeight: true,
   },
   right: {
     direction: -1,
-    resizeFunction: updateWidth,
+    updatesWidth: true,
   },
   bottom: {
     direction: -1,
-    resizeFunction: updateHeight,
+    updatesHeight: true,
   },
   left: {
     direction: 1,
-    resizeFunction: updateWidth,
+    updatesWidth: true,
   },
 };
 
@@ -202,22 +202,18 @@ export default class ImageNode extends Component<EmberNodeArgs> {
 
       let newWidth = initialSize.width;
       let newHeight = initialSize.height;
-      switch (handle.resizeFunction) {
-        case updateSize:
-          newWidth = initialSize.width + dX;
-          newHeight = newWidth * aspectRatio;
-          break;
-        case updateWidth:
-          newWidth = initialSize.width + dX;
-          break;
-        case updateHeight:
-          newHeight = initialSize.height + dY;
-          break;
+      if (handle.updatesWidth && handle.updatesHeight) {
+        newWidth = initialSize.width + dX;
+        newHeight = newWidth * aspectRatio;
+      } else if (handle.updatesWidth) {
+        newWidth = initialSize.width + dX;
+      } else if (handle.updatesHeight) {
+        newHeight = initialSize.height + dY;
       }
 
       if (newWidth * newHeight >= MIN_SURFACE) {
-        handle.resizeFunction(this.imageContainer, newWidth, newHeight);
-        handle.resizeFunction(this.image, newWidth, newHeight);
+        updateSize(this.imageContainer, newWidth, newHeight);
+        updateSize(this.image, newWidth, newHeight);
       }
     }
   };

--- a/addon/plugins/image/index.ts
+++ b/addon/plugins/image/index.ts
@@ -1,1 +1,1 @@
-export { image } from './nodes/image';
+export { image, imageView } from './nodes/image';

--- a/addon/plugins/image/nodes/image.ts
+++ b/addon/plugins/image/nodes/image.ts
@@ -1,27 +1,55 @@
-import { Node as PNode, NodeSpec } from 'prosemirror-model';
+import {
+  createEmberNodeSpec,
+  createEmberNodeView,
+  EmberNodeConfig,
+} from '@lblod/ember-rdfa-editor/utils/ember-node';
+import { Node as PNode } from 'prosemirror-model';
 
-export const image: NodeSpec = {
+const emberNodeConfig: EmberNodeConfig = {
+  name: 'image',
+  componentPath: 'plugins/image/node',
   inline: true,
+  group: 'inline',
+  draggable: true,
+  atom: true,
   attrs: {
     src: {},
     alt: { default: null },
-    title: { default: null },
+    width: { default: null },
+    height: { default: null },
   },
-  group: 'inline',
-  draggable: true,
   parseDOM: [
     {
       tag: 'img[src]',
       getAttrs(dom: HTMLElement) {
         return {
           src: dom.getAttribute('src'),
-          title: dom.getAttribute('title'),
           alt: dom.getAttribute('alt'),
+          width: dom.dataset.width ? Number(dom.dataset.width) : null,
+          height: dom.dataset.height ? Number(dom.dataset.height) : null,
         };
       },
     },
   ],
   toDOM(node: PNode) {
-    return ['img', node.attrs];
+    const { src, alt, width, height } = node.attrs;
+    const widthStyle = width ? `width: ${width as number}px;` : '';
+    const heightStyle = height ? `height: ${height as number}px;` : '';
+    return [
+      'img',
+      {
+        src: src as string,
+        alt: alt as string | undefined,
+        'data-width': width as number,
+        'data-height': height as number,
+        style: widthStyle + heightStyle,
+      },
+    ];
+  },
+  stopEvent() {
+    return false;
   },
 };
+
+export const image = createEmberNodeSpec(emberNodeConfig);
+export const imageView = createEmberNodeView(emberNodeConfig);

--- a/addon/plugins/image/utils/resize-functions.ts
+++ b/addon/plugins/image/utils/resize-functions.ts
@@ -1,0 +1,18 @@
+export type ResizeFunction = (
+  element: HTMLElement,
+  width: number,
+  height: number
+) => void;
+
+export const updateSize: ResizeFunction = (element, width, height) => {
+  element.style.width = `${width}px`;
+  element.style.height = `${height}px`;
+};
+
+export const updateWidth: ResizeFunction = (element, width) => {
+  element.style.width = `${width}px`;
+};
+
+export const updateHeight: ResizeFunction = (element, _width, height) => {
+  element.style.height = `${height}px`;
+};

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -70,6 +70,7 @@ class EmberNodeView implements NodeView {
   contentDOM?: HTMLElement;
   emberComponent: EmberInlineComponent;
   template: TemplateFactory;
+  stopEvent: (event: InputEvent) => boolean;
 
   constructor(
     controller: SayController,
@@ -78,7 +79,13 @@ class EmberNodeView implements NodeView {
     view: SayView,
     getPos: () => number
   ) {
-    const { name, componentPath, atom, inline } = emberNodeConfig;
+    const {
+      name,
+      componentPath,
+      atom,
+      inline,
+      stopEvent = () => true,
+    } = emberNodeConfig;
     this.template = hbs`{{#component this.componentPath
                           getPos=this.getPos
                           node=this.node
@@ -96,6 +103,7 @@ class EmberNodeView implements NodeView {
     this.contentDOM = !atom
       ? document.createElement(inline ? 'span' : 'div')
       : undefined;
+    this.stopEvent = stopEvent;
 
     const { node, component } = emberComponent(
       controller.owner,
@@ -147,10 +155,6 @@ class EmberNodeView implements NodeView {
   destroy() {
     this.emberComponent.destroy();
   }
-
-  stopEvent() {
-    return true;
-  }
 }
 
 export type EmberNodeConfig = {
@@ -172,6 +176,7 @@ export type EmberNodeConfig = {
   };
   parseDOM?: readonly ParseRule[];
   toDOM?: (node: PNode) => DOMOutputSpec;
+  stopEvent?: (event: InputEvent) => boolean;
 } & (
   | {
       atom: true;

--- a/app/components/plugins/image/node.js
+++ b/app/components/plugins/image/node.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/components/plugins/image/node';

--- a/app/styles/ember-rdfa-editor/_a-custom-components.scss
+++ b/app/styles/ember-rdfa-editor/_a-custom-components.scss
@@ -17,6 +17,7 @@
 @import 'c-table';
 @import 'c-ember-node';
 @import 'c-color-selector';
+@import 'c-image';
 // RDFA AND ANNOTATION COMPONENTS
 @import 'c-annotation';
 @import 'c-annotation-hover';

--- a/app/styles/ember-rdfa-editor/_c-image.scss
+++ b/app/styles/ember-rdfa-editor/_c-image.scss
@@ -1,0 +1,104 @@
+.say-image {
+  display: inline-flex;
+  cursor: move;
+}
+
+.ProseMirror-selectednode {
+  .say-image img {
+    &::selection {
+      background-color: transparent;
+    }
+  }
+}
+
+.ember-node:not(.ProseMirror-selectednode) {
+  .say-image {
+    .say-image__resizer {
+      display: none;
+    }
+  }
+}
+.say-image {
+  position: relative;
+
+  .say-image__resizer {
+    outline: 2px solid var(--au-blue-500);
+    position: absolute !important;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+
+    .say-image__resize__handle {
+      z-index: 1;
+      width: 8px;
+      height: 8px;
+      background-color: var(--au-blue-500);
+      position: absolute;
+      margin: 0;
+      padding: 0;
+    }
+
+    .say-image__resize__handle-top-left {
+      left: -5px;
+      top: -5px;
+      cursor: nw-resize;
+    }
+
+    .say-image__resize__handle-top-right {
+      right: -5px;
+      top: -5px;
+      cursor: ne-resize;
+    }
+
+    .say-image__resize__handle-bottom-right {
+      right: -5px;
+      bottom: -5px;
+      cursor: se-resize;
+    }
+
+    .say-image__resize__handle-bottom-left {
+      left: -5px;
+      bottom: -5px;
+      cursor: sw-resize;
+    }
+
+    .say-image__resize__handle-top {
+      left: 0;
+      right: 0;
+      margin-left: auto;
+      margin-right: auto; 
+      top: -5px;
+      cursor: n-resize;
+    }
+
+    .say-image__resize__handle-right {
+      top: 0;
+      bottom: 0;
+      right: -5px;
+      cursor: e-resize;
+      margin-top: auto;
+      margin-bottom: auto;
+    }
+
+    .say-image__resize__handle-bottom {
+      bottom: -5px;
+      left: 0;
+      right: 0;
+      cursor: s-resize;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .say-image__resize__handle-left {
+      top: 0;
+      bottom: 0;
+      left: -5px;
+      cursor: w-resize;
+      margin-top: auto;
+      margin-bottom: auto;
+    }
+  }
+}

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -28,7 +28,7 @@ import {
   tableNodes,
   tablePlugin,
 } from '@lblod/ember-rdfa-editor/plugins/table';
-import { image } from '@lblod/ember-rdfa-editor/plugins/image';
+import { image, imageView } from '@lblod/ember-rdfa-editor/plugins/image';
 import { blockquote } from '@lblod/ember-rdfa-editor/plugins/blockquote';
 import { heading } from '@lblod/ember-rdfa-editor/plugins/heading';
 import { code_block } from '@lblod/ember-rdfa-editor/plugins/code';
@@ -117,6 +117,7 @@ export default class IndexController extends Controller {
   @tracked nodeViews = (controller: SayController) => {
     return {
       link: linkView(this.linkOptions)(controller),
+      image: imageView(controller),
     };
   };
 

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -30,7 +30,7 @@ import {
   tableNodes,
   tablePlugin,
 } from '@lblod/ember-rdfa-editor/plugins/table';
-import { image } from '@lblod/ember-rdfa-editor/plugins/image';
+import { image, imageView } from '@lblod/ember-rdfa-editor/plugins/image';
 import { blockquote } from '@lblod/ember-rdfa-editor/plugins/blockquote';
 import {
   em,
@@ -116,6 +116,7 @@ export default class IndexController extends Controller {
       counter: counterView(proseController),
       dropdown: dropdownView(proseController),
       link: linkView(this.linkOptions)(proseController),
+      image: imageView(proseController),
     };
   };
   @tracked plugins: Plugin[] = [

--- a/tests/dummy/app/dummy-nodes/card.ts
+++ b/tests/dummy/app/dummy-nodes/card.ts
@@ -11,6 +11,10 @@ const emberNodeConfig: EmberNodeConfig = {
   group: 'block',
   content: 'inline*',
   atom: false,
+  draggable: true,
+  stopEvent() {
+    return false;
+  },
 };
 
 export const card = createEmberNodeSpec(emberNodeConfig);

--- a/tests/dummy/app/dummy-nodes/counter.ts
+++ b/tests/dummy/app/dummy-nodes/counter.ts
@@ -11,6 +11,7 @@ const emberNodeConfig: EmberNodeConfig = {
   inline: true,
   group: 'inline',
   atom: true,
+  draggable: true,
   attrs: {
     count: {
       default: 0,
@@ -21,6 +22,9 @@ const emberNodeConfig: EmberNodeConfig = {
         return optionMapOr(0, parseInt, element.getAttribute('count'));
       },
     },
+  },
+  stopEvent() {
+    return false;
   },
 };
 

--- a/tests/dummy/app/dummy-nodes/dropdown.ts
+++ b/tests/dummy/app/dummy-nodes/dropdown.ts
@@ -10,6 +10,10 @@ const emberNodeConfig: EmberNodeConfig = {
   inline: true,
   group: 'inline',
   atom: true,
+  draggable: true,
+  stopEvent() {
+    return false;
+  },
 };
 
 export const dropdown = createEmberNodeSpec(emberNodeConfig);


### PR DESCRIPTION
This PR introduces the resizable images feature. Resizable images are implemented using an ember-node, when selected, handles are shown at the corners and sides of the image in order to resize it.

Specifically, this PR contains the following:
- A reworked `image` node-spec and an `image` node-view.
- The addition of an optional `stopEvent` attribute which can be provided when configuring an ember-node, it can be used to override the default behaviour of the `stopEvent` attribute of the ember-node node-view.

This PR is a solution to https://binnenland.atlassian.net/browse/GN-4142