### PR TITLE
docs(pr-template): add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+### Overview
+<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->
+
+##### connected issues and PRs:
+<!-- links to connected jira tickets -->
+<!-- Link to PRs that are related (and in what way) -->
+
+
+### Setup
+<!-- PR dependencies -->
+<!-- override snippets -->
+
+### How to test/reproduce
+<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->
+
+### Challenges/uncertainties
+<!-- any notes for the reviewer to put special attention to or decisions that were made -->
+
+
+
+### Checks PR readiness
+- [ ] UI: works on smaller screen sizes
+- [ ] UI: feedback for any loading/error states
+- [ ] Check cancel/go-back flows
+- [ ] Check database state correct when deleting/updating (especially regarding relationships)
+- [ ] changelog
+- [ ] npm lint
+- [ ] no new deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- add pr template
 ### Dependencies
 - Bumps `@codemirror/state` from 6.2.0 to 6.2.1
 


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Adds the discussed PR template. This description uses that template, but with the irrelevant sections removed to show that simple PRs can stay simple 

[rendered](https://github.com/lblod/ember-rdfa-editor/blob/feature/pr-template/.github/pull_request_template.md)


### Checks PR readiness

- [x] changelog

