### PR TITLE
Add utility functions to work with node groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - add pr template
+- Addition of `getGroups` and `hasGroups` utility functions
 ### Dependencies
 - Bumps `@codemirror/state` from 6.2.0 to 6.2.1
 - Bumps `sinon` from 15.0.4 to 15.1.2

--- a/addon/utils/_private/node-utils.ts
+++ b/addon/utils/_private/node-utils.ts
@@ -1,0 +1,10 @@
+import { PNode } from '@lblod/ember-rdfa-editor';
+
+export function getGroups(node: PNode) {
+  return node.type.spec.group?.split(' ') ?? [];
+}
+
+export function hasGroups(node: PNode, ...groups: string[]) {
+  const nodeGroups = getGroups(node);
+  return groups.every((group) => nodeGroups.includes(group));
+}

--- a/addon/utils/node-utils.ts
+++ b/addon/utils/node-utils.ts
@@ -1,0 +1,1 @@
+export * from './_private/node-utils';


### PR DESCRIPTION
### Overview
This PR adds two new utility functions:
- `getGroups(node: PNode): string[]`: this function returns the list of groups a given node belongs to
- `hasGroups(node: PNode, ...groups: string[]): boolean`: this function checks whether a given node belongs to a given series of groups.

These utility functions can be useful in order to implement functionality which is applicable to a specific node-group.

##### connected issues and PRs:
None

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
