### PR TITLE
GN-4264 embedded-editor extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Addition of an ember-application prosemirror plugin which allows for accessing the current instance of the ember application given a prosemirror state.
+- Can specify plugins and keymap for embedded-editor.
+- `ParagraphWithConfig` node that allows paragraphs with customized configuration like marks, groups and allowed content.
+- Option `allowedTypes` for indentation menu to override which types can be indented. 
+### Changed
+- The schema defined for embedded-editor was not used by prosemirror. This has been removed to avoid confusion.
+- Mark buttons (bold, italic, ...) are now disabled if not allowed for the selected text.
 ### Dependencies
 - Bumps `@codemirror/view` from 6.14.1 to 6.15.3
 - Bumps `@codemirror/view` from 6.14.0 to 6.15.3

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -61,6 +61,10 @@ type Args = EmberNodeArgs & {
   plugins?: Plugin[];
 };
 
+/**
+ * An embedded editor to use for *inline* content. This way you can specify extra content for an
+ * inline (atom) node. For block content, use content directly instead ({{yield}} in ember-nodes).
+ */
 export default class EmbeddedEditor extends Component<Args> {
   @service declare intl: IntlService;
   innerView: SayView | null = null;

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -73,8 +73,6 @@ import { Plugin } from 'prosemirror-state';
 type Args = EmberNodeArgs & {
   placeholder: string;
   initEditor?: (view: SayView) => void;
-  /* override the schema */
-  schema?: Schema;
   /* override the keymap. Pass outerView where needed. See `embeddedConfig` option in baseKeymap as example) */
   keymap?: { [key: string]: Command };
   /* editor plugins to add */
@@ -97,6 +95,10 @@ export default class EmbeddedEditor extends Component<Args> {
     return this.args.node;
   }
 
+  get schema() {
+    return this.controller.schema;
+  }
+
   get pos() {
     return this.args.getPos();
   }
@@ -107,37 +109,6 @@ export default class EmbeddedEditor extends Component<Args> {
 
   get plugins() {
     return this.args.plugins || [];
-  }
-
-  get schema() {
-    if (this.args.schema) {
-      return this.args.schema;
-    } else {
-      return new Schema({
-        nodes: {
-          doc: {
-            content: 'block+',
-          },
-          paragraph,
-          repaired_block,
-          placeholder,
-
-          text,
-
-          hard_break,
-          block_rdfa,
-          invisible_rdfa,
-        },
-        marks: {
-          inline_rdfa,
-          link,
-          em,
-          strong,
-          underline,
-          strikethrough,
-        },
-      });
-    }
   }
 
   get keymap() {
@@ -180,7 +151,7 @@ export default class EmbeddedEditor extends Component<Args> {
         state: EditorState.create({
           doc: this.node,
           plugins: [keymap(this.keymap), ...this.plugins],
-          schema: this.schema,
+          // the schema is derived from 'doc' key and can't be customized
         }),
         attributes: {
           ...(this.args.placeholder && {

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -98,7 +98,7 @@ export default class EmbeddedEditor extends Component<Args> {
   }
 
   get keymap() {
-    const baseMap = {
+    const undoRedoMap = {
       'Mod-z': () =>
         undo(this.outerView.state, this.outerView.dispatch.bind(this)),
       'Mod-Z': () =>
@@ -107,6 +107,8 @@ export default class EmbeddedEditor extends Component<Args> {
         redo(this.outerView.state, this.outerView.dispatch.bind(this)),
       'Mod-Y': () =>
         redo(this.outerView.state, this.outerView.dispatch.bind(this)),
+    };
+    const baseMap = {
       'Mod-b': toggleMarkAddFirst(this.schema.marks.strong),
       'Mod-B': toggleMarkAddFirst(this.schema.marks.strong),
       'Mod-i': toggleMarkAddFirst(this.schema.marks.em),
@@ -125,9 +127,10 @@ export default class EmbeddedEditor extends Component<Args> {
       return {
         ...baseMap,
         ...this.args.keymap,
+        ...undoRedoMap,
       };
     } else {
-      return baseMap;
+      return { ...baseMap, ...undoRedoMap };
     }
   }
 

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -31,30 +31,12 @@ import {
   keymap,
   NodeSelection,
   SayView,
-  Schema,
   Selection,
   StepMap,
   Transaction,
 } from '@lblod/ember-rdfa-editor';
 import { insertHardBreak } from '@lblod/ember-rdfa-editor/commands/insert-hard-break';
 import { toggleMarkAddFirst } from '@lblod/ember-rdfa-editor/commands/toggle-mark-add-first';
-import { inline_rdfa } from '@lblod/ember-rdfa-editor/marks';
-import {
-  block_rdfa,
-  hard_break,
-  invisible_rdfa,
-  paragraph,
-  repaired_block,
-  text,
-} from '@lblod/ember-rdfa-editor/nodes';
-import { link } from '@lblod/ember-rdfa-editor/plugins/link';
-import {
-  em,
-  strikethrough,
-  strong,
-  underline,
-} from '@lblod/ember-rdfa-editor/plugins/text-style';
-import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
 import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import IntlService from 'ember-intl/services/intl';
 import { v4 as uuid } from 'uuid';

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -55,7 +55,7 @@ import { Plugin } from 'prosemirror-state';
 type Args = EmberNodeArgs & {
   placeholder: string;
   initEditor?: (view: SayView) => void;
-  /* override the keymap. Pass outerView where needed. See `embeddedConfig` option in baseKeymap as example) */
+  /* override the keymap. */
   keymap?: { [key: string]: Command };
   /* editor plugins to add */
   plugins?: Plugin[];
@@ -98,42 +98,36 @@ export default class EmbeddedEditor extends Component<Args> {
   }
 
   get keymap() {
+    const baseMap = {
+      'Mod-z': () =>
+        undo(this.outerView.state, this.outerView.dispatch.bind(this)),
+      'Mod-Z': () =>
+        undo(this.outerView.state, this.outerView.dispatch.bind(this)),
+      'Mod-y': () =>
+        redo(this.outerView.state, this.outerView.dispatch.bind(this)),
+      'Mod-Y': () =>
+        redo(this.outerView.state, this.outerView.dispatch.bind(this)),
+      'Mod-b': toggleMarkAddFirst(this.schema.marks.strong),
+      'Mod-B': toggleMarkAddFirst(this.schema.marks.strong),
+      'Mod-i': toggleMarkAddFirst(this.schema.marks.em),
+      'Mod-I': toggleMarkAddFirst(this.schema.marks.em),
+      'Mod-u': toggleMarkAddFirst(this.schema.marks.underline),
+      'Mod-U': toggleMarkAddFirst(this.schema.marks.underline),
+      Enter: chainCommands(
+        newlineInCode,
+        createParagraphNear,
+        liftEmptyBlock,
+        splitBlock,
+        insertHardBreak,
+      ),
+    };
     if (this.args.keymap) {
       return {
+        ...baseMap,
         ...this.args.keymap,
-        'Mod-z': () =>
-          undo(this.outerView.state, this.outerView.dispatch.bind(this)),
-        'Mod-Z': () =>
-          undo(this.outerView.state, this.outerView.dispatch.bind(this)),
-        'Mod-y': () =>
-          redo(this.outerView.state, this.outerView.dispatch.bind(this)),
-        'Mod-Y': () =>
-          redo(this.outerView.state, this.outerView.dispatch.bind(this)),
       };
     } else {
-      return {
-        'Mod-z': () =>
-          undo(this.outerView.state, this.outerView.dispatch.bind(this)),
-        'Mod-Z': () =>
-          undo(this.outerView.state, this.outerView.dispatch.bind(this)),
-        'Mod-y': () =>
-          redo(this.outerView.state, this.outerView.dispatch.bind(this)),
-        'Mod-Y': () =>
-          redo(this.outerView.state, this.outerView.dispatch.bind(this)),
-        'Mod-b': toggleMarkAddFirst(this.schema.marks.strong),
-        'Mod-B': toggleMarkAddFirst(this.schema.marks.strong),
-        'Mod-i': toggleMarkAddFirst(this.schema.marks.em),
-        'Mod-I': toggleMarkAddFirst(this.schema.marks.em),
-        'Mod-u': toggleMarkAddFirst(this.schema.marks.underline),
-        'Mod-U': toggleMarkAddFirst(this.schema.marks.underline),
-        Enter: chainCommands(
-          newlineInCode,
-          createParagraphNear,
-          liftEmptyBlock,
-          splitBlock,
-          insertHardBreak,
-        ),
-      };
+      return baseMap;
     }
   }
 

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -95,7 +95,17 @@ export default class EmbeddedEditor extends Component<Args> {
 
   get keymap() {
     if (this.args.keymap) {
-      return this.args.keymap;
+      return {
+        ...this.args.keymap,
+        'Mod-z': () =>
+          undo(this.outerView.state, this.outerView.dispatch.bind(this)),
+        'Mod-Z': () =>
+          undo(this.outerView.state, this.outerView.dispatch.bind(this)),
+        'Mod-y': () =>
+          redo(this.outerView.state, this.outerView.dispatch.bind(this)),
+        'Mod-Y': () =>
+          redo(this.outerView.state, this.outerView.dispatch.bind(this)),
+      };
     } else {
       return {
         'Mod-z': () =>

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -51,6 +51,7 @@ import {
 import { isSome, unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import { lastKeyPressedPluginKey } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
 import { Plugin } from 'prosemirror-state';
+import { embeddedEditorBaseKeymap } from '@lblod/ember-rdfa-editor/core/keymap';
 
 type Args = EmberNodeArgs & {
   placeholder: string;
@@ -108,29 +109,14 @@ export default class EmbeddedEditor extends Component<Args> {
       'Mod-Y': () =>
         redo(this.outerView.state, this.outerView.dispatch.bind(this)),
     };
-    const baseMap = {
-      'Mod-b': toggleMarkAddFirst(this.schema.marks.strong),
-      'Mod-B': toggleMarkAddFirst(this.schema.marks.strong),
-      'Mod-i': toggleMarkAddFirst(this.schema.marks.em),
-      'Mod-I': toggleMarkAddFirst(this.schema.marks.em),
-      'Mod-u': toggleMarkAddFirst(this.schema.marks.underline),
-      'Mod-U': toggleMarkAddFirst(this.schema.marks.underline),
-      Enter: chainCommands(
-        newlineInCode,
-        createParagraphNear,
-        liftEmptyBlock,
-        splitBlock,
-        insertHardBreak,
-      ),
-    };
+
     if (this.args.keymap) {
       return {
-        ...baseMap,
         ...this.args.keymap,
         ...undoRedoMap,
       };
     } else {
-      return { ...baseMap, ...undoRedoMap };
+      return { ...embeddedEditorBaseKeymap, ...undoRedoMap };
     }
   }
 

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -35,19 +35,10 @@ import {
   StepMap,
   Transaction,
 } from '@lblod/ember-rdfa-editor';
-import { insertHardBreak } from '@lblod/ember-rdfa-editor/commands/insert-hard-break';
-import { toggleMarkAddFirst } from '@lblod/ember-rdfa-editor/commands/toggle-mark-add-first';
 import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import IntlService from 'ember-intl/services/intl';
 import { v4 as uuid } from 'uuid';
 import { redo, undo } from '@lblod/ember-rdfa-editor/plugins/history';
-import {
-  chainCommands,
-  createParagraphNear,
-  liftEmptyBlock,
-  newlineInCode,
-  splitBlock,
-} from '@lblod/ember-rdfa-editor/commands';
 import { isSome, unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import { lastKeyPressedPluginKey } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
 import { Plugin } from 'prosemirror-state';

--- a/addon/components/plugins/indentation/indentation-menu.ts
+++ b/addon/components/plugins/indentation/indentation-menu.ts
@@ -8,7 +8,7 @@ import { NodeType } from 'prosemirror-model';
 
 type Args = {
   controller: SayController;
-  extraTypes?: NodeType[] | NodeType;
+  allowedTypes?: NodeType[] | NodeType;
 };
 
 export default class IndentationMenuComponent extends Component<Args> {
@@ -20,18 +20,11 @@ export default class IndentationMenuComponent extends Component<Args> {
     return this.controller.schema;
   }
 
-  get extraTypes() {
-    if (!this.args.extraTypes) return [];
-    if (this.args.extraTypes instanceof Array) return this.args.extraTypes;
-    return [this.args.extraTypes];
-  }
-
   get allowedTypes() {
-    return [
-      this.schema.nodes.paragraph,
-      this.schema.nodes.heading,
-      ...this.extraTypes,
-    ];
+    if (!this.args.allowedTypes)
+      return [this.schema.nodes.paragraph, this.schema.nodes.heading];
+    if (this.args.allowedTypes instanceof Array) return this.args.allowedTypes;
+    return [this.args.allowedTypes];
   }
 
   get indentCommand() {

--- a/addon/components/toolbar/mark.hbs
+++ b/addon/components/toolbar/mark.hbs
@@ -3,6 +3,7 @@
   @active={{this.isActive}}
   @title={{@title}}
   @icon={{@icon}}
+  @disabled={{not this.canToggle}}
   {{on 'click' this.toggle}}
 />
 {{/if}}

--- a/addon/components/toolbar/mark.ts
+++ b/addon/components/toolbar/mark.ts
@@ -20,6 +20,10 @@ export default class BoldComponent extends Component<Args> {
     return this.controller.isMarkActive(this.mark);
   }
 
+  get canToggle() {
+    return this.controller.checkCommand(toggleMarkAddFirst(this.mark));
+  }
+
   @action
   toggle() {
     this.controller.focus();

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -14,6 +14,7 @@ import {
   exitCode,
   joinBackward,
   joinForward,
+  liftEmptyBlock,
   newlineInCode,
   selectAll,
   selectNodeBackward,
@@ -153,6 +154,24 @@ export const macBaseKeymap: Keymap = (schema, options) => {
     'Alt-d': pcmap['Mod-Delete'],
     'Ctrl-a': selectTextblockStart,
     'Ctrl-e': selectTextblockEnd,
+  };
+};
+
+export const embeddedEditorBaseKeymap: Keymap = (schema) => {
+  return {
+    'Mod-b': toggleMarkAddFirst(schema.marks.strong),
+    'Mod-B': toggleMarkAddFirst(schema.marks.strong),
+    'Mod-i': toggleMarkAddFirst(schema.marks.em),
+    'Mod-I': toggleMarkAddFirst(schema.marks.em),
+    'Mod-u': toggleMarkAddFirst(schema.marks.underline),
+    'Mod-U': toggleMarkAddFirst(schema.marks.underline),
+    Enter: chainCommands(
+      newlineInCode,
+      createParagraphNear,
+      liftEmptyBlock,
+      splitBlock,
+      insertHardBreak,
+    ),
   };
 };
 

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -4,7 +4,7 @@ import {
   sinkListItem,
   splitListItem,
 } from 'prosemirror-schema-list';
-import { Command, EditorState, Transaction } from 'prosemirror-state';
+import { Command } from 'prosemirror-state';
 import { Schema } from 'prosemirror-model';
 import { toggleMarkAddFirst } from '@lblod/ember-rdfa-editor/commands/toggle-mark-add-first';
 import {

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -66,9 +66,9 @@ const wrapForEmbeddedConfig: (
   command: Command,
   config?: KeymapOptions,
 ) => Command = (command, config) => {
-  if (config?.embeddedConfig) {
-    return () =>
-      command(config.embeddedConfig.state, config.embeddedConfig.dispatch);
+  const editorConfig = config?.embeddedConfig;
+  if (editorConfig) {
+    return () => command(editorConfig.state, editorConfig.dispatch);
   } else {
     return command;
   }

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -33,14 +33,6 @@ import { hasParentNodeOfType } from '@curvenote/prosemirror-utils';
 import { undoInputRule } from 'prosemirror-inputrules';
 
 export type KeymapOptions = {
-  /**
-   * Pass the state and dispatch if the keymap is used in an embedded editor
-   * e.g. `state: this.args.view.state, dispatch: this.args.view.dispatch.bind(this)`
-   */
-  embeddedConfig?: {
-    state: EditorState;
-    dispatch: (tr: Transaction) => void;
-  };
   backspace?: {
     /**
      * Enables alternative behaviour for backspace.
@@ -56,23 +48,6 @@ export type Keymap = (
   schema: Schema,
   options?: KeymapOptions,
 ) => Record<string, Command>;
-
-/**
- * Wrap a command to run on the "outer"-editor. For use in embedded editor
- * if configurations (`embeddedConfig`) is defined.
- * @param command the command like `undo` or `redo`
- */
-const wrapForEmbeddedConfig: (
-  command: Command,
-  config?: KeymapOptions,
-) => Command = (command, config) => {
-  const editorConfig = config?.embeddedConfig;
-  if (editorConfig) {
-    return () => command(editorConfig.state, editorConfig.dispatch);
-  } else {
-    return command;
-  }
-};
 
 const backspaceBase: Command[] = [
   undoInputRule,
@@ -130,13 +105,12 @@ const del = chainCommands(
 /// * **Mod-Delete** to `deleteSelection`, `joinForward`, `selectNodeForward`
 /// * **Mod-a** to `selectAll`
 ///
-/// add `embeddedConfig` to the options for embedded editors, so `undo` and `redo` work for the
-/// outer editor, which keeps the history intact
+/// `undo` and `redo` pc keybindings are overwritten in embedded-controller!
 export const pcBaseKeymap: Keymap = (schema, options) => ({
-  'Mod-z': wrapForEmbeddedConfig(undo, options),
-  'Mod-Z': wrapForEmbeddedConfig(undo, options),
-  'Mod-y': wrapForEmbeddedConfig(redo, options),
-  'Mod-Y': wrapForEmbeddedConfig(redo, options),
+  'Mod-z': undo,
+  'Mod-Z': undo,
+  'Mod-y': redo,
+  'Mod-Y': redo,
   'Mod-b': toggleMarkAddFirst(schema.marks['strong']),
   'Mod-B': toggleMarkAddFirst(schema.marks['strong']),
   'Mod-i': toggleMarkAddFirst(schema.marks['em']),

--- a/addon/nodes/index.ts
+++ b/addon/nodes/index.ts
@@ -4,5 +4,6 @@ export { hard_break } from './hard-break';
 export { horizontal_rule } from './horizontal-rule';
 export { invisible_rdfa } from './invisible-rdfa';
 export { paragraph } from './paragraph';
+export { paragraphWithConfig } from './paragraphWithConfig';
 export { repaired_block } from './repaired-block';
 export { text } from './text';

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -1,0 +1,14 @@
+import { NodeSpec } from 'prosemirror-model';
+import { paragraph } from './paragraph';
+
+interface paragraphConfig {
+  content?: string;
+  marks?: string;
+}
+
+export const paragraphWithConfig: (config?: paragraphConfig) => NodeSpec = ({
+  content = paragraph.content,
+  marks = paragraph.marks,
+} = {}) => {
+  return { ...paragraph, content: content, marks: marks };
+};

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -4,11 +4,13 @@ import { paragraph } from './paragraph';
 interface paragraphConfig {
   content?: string;
   marks?: string;
+  group?: string;
 }
 
 export const paragraphWithConfig: (config?: paragraphConfig) => NodeSpec = ({
   content = paragraph.content,
   marks = paragraph.marks,
+  group = paragraph.group,
 } = {}) => {
-  return { ...paragraph, content: content, marks: marks };
+  return { ...paragraph, content: content, marks: marks, group: group };
 };


### PR DESCRIPTION
### Overview
This PR is a bit of a mess of features, some needed for [template-comments plugin](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/220). The commits undo/redo some changes because of changing a lot of choices inbetween development. Best to mostly ignore those and squash this PR.

#### Changes
Embedded-editor (not used by template comments):
- don't let a schema be passed (this does not do anything anyway)
- give possibility to pass custom keymap and plugins. 
- explanation to not use this for block content

For template comments (which uses content directly):
- add a `ParagraphWithConfig` to allow custom paragraph nodes.
- let indentationMenu (button to indent something) accept extra nodes that can be indented

##### connected issues and PRs:
see https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/220 

### How to test/reproduce
Best tested with [template comments](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/220) which uses the new functionality.

Embedded editor:
Not really any way to test easily. But the configuration will be useful to fix some bugs (e.g. https://binnenland.atlassian.net/browse/GN-4433 ). If in review there is no certainty it works/is a good idea, I am fine to remove it from this PR and add them when fixing a bug that needs it.

### Challenges/uncertainties
~~This bug also appears in other instances using embedded-editor (like the variable plugin).~~
~~- when changing a mark (e.g. bold with CTRL+B), the button for this mark will not get "pressed" like with the normal editor. It might also have some other weird behavior (but didn't test further)~~ => Fixed by not using the "schema" inside a getter.



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
