### PR TITLE
Bugfix: Validate image URL before insertion

### DIFF
--- a/addon/components/plugins/image/insert-menu.hbs
+++ b/addon/components/plugins/image/insert-menu.hbs
@@ -17,7 +17,10 @@
           <AuLabel @required='true' for={{id}}>
             {{t 'ember-rdfa-editor.image.url-label'}}
           </AuLabel>
-          <AuInput id={{id}} @width='block' @value={{this.url}} />
+          <AuInput id={{id}} @width='block' @value={{this.url}} @error={{this.showError}} {{on "focus" this.hideError}} />
+          {{#if this.showError}}
+            <AuHelpText @error={{true}}>{{t 'ember-rdfa-editor.image.url-error'}}</AuHelpText>
+          {{/if}}
         {{/let}}
       </AuFormRow>
       <AuFormRow>
@@ -29,7 +32,7 @@
         {{/let}}
       </AuFormRow>
     </form>
-    {{#if this.url}}
+    {{#if this.isValidUrl}}
       <img
         src={{this.url}}
         alt={{this.altText}}

--- a/addon/components/plugins/image/insert-menu.ts
+++ b/addon/components/plugins/image/insert-menu.ts
@@ -15,6 +15,7 @@ export default class ImageInsertMenu extends Component<Args> {
   @tracked modalOpen = false;
   @tracked url = '';
   @tracked altText = '';
+  @tracked showError = false;
 
   get controller() {
     return this.args.controller;
@@ -32,10 +33,25 @@ export default class ImageInsertMenu extends Component<Args> {
     return undefined;
   }
 
+  get isValidUrl(): boolean {
+    try {
+      const parsedUrl = new URL(this.url);
+      return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+    } catch (_) {
+      return false;
+    }
+  }
+
   @action
   resetValues() {
     this.url = '';
     this.altText = '';
+    this.hideError();
+  }
+
+  @action
+  hideError() {
+    this.showError = false;
   }
 
   @action
@@ -58,6 +74,11 @@ export default class ImageInsertMenu extends Component<Args> {
 
   @action
   async onInsert() {
+    if (!this.isValidUrl) {
+      this.showError = true;
+      return;
+    }
+
     const { image } = this.schema.nodes;
     this.controller.withTransaction((tr) => {
       return tr.replaceSelectionWith(

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -63,5 +63,6 @@ ember-rdfa-editor:
   image:
     insert: Insert image
     url-label: Image URL
+    url-error: Only image URLs starting with http(s) are allowed
     alt-label: Alternative text (Alt)
     

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -62,6 +62,7 @@ ember-rdfa-editor:
   image:
     insert: Afbeelding invoegen
     url-label: Afbeeldings-URL
+    url-error: Enkel afbeeldings-URLs die beginnen met http(s) zijn toegelaten
     alt-label: Alternatieve tekst (Alt)
 
 


### PR DESCRIPTION
fix: [GN-4209](https://binnenland.atlassian.net/browse/GN-4209?atlOrigin=eyJpIjoiZDdhNGRkN2FiNGI1NDdkYzg4MzgxYzU4NTYxMmU4YWEiLCJwIjoiaiJ9)

In the Image insert modal, when pressing the insert button, the URL is first validated. If it is not valid, an error message is shown. This will disappear when the user clicks in the input box to fix the error.
The image preview also only shows if a valid URL was inputted.

`@onChange` and `{{on "change" ..}}` didn't work (because this is used for reactivity?), hence why `{{on "focus" ..}` is used instead to hide the error message.

In principle this could also be purely reactive, where the error shows directly when the user begins typing (and the submit button is disabled as long as the url is invalid). But this felt a bit chaotic.