### PR TITLE
Improve behaviour of ember-nodes with editable content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - add pr template
 - Addition of `getGroups` and `hasGroups` utility functions
+- Improve behaviour of ember-nodes with editable content
 ### Dependencies
 - Bumps `@codemirror/state` from 6.2.0 to 6.2.1
 - Bumps `sinon` from 15.0.4 to 15.1.2
@@ -20,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumps `@ember/test-helpers` from 2.9.3 to 2.9.4
 - Bumps `@codemirror/lang-html` from 6.4.3 to 6.4.4
 - Bumps `@appuniversum/ember-appuniversum` from 2.5.0 to 2.7.0
+
+### Breaking
+- The default behaviour of the `stopEvent` method of ember-nodeviews has changed in order to provide an improved handling of (input) event in and around ember-nodes
+- The default behaviour of the `ignoreMutation` method of ember-nodeviews has changed in order to provide better handling of mutations and selection changes in and around ember-nodes
+
 
 ## [3.8.1] - 2023-06-13
 

--- a/addon/components/ember-node/slot.hbs
+++ b/addon/components/ember-node/slot.hbs
@@ -1,1 +1,1 @@
-<div data-slot contenteditable='true' {{did-insert this.didInsert}}></div>
+<div data-slot {{did-insert this.didInsert}}></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34563,7 +34563,7 @@
     },
     "@guardian/prosemirror-invisibles": {
       "version": "git+ssh://git@github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
-      "from": "@guardian/prosemirror-invisibles@https://github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
+      "from": "@guardian/prosemirror-invisibles@git+ssh://git@github.com/lblod/prosemirror-invisibles",
       "requires": {}
     },
     "@handlebars/parser": {

--- a/tests/dummy/app/components/sample-ember-nodes/card.hbs
+++ b/tests/dummy/app/components/sample-ember-nodes/card.hbs
@@ -1,5 +1,5 @@
 <AuCard @flex={{true}} as |c|>
-  <c.header>
+  <c.header contenteditable="false">
     <AuHeading @level="2" @skin="4">
       Title
     </AuHeading>

--- a/tests/dummy/app/dummy-nodes/card.ts
+++ b/tests/dummy/app/dummy-nodes/card.ts
@@ -9,12 +9,11 @@ const emberNodeConfig: EmberNodeConfig = {
   componentPath: 'sample-ember-nodes/card',
   inline: false,
   group: 'block',
-  content: 'inline*',
+  content: 'block+',
   atom: false,
-  draggable: true,
-  stopEvent() {
-    return false;
-  },
+  draggable: false,
+  selectable: true,
+  isolating: true,
 };
 
 export const card = createEmberNodeSpec(emberNodeConfig);


### PR DESCRIPTION
### Overview
Currently, ember nodes with editable block content are in a bit of a cumbersome state. At the basic level they work, but in both the firefox and chromium based browsers there are a lot of issues concerning selections and event handling. This PR tries to tackle these issues by providing an improved implementation of the `ignoreMutation` and `stopEvent` methods.

Both methods are based on tiptaps implementation which can be found on https://github.com/ueberdosis/tiptap/blob/d61a621186470ce286e2cecf8206837a1eec7338/packages/core/src/NodeView.ts .
##### connected issues and PRs:
None


### Setup
None

### How to test/reproduce
The dummy application contains a sample `card` ember-node which can be inserted. This `card` component should allow any block content.

### Challenges/uncertainties
- nested `contenteditable` attributes should be prevented. Ember nodes which can contain editable content should never be `contenteditable: false` as a whole, but only the parts which are `contenteditable: false` should be marked as so:
E.g.: It's preferred to write
```hbs
<AuCard @flex={{true}} as |c|>
  <c.header contenteditable="false">
    <AuHeading @level="2" @skin="4">
      Title
    </AuHeading>
    <p>
      Subtitle
    </p>
  </c.header>
  <c.content>
    {{yield}}
  </c.content>
</AuCard>
```
instead of:
```hbs
<AuCard @flex={{true}} contenteditable="false" as |c|>
  <c.header>
    <AuHeading @level="2" @skin="4">
      Title
    </AuHeading>
    <p>
      Subtitle
    </p>
  </c.header>
  <c.content  contenteditable="true">
    {{yield}}
  </c.content>
</AuCard>
```

Both firefox and chrome have issues handling nested `contenteditable` attributes.

- Note: when backspacing and removing text, chromium-based browsers will remove the surrounding div if it is empty and has no attributes, this is why the following code is found in this PR: `this.contentDOM.dataset.content = 'true';`. It is to prevent the removal of the `contentDOM` element.




### Checks PR readiness
- [x] changelog
- [x] npm lint
