### PR TITLE
Add functions to find nodes up and down the document (in order of user-view)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `findNodePosDown` function in `addon/utils/position-utils` that can find a node with specific predicate in the document, searching down (=to the right) in order of the document as seen by the user
+- `findNodePosUp` function in `addon/utils/position-utils` that can find a node with specific predicate in the document, searching up (=to the left) in order of the document as seen by the user
 ### Changed
 - All nodes with `indentationLevel` attribute can be indented, instead of only hardcoded nodes.
 - Check if table can be inserted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `findNodePosDown` function in `addon/utils/position-utils` that can find a node with specific predicate in the document, searching down (=to the right) in order of the document as seen by the user
 ### Changed
 - All nodes with `indentationLevel` attribute can be indented, instead of only hardcoded nodes.
 - Check if table can be inserted
 
 ### Fixed
 - All Paragraphs are now part of the group `paragraphGroup`
+  - A list will accept any `paragraphGroup`
+- ParagraphWithConfig accepts a config option `subType` which is required.
+  - For a normal paragraph this can be the empty string
+  - For others, this will be added to the nodespec as `subType` and the dataset of the node in `parseDom`
 - fetch dependency `lblod/prosemirror-invisibles` via https instead of ssh, as the repo is public
 ### Dependencies
 - Bumps `@typescript-eslint/eslint-plugin` from 6.2.0 to 6.3.0
@@ -19,11 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumps `eslint-config-prettier` from 8.9.0 to 9.0.0
 - Bumps `release-it` from 16.1.3 to 16.1.5
 - Bumps `ember-velcro` from 2.1.0 to 2.1.1
-  - A list will accept any `paragraphGroup`
-- ParagraphWithConfig accepts a config option `subType` which is required.
-  - For a normal paragraph this can be the empty string
-  - For others, this will be added to the nodespec as `subType` and the dataset of the node in `parseDom`
-### Dependencies
 - Bumps `eslint-config-prettier` from 8.8.0 to 8.9.0
 - Bumps `sass` from 1.64.1 to 1.64.2
 - Bumps `prosemirror-view` from 1.31.6 to 1.31.7

--- a/addon/utils/_private/document-walker.ts
+++ b/addon/utils/_private/document-walker.ts
@@ -64,7 +64,7 @@ export function* findNodePosDown(
     // passed node, so an offset has to be kept for the final result.
     let offsetChildren = 0;
     while (index < parent.childCount) {
-      const matchedChildOffsets = FindNodePosChildrenAsOffset(
+      const matchedChildOffsets = findNodePosChildrenAsOffset(
         parent,
         index,
         offsetChildren,
@@ -101,7 +101,7 @@ export function* findNodePosDown(
  * @param predicate the predicate to check for positions between nodes
  * @returns the offset (starting from the parent's startIndex) to the position that was found
  */
-export function* FindNodePosChildrenAsOffset(
+export function* findNodePosChildrenAsOffset(
   parent: PNode,
   startIndex: number,
   currentOffset: number,
@@ -129,7 +129,7 @@ export function* FindNodePosChildrenAsOffset(
     nodeIndex < node.childCount;
     childOffset += node.child(nodeIndex).nodeSize, nodeIndex++
   ) {
-    const childrenMatches = FindNodePosChildrenAsOffset(
+    const childrenMatches = findNodePosChildrenAsOffset(
       node,
       nodeIndex,
       currentOffset + childOffset,

--- a/addon/utils/_private/document-walker.ts
+++ b/addon/utils/_private/document-walker.ts
@@ -6,9 +6,11 @@ import { PNode, ResolvedPos } from '@lblod/ember-rdfa-editor';
  * Tries out all possible node spots to the right if the given position
  * in order of how nodes are displayed in the document.
  * returns the position of the first match of the predicate or null if none found.
+ * If you want to use the position (instead of just parent and index) to check if a node is valid,
+ * loop over the return values of the generator instead.
  * @param mainDoc the main doc for which the position is returned
  * @param $startPos the starting ResolvedPos position to start the search from
- * @param predicate a predicate returning of the position is valid, receiving a parent and a local index. 
+ * @param predicate a predicate returning if the position is valid, receiving a parent and a local index. 
  *                  `parent.child(index)` is then the child after the index place.
 
  * @returns the global position (in reference to `mainDoc`)
@@ -16,7 +18,7 @@ import { PNode, ResolvedPos } from '@lblod/ember-rdfa-editor';
 export function* findNodePosDown(
   mainDoc: PNode,
   $startPos: ResolvedPos,
-  predicate: (parent: PNode, index: number) => boolean,
+  predicate: (parent: PNode, index: number) => boolean = () => true,
 ): Generator<number, void> {
   // loop over the depths.
   // if at a depth no match is found, should check all children of a depth higher

--- a/addon/utils/_private/document-walker.ts
+++ b/addon/utils/_private/document-walker.ts
@@ -1,0 +1,130 @@
+import { PNode, ResolvedPos } from '@lblod/ember-rdfa-editor';
+// this might be better in ember-rdfa-editor as this works for any node and schema
+
+/**
+ * Find a position between nodes that passes a predicate test in document order.
+ * Tries out all possible node spots to the right if the given position
+ * in order of how nodes are displayed in the document.
+ * returns the position of the first match of the predicate or null if none found.
+ * @param mainDoc the main doc for which the position is returned
+ * @param $startPos the starting ResolvedPos position to start the search from
+ * @param predicate a predicate returning of the position is valid, receiving a parent and a local index. 
+ *                  `parent.child(index)` is then the child after the index place.
+
+ * @returns the global position (in reference to `mainDoc`)
+ */
+export function* findNodePosDown(
+  mainDoc: PNode,
+  $startPos: ResolvedPos,
+  predicate: (parent: PNode, index: number) => boolean,
+): Generator<number, void> {
+  // loop over the depths.
+  // if at a depth no match is found, should check all children of a depth higher
+  // *after* the passed $startPos
+  for (let depth = $startPos.depth + 1; depth > 0; depth--) {
+    const $pos = mainDoc.resolve($startPos.after(depth));
+    const parent = $pos.parent;
+    let index = $pos.index();
+
+    // loop over the children *after* the given $startPos
+    // and find a match in one of those children.
+    // Note that checkContentMatchChildren returns offset starting from the
+    // passed node, so an offset has to be kept for the final result.
+    let offsetChildren = 0;
+    while (index < parent.childCount) {
+      const matchedChildOffsets = FindNodePosChildrenAsOffset(
+        parent,
+        index,
+        offsetChildren,
+        predicate,
+      );
+      for (const matchedOffset of matchedChildOffsets) {
+        yield $pos.pos + matchedOffset;
+      }
+      offsetChildren += parent.child(index).nodeSize;
+      index++;
+    }
+    // check if can place here *after* the last node
+    // offsetChildren is now the total offset in the parent, so shows the last pos in parent
+    const lastPosInParent = $pos.pos + offsetChildren;
+    // we don't return the original passed position
+    if (
+      lastPosInParent !== $startPos.pos &&
+      predicate(parent, parent.childCount)
+    ) {
+      yield lastPosInParent;
+    }
+  }
+}
+
+/**
+ * Try to find a predicate match in children (and further down) of the passed parent
+ * starting from startIndex.
+ * returns the offset from the start of the search where a match is found
+ * a global position can be found by adding the returned offset to the passed start position
+ * Checks in order of the "document", from left to right.
+ * @param parent the parent node to check the childs for
+ * @param startIndex the first index to check in the given parent (0 to check all children)
+ * @param currentOffset the current offset which is used by the recursion. An initial value can be passed but this does not change anything for the algorithm.
+ * @param predicate the predicate to check for positions between nodes
+ * @returns the offset (starting from the parent's startIndex) to the position that was found
+ */
+export function* FindNodePosChildrenAsOffset(
+  parent: PNode,
+  startIndex: number,
+  currentOffset: number,
+  predicate: (parent: PNode, index: number) => boolean,
+): Generator<number, void> {
+  // the node that this specific call refers to
+  const node = parent.child(startIndex);
+  // check the current index (="check before the child")
+  const predicateValid = predicate(parent, startIndex);
+  if (predicateValid) {
+    if (currentOffset !== 0) {
+      yield currentOffset;
+    }
+  }
+  // when going inside children, we are moving one place to the right in pos,
+  // e.g. if parent starts at "1", the first child will start at "2",
+  // which means an extra offset needed
+  currentOffset++;
+
+  // going deeper in the tree is "closer" to the start position in regards to the document
+  // than going to the next child
+  let childOffset = 0;
+  for (
+    let nodeIndex = 0;
+    nodeIndex < node.childCount;
+    childOffset += node.child(nodeIndex).nodeSize, nodeIndex++
+  ) {
+    const childrenMatches = FindNodePosChildrenAsOffset(
+      node,
+      nodeIndex,
+      currentOffset + childOffset,
+      predicate,
+    );
+    for (const childMatch of childrenMatches) {
+      if (childMatch && childMatch !== 0) {
+        yield childMatch;
+      }
+    }
+  }
+
+  // for next match, check behind the last child of the passed node
+  // index starts at 0 and exists till after the last child
+  // this means index0 child1 index1 child2 index2
+  // So childCount gives the possible index (=the last possible index)
+  // if our current index is one less than childCount,
+  // we are just before the last child.
+  // startIndex + 1 is just after the last child
+  const beforeLastChild = node.childCount - 1;
+  const afterLastChild = node.childCount;
+  if (startIndex === beforeLastChild) {
+    const predicateValid = predicate(node, afterLastChild);
+    if (predicateValid) {
+      const matchPlace = currentOffset + node.child(startIndex).nodeSize;
+      // position after the next child
+      yield matchPlace;
+    }
+  }
+}

--- a/addon/utils/_private/document-walker.ts
+++ b/addon/utils/_private/document-walker.ts
@@ -1,11 +1,35 @@
 import { PNode, ResolvedPos } from '@lblod/ember-rdfa-editor';
-// this might be better in ember-rdfa-editor as this works for any node and schema
 
 /**
  * Find a position between nodes that passes a predicate test in document order.
- * Tries out all possible node spots to the right if the given position
+ * Tries out all possible node spots to the *left* of the given position
  * in order of how nodes are displayed in the document.
- * returns the position of the first match of the predicate or null if none found.
+ * returns the position of the first match of the predicate or undefined if none found.
+ * @param mainDoc the main doc for which the position is returned
+ * @param $startPos the starting ResolvedPos position to start the search from
+ * @param predicate a predicate returning if the resolved position is valid.
+ * @returns the global position (in reference to `mainDoc`)
+ */
+export function* findNodePosUp(
+  mainDoc: PNode,
+  startPos: number,
+  predicate: ($pos: ResolvedPos) => boolean = () => true,
+): Generator<number, void> {
+  for (let pos = startPos - 1; pos >= 0; pos--) {
+    const $pos = mainDoc.resolve(pos);
+    // TextOffset = 0 means it is between nodes or inside a node with "empty" text content
+    // isTextblock checks for this special case
+    if ($pos.textOffset === 0 && !$pos.parent.isTextblock && predicate($pos)) {
+      yield $pos.pos;
+    }
+  }
+}
+
+/**
+ * Find a position between nodes that passes a predicate test in document order.
+ * Tries out all possible node spots to the right of the given position
+ * in order of how nodes are displayed in the document.
+ * returns the position of the first match of the predicate or undefined if none found.
  * If you want to use the position (instead of just parent and index) to check if a node is valid,
  * loop over the return values of the generator instead.
  * @param mainDoc the main doc for which the position is returned

--- a/addon/utils/_private/document-walker.ts
+++ b/addon/utils/_private/document-walker.ts
@@ -5,6 +5,7 @@ import { PNode, ResolvedPos } from '@lblod/ember-rdfa-editor';
  * Tries out all possible node spots to the *left* of the given position
  * in order of how nodes are displayed in the document.
  * returns the position of the first match of the predicate or undefined if none found.
+ * Note that unlike `findnodePosDown`, this is not optimized and might be slow for bigger documents.
  * @param mainDoc the main doc for which the position is returned
  * @param $startPos the starting ResolvedPos position to start the search from
  * @param predicate a predicate returning if the resolved position is valid.

--- a/addon/utils/_private/document-walker.ts
+++ b/addon/utils/_private/document-walker.ts
@@ -28,6 +28,11 @@ export function* findNodePosDown(
     const parent = $pos.parent;
     let index = $pos.index();
 
+    // for this depth, check if the first place is valid (before checking inside the children)
+    if ($pos.pos !== $startPos.pos && predicate(parent, index)) {
+      yield $pos.pos;
+    }
+
     // loop over the children *after* the given $startPos
     // and find a match in one of those children.
     // Note that checkContentMatchChildren returns offset starting from the

--- a/addon/utils/_private/position-utils.ts
+++ b/addon/utils/_private/position-utils.ts
@@ -85,6 +85,12 @@ type FindNodesArgs = {
   filter?: ({ from, to }: { from: number; to: number }) => boolean;
 };
 
+/**
+ * Finds nodes that matche the filter, given the start and end position of that node.
+ * This search does not follow a specificied order.
+ * For specific searching order, use `findNodePosDown`.
+ * @returns generator for nodes matching the filter
+ */
 export function* findNodes({
   doc,
   visitParentUpwards = false,

--- a/addon/utils/position-utils.ts
+++ b/addon/utils/position-utils.ts
@@ -1,1 +1,2 @@
 export * from './_private/position-utils';
+export * from './_private/document-walker';


### PR DESCRIPTION
### Overview
This implements a function that searches a node (bases on a predicate) up/down the document. It does this in order of how a user views a document, or in easier terms, in increasing and decreasing position. This is often what we want to check when moving or inserting a node.
It only checks and returns positions between nodes.

The moving down algorithm works as follows:
- look before the passed node if can insert there.
- if not, go inside the node (to its children) and look to insert as much to the left as possible.
- if not, go even deeper. If no children, go to a space to the right of the original node and check there.
- if nothing in the parent of the passed node is found, we need to go up the tree.
- when going up, the same is done there.    
In simpler terms it really just loops from top to bottom. 

For moving up, the simplest algorithm is used:
loop over positions, see if it is between nodes and return if so.

A quick test with a small-ish document (5000 positions) was done: looping over positions (18ms) versus specific algorithm (12ms). 
This means that the position-looping algorithm is probably good enough (for now).

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4442
Best way to test together with [PR plugins @229](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/229)

### Setup
to test together with [PR plugins @229](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/229), see setup there.

### How to test/reproduce
move anything up/down in the structure. Because the basic editor does not have a lot of structure, it is easiest to test in [PR plugins @229](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/229)

### Challenges/uncertainties
/
