### PR TITLE
Implement ember-application prosemirror plugin which gives access to ember application instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Addition of an ember-application prosemirror plugin which allows for accessing the current instance of the ember application given a prosemirror state.
 ### Dependencies
 - Bumps `@codemirror/view` from 6.14.0 to 6.14.1
 

--- a/addon/plugins/ember-application/index.ts
+++ b/addon/plugins/ember-application/index.ts
@@ -1,0 +1,31 @@
+import { PluginKey } from 'prosemirror-state';
+import { ProsePlugin } from '@lblod/ember-rdfa-editor';
+import Owner from '@ember/owner';
+
+export const emberApplicationPluginKey = new PluginKey<DatastorePluginState>(
+  'ember_application'
+);
+
+export interface DatastorePluginArgs {
+  application: Owner;
+}
+
+export interface DatastorePluginState {
+  application: Owner;
+}
+
+export function emberApplication({
+  application,
+}: DatastorePluginArgs): ProsePlugin<DatastorePluginState> {
+  return new ProsePlugin<DatastorePluginState>({
+    key: emberApplicationPluginKey,
+    state: {
+      init(): DatastorePluginState {
+        return { application };
+      },
+      apply() {
+        return { application };
+      },
+    },
+  });
+}

--- a/addon/plugins/ember-application/index.ts
+++ b/addon/plugins/ember-application/index.ts
@@ -14,6 +14,12 @@ export interface DatastorePluginState {
   application: Owner;
 }
 
+/** This plugin gives access to the ember application instance, so this can be used in other plugins/nodes. You can initialize it with `emberApplication({ application: getOwner(this) })`. Afterwards, you can access the ember application and do things like accessing ember services anywhere you have access to the state.
+```
+import { emberApplicationPluginKey } from '@lblod/ember-rdfa-editor/plugins/ember-application';
+const intlService = emberApplicationPluginKey.getState(state)?.application.lookup('service:intl');
+```
+*/
 export function emberApplication({
   application,
 }: DatastorePluginArgs): ProsePlugin<DatastorePluginState> {

--- a/tests/dummy/app/controllers/backspace.ts
+++ b/tests/dummy/app/controllers/backspace.ts
@@ -63,6 +63,8 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/list/input_rules';
 import { inputRules, PluginConfig } from '@lblod/ember-rdfa-editor';
 import { KeymapOptions } from '@lblod/ember-rdfa-editor/core/keymap';
+import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
+import { getOwner } from '@ember/application';
 
 export default class BackspaceController extends Controller {
   @tracked rdfaEditor?: SayController;
@@ -146,6 +148,7 @@ export default class BackspaceController extends Controller {
         ordered_list_input_rule(this.schema.nodes.ordered_list),
       ],
     }),
+    emberApplication({ application: getOwner(this) }),
   ];
   @tracked nodeViews = (controller: SayController) => {
     return {

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -64,6 +64,8 @@ import {
 import { inputRules } from '@lblod/ember-rdfa-editor';
 import { chromeHacksPlugin } from '@lblod/ember-rdfa-editor/plugins/chrome-hacks-plugin';
 import { PluginConfig } from '@lblod/ember-rdfa-editor';
+import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
+import { getOwner } from '@ember/application';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
@@ -137,6 +139,7 @@ export default class IndexController extends Controller {
         ordered_list_input_rule(this.schema.nodes.ordered_list),
       ],
     }),
+    emberApplication({ application: getOwner(this) }),
   ];
 
   @tracked nodeViews = (controller: SayController) => {

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -70,6 +70,8 @@ import {
 import { inputRules, PluginConfig } from '@lblod/ember-rdfa-editor';
 import { chromeHacksPlugin } from '@lblod/ember-rdfa-editor/plugins/chrome-hacks-plugin';
 import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-cursor-fix';
+import { getOwner } from '@ember/application';
+import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
@@ -155,6 +157,7 @@ export default class IndexController extends Controller {
         ordered_list_input_rule(this.schema.nodes.ordered_list),
       ],
     }),
+    emberApplication({ application: getOwner(this) }),
   ];
 
   @action


### PR DESCRIPTION
### Overview
This PR adds the `ember-application` prosemirror plugin which stores the current ember application instance in the prosemirror state. This allows other plugins/nodes to access the current ember application instance.

### How to test/reproduce
In order to check if the ember application instance has been stored correctly in the state, you can access the plugin state in the web console and check if it is correct and present. You should also be able to observe the plugin using the prosemirror-dev-tools.

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
