### PR TITLE
Also observe responsive toolbar children for resize

### DIFF
--- a/addon/components/responsive-toolbar.ts
+++ b/addon/components/responsive-toolbar.ts
@@ -27,6 +27,12 @@ export default class ResponsiveToolbar extends Component {
     (element: HTMLElement) => {
       const observer = new ResizeObserver(this.handleResize.bind(this));
       observer.observe(element);
+      if (element.children.length) {
+        const childs = element.children;
+        for (const child of childs) {
+          observer.observe(child);
+        }
+      }
       this.toolbar = element;
     },
     { eager: false }


### PR DESCRIPTION
There was a problem in GN with the besluit type plugin, when you selected a besluit this plugin changed it's size in the toolbar resulting in an overlap describen in https://binnenland.atlassian.net/browse/GN-4212, this PR aims to solve that.
