### PR TITLE
GN-4147 remove comment about disabled firefoxCursorFix

### DIFF
--- a/tests/dummy/app/controllers/backspace.ts
+++ b/tests/dummy/app/controllers/backspace.ts
@@ -128,7 +128,6 @@ export default class BackspaceController extends Controller {
   }
 
   @tracked plugins: PluginConfig = [
-    // disabled until https://binnenland.atlassian.net/browse/GN-4147 is fixed
     firefoxCursorFix(),
     lastKeyPressedPlugin,
     tablePlugin,

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -118,7 +118,6 @@ export default class IndexController extends Controller {
   }
 
   @tracked plugins: PluginConfig = [
-    // disabled until https://binnenland.atlassian.net/browse/GN-4147 is fixed
     firefoxCursorFix(),
     chromeHacksPlugin(),
     lastKeyPressedPlugin,


### PR DESCRIPTION
### Overview
The comment refers to when the `firefoxCursorFix` was still disabled. However https://binnenland.atlassian.net/browse/GN-4147 is fixed and the the plugin is now active (so the comment does not make sense anymore and is outdated).

This PR removes this outdated comment that isn't needed anymore.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4147

### Challenges/uncertainties
- I did not actually test anything, just checked out the related tickets (which all refer to the issue being resolved) and code history, which showed that the comment was originally placed with `firefoxCursorFix` being commented, see https://github.com/lblod/ember-rdfa-editor//commit/84c0ef679f55ff708eccb375e343a3c29c141a09.
