### PR TITLE
GN-4133: Remove whitespace around inline pills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added:
 - Addition of a `ResponsiveToolbar` component which takes into account container and screen size.
 - Addition of a color highlighting mark and toolbar menu
+- Required parts of `AuPill` extracted into `Pill` component
 
 ### Fixed:
 - embedded-editor: only set data-placeholder when placeholder argument is supplied
@@ -17,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix switching unordered list to ordered and applying correct styling
 - ember-node: Fix cursor placement inside of `ember-node` when navigating from left
 - Un-indent paragraph on backspace at the front of paragraph
+- Change `EmberNode` "inline" style to be `inline-block` to avoid pushing away surrounding content
+- Change `outline` for `Link` "ember-node" to have `outline-offset` `-2px` for it not to cover nearby content when focused
 
 ### Changed:
 - disable broken firefox cursor fix plugin

--- a/addon/components/ember-node/link.hbs
+++ b/addon/components/ember-node/link.hbs
@@ -1,32 +1,50 @@
-<Velcro @placement="bottom" @offsetOptions={{hash mainAxis=3}} as |velcro|>
-  <AuPill 
-    class="say-link"
-    @icon="link" 
-    @iconAlignment="right" 
-    @skin="link"
-    title={{t "ember-rdfa-editor.link.ctrlClickDescription"}}
-    aria-describedby="link-tooltip"
+<Velcro @placement='bottom' @offsetOptions={{hash mainAxis=3}} as |velcro|>
+  <Pill
+    class='say-link'
+    @icon='link'
+    @iconAlignment='right'
+    @skin='link'
+    title={{t 'ember-rdfa-editor.link.ctrlClickDescription'}}
+    aria-describedby='link-tooltip'
     {{velcro.hook}}
-    {{on "click" this.onClick }}>
-    <EmberNode::EmbeddedEditor 
-      @controller={{@controller}} 
-      @node={{@node}} 
-      @view={{@view}} 
-      @getPos={{@getPos}} 
-      @selected={{@selected}} 
+    {{on 'click' this.onClick}}
+  >
+    <EmberNode::EmbeddedEditor
+      @controller={{@controller}}
+      @node={{@node}}
+      @view={{@view}}
+      @getPos={{@getPos}}
+      @selected={{@selected}}
       @placeholder={{t 'ember-rdfa-editor.link.placeholder.text'}}
       @decorations={{@decorations}}
       @contentDecorations={{@contentDecorations}}
     />
-  </AuPill>
+  </Pill>
   {{#if (and this.selected this.interactive)}}
-    <AuPill @size="small" 
-            class="say-link-tooltip"
-            id="link-tooltip"
-            {{velcro.loop}}>
-      <AuLinkExternal href={{this.href}} @skin="naked" @icon="link-external" title="Link openen"/>
-      <AuInput @value={{this.href}} placeholder={{t 'ember-rdfa-editor.link.placeholder.href'}} {{on 'focus' this.selectHref}}/>
-      <AuButton @icon="link-broken" @skin="naked" @size="small" {{on 'click' this.remove}} title="Link ontkoppelen"/>
-    </AuPill>
+    <Pill
+      @size='small'
+      class='say-link-tooltip'
+      id='link-tooltip'
+      {{velcro.loop}}
+    >
+      <AuLinkExternal
+        href={{this.href}}
+        @skin='naked'
+        @icon='link-external'
+        title='Link openen'
+      />
+      <AuInput
+        @value={{this.href}}
+        placeholder={{t 'ember-rdfa-editor.link.placeholder.href'}}
+        {{on 'focus' this.selectHref}}
+      />
+      <AuButton
+        @icon='link-broken'
+        @skin='naked'
+        @size='small'
+        {{on 'click' this.remove}}
+        title='Link ontkoppelen'
+      />
+    </Pill>
   {{/if}}
 </Velcro>

--- a/addon/components/pill.hbs
+++ b/addon/components/pill.hbs
@@ -1,0 +1,16 @@
+<span
+  class='au-c-pill {{this.skin}} {{this.size}}'
+  ...attributes
+>
+  {{#if @icon}}
+    {{#if (not-eq @iconAlignment 'right')}}
+      <AuIcon @icon='{{@icon}}' />
+    {{/if}}
+  {{/if}}
+  {{yield}}
+  {{#if @icon}}
+    {{#if (eq @iconAlignment 'right')}}
+      <AuIcon @icon='{{@icon}}' />
+    {{/if}}
+  {{/if}}
+</span>

--- a/addon/components/pill.ts
+++ b/addon/components/pill.ts
@@ -1,0 +1,39 @@
+import Component from '@glimmer/component';
+
+const PILL_SIZES = ['small'] as const;
+
+type PillComponentArgs = {
+  skin?:
+    | 'border'
+    | 'action'
+    | 'ongoing'
+    | 'link'
+    | 'success'
+    | 'warning'
+    | 'error';
+  size?: (typeof PILL_SIZES)[number];
+  iconAlignment?: 'left' | 'right';
+  icon?: string;
+};
+
+export default class PillComponent extends Component<PillComponentArgs> {
+  get skin() {
+    if (this.args.skin) {
+      return `au-c-pill--${this.args.skin}`;
+    }
+
+    return 'au-c-pill--default';
+  }
+
+  get size() {
+    if (!this.args.size) {
+      return '';
+    }
+
+    return `au-c-pill--${this.args.size}`;
+  }
+
+  get iconAlignment(): PillComponentArgs['iconAlignment'] {
+    return this.args.iconAlignment ?? 'left';
+  }
+}

--- a/addon/components/utils/au-pill-dropdown.hbs
+++ b/addon/components/utils/au-pill-dropdown.hbs
@@ -1,13 +1,13 @@
 <div class='say-dropdown' ...attributes>
-  <AuPill
+  <Pill
     aria-haspopup='true'
     aria-expanded='{{if this.dropdownOpen "true" "false"}}'
     {{on 'click' this.openDropdown}}
     @icon={{@icon}}
     @iconAlignment={{@iconAlignment}}
-  > 
+  >
     {{yield to='header'}}
-  </AuPill>
+  </Pill>
   {{#if this.dropdownOpen}}
     <div
       id='{{this.dropdownId}}'

--- a/app/components/pill.js
+++ b/app/components/pill.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/components/pill';

--- a/app/styles/ember-rdfa-editor/_c-ember-node.scss
+++ b/app/styles/ember-rdfa-editor/_c-ember-node.scss
@@ -1,3 +1,7 @@
+span.ember-node {
+  display: inline-block;
+}
+
 .ember-node {
   white-space: normal;
 

--- a/app/styles/ember-rdfa-editor/_c-link.scss
+++ b/app/styles/ember-rdfa-editor/_c-link.scss
@@ -33,6 +33,7 @@
   .say-link {
     background-color: var(--au-blue-200);
     outline: 2px solid var(--au-blue-500);
+    outline-offset: -2px;
 
     ::selection {
       background-color: var(--au-blue-300);


### PR DESCRIPTION
* Extract required parts of `AuPill` into `Pill`
* Change `Pill` "inline" style to be `inline-block`
* Change `outline` for `Link` "ember-node" to have `outline-offset` `-2px` for it not to cover nearby content when focused
