### PR TITLE
Addition of a locale plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Addition of a `locale` prosemirror plugin which allows other plugins/code to lookup the locale/language of the current document/editor instance.
+- Addition of a `locale` getter to the `SayController` class which returns the state of the `locale` plugin.
+
 ## [3.10.0] - 2023-06-22
 ### Fixed
 - better handle weird edgecases when copying from word

--- a/addon/core/say-controller.ts
+++ b/addon/core/say-controller.ts
@@ -13,6 +13,7 @@ import {
   Schema,
 } from 'prosemirror-model';
 import { Command, Selection, Transaction } from 'prosemirror-state';
+import { localePluginKey } from '@lblod/ember-rdfa-editor/plugins/locale';
 
 export default class SayController {
   @tracked
@@ -95,6 +96,10 @@ export default class SayController {
 
   get datastore(): SayStore {
     return unwrap(datastoreKey.getState(this.mainEditorState)).datastore();
+  }
+
+  get locale() {
+    return unwrap(localePluginKey.getState(this.mainEditorState)).locale;
   }
 
   get schema(): Schema {

--- a/addon/core/say-editor.ts
+++ b/addon/core/say-editor.ts
@@ -33,6 +33,7 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/default-attribute-value-generation';
 import SayView from '@lblod/ember-rdfa-editor/core/say-view';
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
+import { locale } from '@lblod/ember-rdfa-editor/plugins/locale';
 export type PluginConfig = Plugin[] | { plugins: Plugin[]; override?: boolean };
 interface SayEditorArgs {
   owner: Owner;
@@ -85,6 +86,7 @@ export default class SayEditor {
     } else {
       pluginConf = [
         datastore({ pathFromRoot: this.pathFromRoot, baseIRI }),
+        locale({ locale: 'nl-BE' }),
         ...pluginArr,
         pasteHandler(),
         dropCursor(),

--- a/addon/plugins/locale/index.ts
+++ b/addon/plugins/locale/index.ts
@@ -1,0 +1,29 @@
+import { ProsePlugin } from '@lblod/ember-rdfa-editor';
+import { PluginKey } from 'prosemirror-state';
+export const localePluginKey = new PluginKey<LocalePluginState>(
+  'LOCALE_PLUGIN'
+);
+
+interface LocalePluginState {
+  locale: string;
+}
+
+export function locale({
+  locale,
+}: LocalePluginState): ProsePlugin<LocalePluginState> {
+  return new ProsePlugin<LocalePluginState>({
+    key: localePluginKey,
+    state: {
+      init() {
+        return {
+          locale,
+        };
+      },
+      apply() {
+        return {
+          locale,
+        };
+      },
+    },
+  });
+}


### PR DESCRIPTION
### Overview
This PR adds a keyed prosemirror plugin which allows setting the locale of a document/the editor. This prosemirror plugin can be used by other plugins in order to decide in which language they need to display their content.
Additionally, this PR also exposes a `locale` getter on instances of the `SayController` class.
The plugin is added to the list of default plugins and has a default locale of `nl-BE`.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-4365?atlOrigin=eyJpIjoiNmY5MzVjZjhlYTM1NGUyN2I1MjZiODhkODIwNzE2MTYiLCJwIjoiaiJ9


### How to test/reproduce
The keyed locale plugin should be visible in the `plugins` tab of the prosemirror-dev-tools

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
