### PR TITLE
Use `github.token` in github actions when running checkout action

### DIFF
--- a/.github/workflows/dependabot-changelog.yml
+++ b/.github/workflows/dependabot-changelog.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.DEPENDABOT_TOKEN }}
+          token: ${{ github.token }}
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Update the changelog

--- a/.github/workflows/ensure-changelog.yml
+++ b/.github/workflows/ensure-changelog.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.DEPENDABOT_TOKEN }}
+          token: ${{ github.token }}
       - name: check changelog edits
         uses: dangoslen/changelog-enforcer@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - better handle weird edgecases when copying from word
+
+### Internal
+- use `github.token` for github checkout action
 ### Dependencies
 - Bumps `prosemirror-view` from 1.31.3 to 1.31.4
 - Bumps `xml-formatter` from 3.3.2 to 3.4.1


### PR DESCRIPTION
### Overview
When checking out a public repositiory and/or the current repository with the github checkout action. A github PAT is not necessary and can be replaced by `github.token`.
