### PR TITLE
fix(firefox): fix problematic backspacing after link nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Un-indent paragraph on backspace at the front of paragraph
 - Change `EmberNode` "inline" style to be `inline-block` to avoid pushing away surrounding content
 - Change `outline` for `Link` "ember-node" to have `outline-offset` `-2px` for it not to cover nearby content when focused
+- fix backspacing into link nodes on firefox
 
 ### Changed:
 - disable broken firefox cursor fix plugin

--- a/addon/plugins/firefox-cursor-fix/index.ts
+++ b/addon/plugins/firefox-cursor-fix/index.ts
@@ -7,44 +7,55 @@ import {
   TextSelection,
 } from '@lblod/ember-rdfa-editor';
 import { gecko } from '@lblod/ember-rdfa-editor/utils/_private/browser';
-import { isNone } from '@lblod/ember-rdfa-editor/utils/_private/option';
 
 export function firefoxCursorFix(): ProsePlugin {
   const firefoxCursorFix = new ProsePlugin({
     props: {
-      handleDOMEvents: {
-        mousedown(view: SayView, event: MouseEvent) {
-          if (!gecko) {
-            return;
+      handleKeyDown(view, event: KeyboardEvent): boolean {
+        if (!gecko) {
+          return false;
+        }
+        if (event.key === 'Backspace') {
+          const { $from, from, to } = view.state.selection;
+          if (from !== to) {
+            return false;
           }
-          const clickedPos = view.posAtCoords({
-            left: event.clientX,
-            top: event.clientY,
-          });
-          console.log('clickpos', clickedPos);
-          if (isNone(clickedPos)) {
-            return;
+          // If we're at the start of the parent node, the problem cannot occur
+          // since it only happens when we backspace into a problematic previous sibling
+          if ($from.parentOffset === 0) {
+            return false;
           }
-          const $pos = view.state.doc.resolve(clickedPos.pos);
-          let cur = $pos.nodeAfter;
-          let insertPos = $pos.pos;
-          while (cur && !cur.type.spec.needsFFKludge) {
-            cur = cur.firstChild;
-            insertPos++;
-          }
-          if (cur?.type.spec.needsFFKludge) {
-            event.preventDefault();
-            view.dispatch(
-              view.state.tr
-                .setSelection(
-                  new TextSelection(view.state.doc.resolve(insertPos))
-                )
-                .scrollIntoView()
-            );
+          // The problematic position is reached AFTER we backspace the char right after the problematic node
+          // so we have to check one position in advance
+          const $posToCheck = $from.parent.resolve($from.parentOffset - 1);
+          const nodeBefore = $posToCheck.nodeBefore;
+          if (nodeBefore && nodeBefore.type.spec.needsFFKludge) {
+            view.dispatch(view.state.tr.deleteRange($posToCheck.pos, from));
             return true;
           }
-          return;
-        },
+        }
+        return false;
+      },
+      handleClick(view: SayView, pos: number, event: MouseEvent) {
+        const $pos = view.state.doc.resolve(pos);
+        let cur = $pos.nodeAfter;
+        let insertPos = $pos.pos;
+        while (cur && !cur.type.spec.needsFFKludge) {
+          cur = cur.firstChild;
+          insertPos++;
+        }
+        if (cur?.type.spec.needsFFKludge) {
+          event.preventDefault();
+          view.dispatch(
+            view.state.tr
+              .setSelection(
+                new TextSelection(view.state.doc.resolve(insertPos))
+              )
+              .scrollIntoView()
+          );
+          return true;
+        }
+        return;
       },
       decorations(state: EditorState): DecorationSet | undefined {
         if (!gecko) {

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -50,6 +50,7 @@ import IntlService from 'ember-intl/services/intl';
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import { lastKeyPressedPlugin } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
+import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-cursor-fix';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
@@ -103,7 +104,7 @@ export default class IndexController extends Controller {
 
   @tracked plugins: Plugin[] = [
     // disabled until https://binnenland.atlassian.net/browse/GN-4147 is fixed
-    // firefoxCursorFix(),
+    firefoxCursorFix(),
     lastKeyPressedPlugin,
     tablePlugin,
     tableKeymap,


### PR DESCRIPTION
repro of the bug before:
![image](https://user-images.githubusercontent.com/16419862/226383563-b30363ac-f470-4b1c-bace-0164144d2a6f.png)
cursor after "c"
backspace twice

"a" gets removed instead of the link node

firefox only