### PR TITLE
Set up Github merge queues

### DIFF
--- a/.woodpecker/.build-pr.yml
+++ b/.woodpecker/.build-pr.yml
@@ -5,5 +5,6 @@ steps:
       repo: lblod/ember-rdfa-editor
       dry_run: true
 when:
-  event:
-    - pull_request
+  - event: pull_request
+  - event: push
+    branch: gh-readonly-queue/*

--- a/.woodpecker/.ember-scenarios.yml
+++ b/.woodpecker/.ember-scenarios.yml
@@ -8,5 +8,6 @@ steps:
       - npm ci
       - npx ember try:one ${scenario}
 when:
-  event:
-    - pull_request
+  - event: pull_request
+  - event: push
+    branch: gh-readonly-queue/*

--- a/.woodpecker/.verify-pr.yml
+++ b/.woodpecker/.verify-pr.yml
@@ -29,5 +29,7 @@ steps:
     commands:
       - ember ts:precompile
 when:
-  event:
-    - pull_request
+  - event: pull_request
+  - event: push
+    branch: gh-readonly-queue/*
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 - remove option `allowedTypes`. Instead all nodes with attribute `indentationLevel` can be indented.
 
+### Internal
+- Add support for Github merge queues
+
 ## [4.2.0] - 2023-07-29
 ### Dependencies
 - Bumps `@typescript-eslint/parser` from 6.1.0 to 6.2.0


### PR DESCRIPTION
### Overview
This PR sets up the requirements for github merge queues to work. It ensures that the necessary CI task that are run when a pull request is made/updated, are also run when a push to `gh-readonly-queue/*` happens (see https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).
