### PR TITLE
GN-4152: No more `undefined` with `prosemirror-invisibles` enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Un-indent paragraph on backspace at the front of paragraph
 - Change `EmberNode` "inline" style to be `inline-block` to avoid pushing away surrounding content
 - Change `outline` for `Link` "ember-node" to have `outline-offset` `-2px` for it not to cover nearby content when focused
+- When the `prosemirror-invisibles` is enabled, an `undefined` is no longer thrown on some occasions
 
 ### Changed:
 - disable broken firefox cursor fix plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@ember/render-modifiers": "^2.0.5",
         "@glimmer/tracking": "^1.1.2",
         "@graphy/memory.dataset.fast": "4.3.3",
-        "@guardian/prosemirror-invisibles": "^3.0.3",
+        "@guardian/prosemirror-invisibles": "git+ssh://git@github.com/lblod/prosemirror-invisibles",
         "@lblod/marawa": "^0.8.0-beta.2",
         "@types/diff-match-patch": "^1.0.32",
         "codemirror": "^6.0.1",
@@ -1860,9 +1860,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz",
-      "integrity": "sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -2811,8 +2811,8 @@
     },
     "node_modules/@guardian/prosemirror-invisibles": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@guardian/prosemirror-invisibles/-/prosemirror-invisibles-3.0.3.tgz",
-      "integrity": "sha512-jc4n//24RNJGmyY+QHi1Fubf0UMXGvdPesfHa9ZgutvfP+/o82VS/Opiqc36xuWtcZ98v3GQGJu12A2rhQE2PQ==",
+      "resolved": "git+ssh://git@github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
+      "license": "MIT",
       "peerDependencies": {
         "prosemirror-model": "^1.18.2",
         "prosemirror-state": "^1.4.2",
@@ -33489,9 +33489,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz",
-      "integrity": "sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -34273,9 +34273,8 @@
       }
     },
     "@guardian/prosemirror-invisibles": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@guardian/prosemirror-invisibles/-/prosemirror-invisibles-3.0.3.tgz",
-      "integrity": "sha512-jc4n//24RNJGmyY+QHi1Fubf0UMXGvdPesfHa9ZgutvfP+/o82VS/Opiqc36xuWtcZ98v3GQGJu12A2rhQE2PQ==",
+      "version": "git+ssh://git@github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
+      "from": "@guardian/prosemirror-invisibles@git+ssh://git@github.com/lblod/prosemirror-invisibles",
       "requires": {}
     },
     "@handlebars/parser": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@ember/render-modifiers": "^2.0.5",
     "@glimmer/tracking": "^1.1.2",
     "@graphy/memory.dataset.fast": "4.3.3",
-    "@guardian/prosemirror-invisibles": "^3.0.3",
+    "@guardian/prosemirror-invisibles": "git+ssh://git@github.com/lblod/prosemirror-invisibles",
     "@lblod/marawa": "^0.8.0-beta.2",
     "@types/diff-match-patch": "^1.0.32",
     "codemirror": "^6.0.1",

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -47,6 +47,13 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/link';
 import { inject as service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
+import {
+  createInvisiblesPlugin,
+  hardBreak,
+  heading as headingInvisible,
+  paragraph as paragraphInvisible,
+  space,
+} from '@lblod/ember-rdfa-editor/plugins/invisibles';
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import { lastKeyPressedPlugin } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
@@ -108,13 +115,12 @@ export default class IndexController extends Controller {
     tablePlugin,
     tableKeymap,
     linkPasteHandler(this.schema.nodes.link),
-    // disabled until https://binnenland.atlassian.net/browse/GN-4152 is fixed
-    // createInvisiblesPlugin(
-    //   [space, hardBreak, paragraphInvisible, headingInvisible],
-    //   {
-    //     shouldShowInvisibles: false,
-    //   }
-    // ),
+    createInvisiblesPlugin(
+      [space, hardBreak, paragraphInvisible, headingInvisible],
+      {
+        shouldShowInvisibles: false,
+      }
+    ),
   ];
   @tracked nodeViews = (controller: SayController) => {
     return {

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -55,6 +55,13 @@ import {
   linkPasteHandler,
   linkView,
 } from '@lblod/ember-rdfa-editor/plugins/link';
+import {
+  createInvisiblesPlugin,
+  hardBreak,
+  space,
+  paragraph as paragraphInvisible,
+  heading as headingInvisible,
+} from '@lblod/ember-rdfa-editor/plugins/invisibles';
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 
 export default class IndexController extends Controller {
@@ -123,13 +130,12 @@ export default class IndexController extends Controller {
     tablePlugin,
     tableKeymap,
     linkPasteHandler(this.schema.nodes.link),
-    // disabled until https://binnenland.atlassian.net/browse/GN-4152 is fixed
-    // createInvisiblesPlugin(
-    //   [space, hardBreak, paragraphInvisible, headingInvisible],
-    //   {
-    //     shouldShowInvisibles: false,
-    //   }
-    // ),
+    createInvisiblesPlugin(
+      [space, hardBreak, paragraphInvisible, headingInvisible],
+      {
+        shouldShowInvisibles: false,
+      }
+    ),
   ];
 
   @action


### PR DESCRIPTION
When the `prosemirror-invisibles` is enabled, an `undefined` is no longer thrown on some occasions.

The issue was that the Editor was importing a `*.js` file of `prosemirror-view`, and `prosemirror-invisibles` was importing `*.cjs` file of `prosemirror-view`.

At some point `prosemirror-view` was comparing provided `decorations` and checking their `instanceof`, but because `instanceof` was coming from different sources, the comparison was always `false` leading to an invalid attempt at reading a field in an object.

The real fix is adding `exports` field in `prosemirror-invisibles` - https://github.com/lblod/prosemirror-invisibles/commit/d1d3d045691af737c30d436ff7dc73e5479b098f