### PR TITLE
[Ember nodes] add documentation and extra config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Addition of list inputrules
+- Possibility to pass `ignoreMutation` to the EmberNodeSpec when creating Ember Nodes
 ### Fixed
 - Also observe responsive toolbar children for resize
 - Solve bug with cursor in front a multiple line link

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -13,6 +13,7 @@ import {
   repaired_block,
   text,
 } from '@lblod/ember-rdfa-editor/nodes';
+import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import { highlightPlugin } from 'dummy/dummy-plugins/highlight-plugin';
 import { NodeViewConstructor } from 'prosemirror-view';
 import applyDevTools from 'prosemirror-dev-tools';
@@ -111,6 +112,7 @@ export default class IndexController extends Controller {
       subscript,
       superscript,
       highlight,
+      color,
     },
   });
 

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -13,7 +13,6 @@ import {
   repaired_block,
   text,
 } from '@lblod/ember-rdfa-editor/nodes';
-import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import { highlightPlugin } from 'dummy/dummy-plugins/highlight-plugin';
 import { NodeViewConstructor } from 'prosemirror-view';
 import applyDevTools from 'prosemirror-dev-tools';
@@ -115,7 +114,6 @@ export default class IndexController extends Controller {
       subscript,
       superscript,
       highlight,
-      color,
     },
   });
 

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -114,6 +114,7 @@ export default class IndexController extends Controller {
       subscript,
       superscript,
       highlight,
+      color,
     },
   });
 


### PR DESCRIPTION
Add the possibility to pass `ignoreMutation`. ~~This is useful to avoid prosemirror updating when nothing changed internally. Especially with big documents this has an impact, as things like hover functionality might update attributes, which can really slow everything down.~~ 
This is set to `true` by default. Explanation is in comments.  

I also added some basic documentation (just a first pass, so not perfect). I might add to it if I am more familiar with Ember Node and know what else is important to add, but this already gives a basic understanding of how to use them and some notes on what to look out for. -> can be merged if it is correct. I can always create another PR for documentation updates.

It is unclear if an ember node will ever be rerendered with the current `update()` and `ignoreMutation()` implementation. As long as this has not been tested thoroughly, the best strategy is to keep state in `attrs` by default. However, this might not be necessary.
E.g. for UI states (showButton, showHoverBox etc), it might be okay to keep this in a tracked state?

