### PR TITLE
Add inputrules for list generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Addition of list inputrules
 ### Fixed
 - Also observe responsive toolbar children for resize
 

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -29,10 +29,12 @@ import {
 } from '@lblod/ember-rdfa-editor/commands';
 import selectParentNodeOfType from '../commands/select-parent-node-of-type';
 import { hasParentNodeOfType } from '@curvenote/prosemirror-utils';
+import { undoInputRule } from 'prosemirror-inputrules';
 
 export type Keymap = (schema: Schema) => Record<string, Command>;
 
 const backspace = chainCommands(
+  undoInputRule,
   reduceIndent,
   deleteSelection,
   (state, dispatch, view) => {

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -15,6 +15,8 @@ export * from 'prosemirror-view';
 
 export * from 'prosemirror-transform';
 
+export * from 'prosemirror-inputrules';
+
 export type InlineDecorationSpec = NonNullable<
   Parameters<typeof Decoration.inline>[3]
 >;

--- a/addon/plugins/list/index.ts
+++ b/addon/plugins/list/index.ts
@@ -1,3 +1,4 @@
 export { toggleList } from './commands/toggle-list';
 export { ordered_list, list_item, bullet_list } from './nodes/list-nodes';
 export type { OrderListStyle } from './nodes/list-nodes';
+export { bullet_list_input_rule, ordered_list_input_rule } from './input_rules';

--- a/addon/plugins/list/input_rules/index.ts
+++ b/addon/plugins/list/input_rules/index.ts
@@ -1,0 +1,8 @@
+import { wrappingInputRule } from 'prosemirror-inputrules';
+import { NodeType } from 'prosemirror-model';
+
+export const bullet_list_input_rule = (type: NodeType) =>
+  wrappingInputRule(/^\s*([-*])\s$/, type);
+
+export const ordered_list_input_rule = (type: NodeType) =>
+  wrappingInputRule(/^\s*(1.)\s$/, type);

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -62,7 +62,7 @@ import {
   bullet_list_input_rule,
   ordered_list_input_rule,
 } from '@lblod/ember-rdfa-editor/plugins/list/input_rules';
-import { inputRules } from 'prosemirror-inputrules';
+import { inputRules } from '@lblod/ember-rdfa-editor';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -58,6 +58,11 @@ import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/high
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import { lastKeyPressedPlugin } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
 import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-cursor-fix';
+import {
+  bullet_list_input_rule,
+  ordered_list_input_rule,
+} from '@lblod/ember-rdfa-editor/plugins/list/input_rules';
+import { inputRules } from 'prosemirror-inputrules';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
@@ -122,6 +127,12 @@ export default class IndexController extends Controller {
         shouldShowInvisibles: false,
       }
     ),
+    inputRules({
+      rules: [
+        bullet_list_input_rule(this.schema.nodes.bullet_list),
+        ordered_list_input_rule(this.schema.nodes.ordered_list),
+      ],
+    }),
   ];
   @tracked nodeViews = (controller: SayController) => {
     return {

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -63,6 +63,11 @@ import {
   heading as headingInvisible,
 } from '@lblod/ember-rdfa-editor/plugins/invisibles';
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
+import {
+  bullet_list_input_rule,
+  ordered_list_input_rule,
+} from '@lblod/ember-rdfa-editor/plugins/list/input_rules';
+import { inputRules } from 'prosemirror-inputrules';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
@@ -137,6 +142,12 @@ export default class IndexController extends Controller {
         shouldShowInvisibles: false,
       }
     ),
+    inputRules({
+      rules: [
+        bullet_list_input_rule(this.schema.nodes.bullet_list),
+        ordered_list_input_rule(this.schema.nodes.ordered_list),
+      ],
+    }),
   ];
 
   @action

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -67,7 +67,7 @@ import {
   bullet_list_input_rule,
   ordered_list_input_rule,
 } from '@lblod/ember-rdfa-editor/plugins/list/input_rules';
-import { inputRules } from 'prosemirror-inputrules';
+import { inputRules } from '@lblod/ember-rdfa-editor';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;


### PR DESCRIPTION
This PR adds two inputrules for list generation:
- one for generating a bullet-list when the user types `-` or `*` followed by a space.
- one for generating an ordered list when the user types `1.` followed by a space.