### PR TITLE
Fetch prosemirror-invisibles via https instead of ssh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - All Paragraphs are now part of the group `paragraphGroup`
+- fetch dependency `lblod/prosemirror-invisibles` via https instead of ssh, as the repo is public
 ### Dependencies
 - Bumps `@typescript-eslint/eslint-plugin` from 6.2.0 to 6.3.0
 - Bumps `xml-formatter` from 3.4.1 to 3.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@ember/render-modifiers": "^2.0.5",
         "@glimmer/tracking": "^1.1.2",
         "@graphy/memory.dataset.fast": "4.3.3",
-        "@guardian/prosemirror-invisibles": "git+ssh://git@github.com/lblod/prosemirror-invisibles",
+        "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",
         "@lblod/marawa": "^0.8.0-beta.2",
         "@types/diff-match-patch": "^1.0.32",
         "codemirror": "^6.0.1",
@@ -34457,7 +34457,7 @@
     },
     "@guardian/prosemirror-invisibles": {
       "version": "git+ssh://git@github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
-      "from": "@guardian/prosemirror-invisibles@https://github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
+      "from": "@guardian/prosemirror-invisibles@git+https://git@github.com/lblod/prosemirror-invisibles",
       "requires": {}
     },
     "@handlebars/parser": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ember/render-modifiers": "^2.0.5",
     "@glimmer/tracking": "^1.1.2",
     "@graphy/memory.dataset.fast": "4.3.3",
-    "@guardian/prosemirror-invisibles": "git+ssh://git@github.com/lblod/prosemirror-invisibles",
+    "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",
     "@lblod/marawa": "^0.8.0-beta.2",
     "@types/diff-match-patch": "^1.0.32",
     "codemirror": "^6.0.1",


### PR DESCRIPTION
### Overview
An issue was mentioned that git+ssh does not work on Jenkins, as it does not support ssh, with error 

> Host key verification failed & fatal: Could not read from remote repository on /usr/bin/git ls-remote -h -t ssh://git@github.com/lblod/prosemirror-invisibles.git.
 
As the repo is public, https can be used instead, which should fix this problem.
 
### How to test/reproduce
Not a real good way to test. This gives no difference locally and should fix the problem mentioned as far as I can find.