### PR TITLE
Fix/table header whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Show correct import for heading node in documentation
+- Whitespace is not removed in table headers
 
 ## [3.7.0] - 2023-05-12
 ### Dependencies

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -365,7 +365,6 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
 
   // Table styling
   table th {
-    white-space: initial;
     background-color: var(--au-white);
   }
 


### PR DESCRIPTION
### Overview
Whitespace is no longer automatically removed in table headers.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4373

### How to test/reproduce
Create table, toggle header, type word and observe that whitespace characters remain visible.