### PR TITLE
Hotfix: fetch prosemirror-invisibles using https instead of ssh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- fetch dependency `lblod/prosemirror-invisibles` via https instead of ssh, as the repo is public (hotfix)
+
 ## [3.10.0] - 2023-06-22
 ### Fixed
 - better handle weird edgecases when copying from word

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@ember/render-modifiers": "^2.0.5",
         "@glimmer/tracking": "^1.1.2",
         "@graphy/memory.dataset.fast": "4.3.3",
-        "@guardian/prosemirror-invisibles": "git+ssh://git@github.com/lblod/prosemirror-invisibles",
+        "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",
         "@lblod/marawa": "^0.8.0-beta.2",
         "@types/diff-match-patch": "^1.0.32",
         "codemirror": "^6.0.1",
@@ -34563,7 +34563,7 @@
     },
     "@guardian/prosemirror-invisibles": {
       "version": "git+ssh://git@github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
-      "from": "@guardian/prosemirror-invisibles@https://github.com/lblod/prosemirror-invisibles.git#3010d629b1b210d57e2d2e1c80f1b4633195b461",
+      "from": "@guardian/prosemirror-invisibles@git+https://git@github.com/lblod/prosemirror-invisibles",
       "requires": {}
     },
     "@handlebars/parser": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@ember/render-modifiers": "^2.0.5",
     "@glimmer/tracking": "^1.1.2",
     "@graphy/memory.dataset.fast": "4.3.3",
-    "@guardian/prosemirror-invisibles": "git+ssh://git@github.com/lblod/prosemirror-invisibles",
+    "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",
     "@lblod/marawa": "^0.8.0-beta.2",
     "@types/diff-match-patch": "^1.0.32",
     "codemirror": "^6.0.1",


### PR DESCRIPTION
### Overview
Hotfix version of https://github.com/lblod/ember-rdfa-editor/pull/937