### PR TITLE
Pin typescript version to 5.0.x and update ember-velcro to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Dependencies
 - Bumps `caniuse-lite` to 1.0.30001492
 - Bumps `ember-focus-trap` from 1.0.1 to 1.0.2
-- Fix `typescript` to 5.0.x
+- Bumps `ember-velcro` to 2.1.0
+- Pin `typescript` to 5.0.x
 
 ## [3.8.0] - 2023-05-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Dependencies
 - Bumps `caniuse-lite` to 1.0.30001492
 - Bumps `ember-focus-trap` from 1.0.1 to 1.0.2
+- Fix `typescript` to 5.0.x
 
 ## [3.8.0] - 2023-05-31
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,7 @@
         "sass": "^1.49.9",
         "sinon": "^15.0.1",
         "svg-symbols": "^1.0.5",
-        "typescript": "^5.0.4",
+        "typescript": "~5.0.4",
         "webpack": "^5.74.0"
       },
       "engines": {
@@ -34640,7 +34640,7 @@
     },
     "@guardian/prosemirror-invisibles": {
       "version": "git+ssh://git@github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
-      "from": "@guardian/prosemirror-invisibles@https://github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
+      "from": "@guardian/prosemirror-invisibles@git+ssh://git@github.com/lblod/prosemirror-invisibles",
       "requires": {}
     },
     "@handlebars/parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "ember-intl": "^5.7.2",
         "ember-truth-helpers": "^3.0.0",
         "ember-unique-id-helper-polyfill": "^1.2.2",
-        "ember-velcro": "^1.1.0",
+        "ember-velcro": "^2.1.0",
         "handlebars": "^4.7.7",
         "handlebars-loader": "^1.7.2",
         "iter-tools": "^7.4.0",
@@ -2730,50 +2730,6 @@
       "integrity": "sha512-HS2dEbJ3CgXn56wk/5QdudM7rE3vtNMvPIoG7Rrg+GhkGMNxBCIRxOeEF2g520j9rwlA2LAZFpc7MCDMFbTjNA==",
       "dependencies": {
         "babel-plugin-debug-macros": "^0.3.4"
-      }
-    },
-    "node_modules/@glint/config": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/config/-/config-0.9.7.tgz",
-      "integrity": "sha512-XkWIZ3fuOlcofUJUaJmRS57mVVNi+Af2HtrZkBXEOCh4+BNz2wclxv2WKvkhmtvLhEUOhHb5eU3gwI58SuwgXQ==",
-      "peer": true,
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.17.0",
-        "silent-error": "^1.1.1"
-      }
-    },
-    "node_modules/@glint/environment-ember-loose": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/environment-ember-loose/-/environment-ember-loose-0.9.7.tgz",
-      "integrity": "sha512-MlCGZtB1Clp4vQWIm2APSnCm7nL8wVhFMOhVy2qzpV0nfLyg3pcN9CQHNpfdJvCydBB72cA4/ahPj7VEFL6xsg==",
-      "peer": true,
-      "dependencies": {
-        "@glint/config": "^0.9.7",
-        "@glint/template": "^0.9.7"
-      },
-      "peerDependencies": {
-        "@glimmer/component": "^1.1.2",
-        "ember-cli-htmlbars": "^6.0.1",
-        "ember-modifier": "^3.2.7"
-      },
-      "peerDependenciesMeta": {
-        "ember-cli-htmlbars": {
-          "optional": true
-        },
-        "ember-modifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@glint/template": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/template/-/template-0.9.7.tgz",
-      "integrity": "sha512-MCp8GxQDIbH8ZzfNxHhVqCSKlydBgQfBEwJLDpN81lgFRCldSDPueIbk8sz3EhpGiZJVdNQbpGeYIDsUXe1ocg==",
-      "peer": true,
-      "peerDependencies": {
-        "@glimmer/component": "^1.1.2"
       }
     },
     "node_modules/@graphy/core.data.factory": {
@@ -18222,9 +18178,9 @@
       }
     },
     "node_modules/ember-velcro": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ember-velcro/-/ember-velcro-1.1.0.tgz",
-      "integrity": "sha512-oZxcQvd39o0Miv4C4a44BMkzSuS5X684eVLX2Ct4qh7ofAvqSWpEGF9dUDwzCOq5hk4WS8DMsXa0azonv6tP7Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-velcro/-/ember-velcro-2.1.0.tgz",
+      "integrity": "sha512-5m1JDAGmTT9J8SrVL1NrBj6qe1L0dgb3T1muWL2b36HO4sCHn8/njT/GMHXorcbYz7C/PawYuxKpbILNaGa50A==",
       "dependencies": {
         "@embroider/addon-shim": "^1.0.0",
         "@floating-ui/dom": "^1.0.1",
@@ -18233,10 +18189,6 @@
       },
       "engines": {
         "node": "14.* || >= 16"
-      },
-      "peerDependencies": {
-        "@glint/environment-ember-loose": "^0.9.4",
-        "@glint/template": "^0.9.5"
       }
     },
     "node_modules/emoji-regex": {
@@ -18511,6 +18463,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -34584,35 +34537,6 @@
         "babel-plugin-debug-macros": "^0.3.4"
       }
     },
-    "@glint/config": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/config/-/config-0.9.7.tgz",
-      "integrity": "sha512-XkWIZ3fuOlcofUJUaJmRS57mVVNi+Af2HtrZkBXEOCh4+BNz2wclxv2WKvkhmtvLhEUOhHb5eU3gwI58SuwgXQ==",
-      "peer": true,
-      "requires": {
-        "escape-string-regexp": "^4.0.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.17.0",
-        "silent-error": "^1.1.1"
-      }
-    },
-    "@glint/environment-ember-loose": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/environment-ember-loose/-/environment-ember-loose-0.9.7.tgz",
-      "integrity": "sha512-MlCGZtB1Clp4vQWIm2APSnCm7nL8wVhFMOhVy2qzpV0nfLyg3pcN9CQHNpfdJvCydBB72cA4/ahPj7VEFL6xsg==",
-      "peer": true,
-      "requires": {
-        "@glint/config": "^0.9.7",
-        "@glint/template": "^0.9.7"
-      }
-    },
-    "@glint/template": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@glint/template/-/template-0.9.7.tgz",
-      "integrity": "sha512-MCp8GxQDIbH8ZzfNxHhVqCSKlydBgQfBEwJLDpN81lgFRCldSDPueIbk8sz3EhpGiZJVdNQbpGeYIDsUXe1ocg==",
-      "peer": true,
-      "requires": {}
-    },
     "@graphy/core.data.factory": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@graphy/core.data.factory/-/core.data.factory-4.3.4.tgz",
@@ -47193,9 +47117,9 @@
       }
     },
     "ember-velcro": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ember-velcro/-/ember-velcro-1.1.0.tgz",
-      "integrity": "sha512-oZxcQvd39o0Miv4C4a44BMkzSuS5X684eVLX2Ct4qh7ofAvqSWpEGF9dUDwzCOq5hk4WS8DMsXa0azonv6tP7Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-velcro/-/ember-velcro-2.1.0.tgz",
+      "integrity": "sha512-5m1JDAGmTT9J8SrVL1NrBj6qe1L0dgb3T1muWL2b36HO4sCHn8/njT/GMHXorcbYz7C/PawYuxKpbILNaGa50A==",
       "requires": {
         "@embroider/addon-shim": "^1.0.0",
         "@floating-ui/dom": "^1.0.1",
@@ -47421,7 +47345,8 @@
     "escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.3",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "sass": "^1.49.9",
     "sinon": "^15.0.1",
     "svg-symbols": "^1.0.5",
-    "typescript": "^5.0.4",
+    "typescript": "~5.0.4",
     "webpack": "^5.74.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ember-intl": "^5.7.2",
     "ember-truth-helpers": "^3.0.0",
     "ember-unique-id-helper-polyfill": "^1.2.2",
-    "ember-velcro": "^1.1.0",
+    "ember-velcro": "^2.1.0",
     "handlebars": "^4.7.7",
     "handlebars-loader": "^1.7.2",
     "iter-tools": "^7.4.0",


### PR DESCRIPTION
This PR ensures that the typescript version is fixed to `5.0.x`. The latest release (5.1.3) of typescript causes issues with the `lodash` package (https://github.com/microsoft/TypeScript/issues/54542). Additionally, this PR updates ember-velcro to 2.1.0. Both dependencies need to be updated together.