### PR TITLE
GN-4433: Links - Bind enter-key to leave node/input-box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- GN-4433: Pressing `enter`-key inside a link will set the cursor behind this link.
 
 ## [5.2.0] - 2023-08-29
 

--- a/addon/components/ember-node/link.hbs
+++ b/addon/components/ember-node/link.hbs
@@ -18,7 +18,7 @@
       @placeholder={{t 'ember-rdfa-editor.link.placeholder.text'}}
       @decorations={{@decorations}}
       @contentDecorations={{@contentDecorations}}
-      {{leaveOnEnterKey this.controller this.pos}}
+      {{leave-on-enter-key this.controller this.pos}}
     />
   </Pill>
   {{#if (and this.selected this.interactive)}}
@@ -38,7 +38,7 @@
         @value={{this.href}}
         placeholder={{t 'ember-rdfa-editor.link.placeholder.href'}}
         {{on 'focus' this.selectHref}}
-        {{leaveOnEnterKey this.controller this.pos}}
+        {{leave-on-enter-key this.controller this.pos}}
       />
       <AuButton
         @icon='link-broken'

--- a/addon/components/ember-node/link.hbs
+++ b/addon/components/ember-node/link.hbs
@@ -18,6 +18,7 @@
       @placeholder={{t 'ember-rdfa-editor.link.placeholder.text'}}
       @decorations={{@decorations}}
       @contentDecorations={{@contentDecorations}}
+      {{leaveOnEnterKey this.controller this.pos}}
     />
   </Pill>
   {{#if (and this.selected this.interactive)}}
@@ -37,6 +38,7 @@
         @value={{this.href}}
         placeholder={{t 'ember-rdfa-editor.link.placeholder.href'}}
         {{on 'focus' this.selectHref}}
+        {{leaveOnEnterKey this.controller this.pos}}
       />
       <AuButton
         @icon='link-broken'

--- a/addon/modifiers/leave-on-enter-key.ts
+++ b/addon/modifiers/leave-on-enter-key.ts
@@ -1,26 +1,27 @@
 import { modifier } from 'ember-modifier';
 import { SayController, TextSelection } from '..';
 
-export default modifier(function leaveOnEnterKey(
-  element: HTMLElement,
-  controller: SayController,
-  startPosNode: number,
-) {
-  const state = controller.mainEditorState;
-  const node = state.doc.resolve(startPosNode).nodeAfter;
-  const leaveOnEnter = (event: KeyboardEvent) => {
-    if (event !== 'Enter') return;
+export default modifier(
+  (
+    element: HTMLElement,
+    [controller, startPosNode]: [SayController, number],
+  ) => {
+    const state = controller.mainEditorState;
+    const node = state.doc.resolve(startPosNode).nodeAfter;
+    const leaveOnEnter = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter' || !node) return;
 
-    const posAfter = startPosNode + node.nodeSize;
-    const tr = state.tr;
-    tr.setSelection(TextSelection.create(state.doc, posAfter));
-    controller.mainEditorView.dispatch(tr);
-    controller.mainEditorView.focus();
-  };
+      const posAfter = startPosNode + node.nodeSize;
+      const tr = state.tr;
+      tr.setSelection(TextSelection.create(state.doc, posAfter));
+      controller.mainEditorView.dispatch(tr);
+      controller.mainEditorView.focus();
+    };
 
-  element.addEventListener('keyup', leaveOnEnter);
+    element.addEventListener('keyup', leaveOnEnter);
 
-  return () => {
-    element.removeEventListener('keyup', leaveOnEnter);
-  };
-});
+    return () => {
+      element.removeEventListener('keyup', leaveOnEnter);
+    };
+  },
+);

--- a/addon/modifiers/leave-on-enter-key.ts
+++ b/addon/modifiers/leave-on-enter-key.ts
@@ -2,15 +2,15 @@ import { modifier } from 'ember-modifier';
 import { SayController, TextSelection } from '..';
 
 export default modifier(
-  (
+  function leaveOnEnterKey(
     element: HTMLElement,
     [controller, startPosNode]: [SayController, number],
-  ) => {
-    const state = controller.mainEditorState;
-    const node = state.doc.resolve(startPosNode).nodeAfter;
+  ) {
     const leaveOnEnter = (event: KeyboardEvent) => {
-      if (event.key !== 'Enter' || !node) return;
-
+      if (event.key !== 'Enter') return;
+      const state = controller.mainEditorState;
+      const node = state.doc.resolve(startPosNode).nodeAfter;
+      if (!node) return;
       const posAfter = startPosNode + node.nodeSize;
       const tr = state.tr;
       tr.setSelection(TextSelection.create(state.doc, posAfter));
@@ -24,4 +24,5 @@ export default modifier(
       element.removeEventListener('keyup', leaveOnEnter);
     };
   },
+  { eager: false },
 );

--- a/addon/modifiers/leave-on-enter-key.ts
+++ b/addon/modifiers/leave-on-enter-key.ts
@@ -1,0 +1,26 @@
+import { modifier } from 'ember-modifier';
+import { SayController, TextSelection } from '..';
+
+export default modifier(function leaveOnEnterKey(
+  element: HTMLElement,
+  controller: SayController,
+  startPosNode: number,
+) {
+  const state = controller.mainEditorState;
+  const node = state.doc.resolve(startPosNode).nodeAfter;
+  const leaveOnEnter = (event: KeyboardEvent) => {
+    if (event !== 'Enter') return;
+
+    const posAfter = startPosNode + node.nodeSize;
+    const tr = state.tr;
+    tr.setSelection(TextSelection.create(state.doc, posAfter));
+    controller.mainEditorView.dispatch(tr);
+    controller.mainEditorView.focus();
+  };
+
+  element.addEventListener('keyup', leaveOnEnter);
+
+  return () => {
+    element.removeEventListener('keyup', leaveOnEnter);
+  };
+});

--- a/app/modifiers/leave-on-enter-key.js
+++ b/app/modifiers/leave-on-enter-key.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/modifiers/leave-on-enter-key';

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,6 @@
         "ember-disable-prototype-extensions": "^1.1.3",
         "ember-functions-as-helper-polyfill": "^2.1.1",
         "ember-load-initializers": "^2.1.2",
-        "ember-modifier": "^4.1.0",
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^6.0.0",
         "ember-resolver": "^8.0.3",
@@ -145,7 +144,8 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.4.2",
-        "ember-cli-sass": "^11.0.1"
+        "ember-cli-sass": "^11.0.1",
+        "ember-modifier": "^3.2.7"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -214,22 +214,6 @@
       },
       "peerDependencies": {
         "ember-source": "^3.28.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-modifier": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.5"
-      },
-      "engines": {
-        "node": "12.* || >= 14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4688,22 +4672,6 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/ember-modifier": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.5"
-      },
-      "engines": {
-        "node": "12.* || >= 14"
       }
     },
     "node_modules/abbrev": {
@@ -10630,45 +10598,6 @@
         "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/ember-basic-dropdown/node_modules/ember-modifier": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.5"
-      },
-      "engines": {
-        "node": "12.* || >= 14"
-      }
-    },
-    "node_modules/ember-basic-dropdown/node_modules/ember-modifier/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
     "node_modules/ember-basic-dropdown/node_modules/execa": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -14840,22 +14769,6 @@
         }
       }
     },
-    "node_modules/ember-file-upload/node_modules/ember-modifier": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.5"
-      },
-      "engines": {
-        "node": "12.* || >= 14"
-      }
-    },
     "node_modules/ember-focus-trap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.0.2.tgz",
@@ -16665,21 +16578,18 @@
       }
     },
     "node_modules/ember-modifier": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.1.0.tgz",
-      "integrity": "sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
       "dependencies": {
-        "@embroider/addon-shim": "^1.8.4",
+        "ember-cli-babel": "^7.26.6",
         "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0"
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-typescript": "^5.0.0",
+        "ember-compatibility-helpers": "^1.2.5"
       },
-      "peerDependencies": {
-        "ember-source": "*"
-      },
-      "peerDependenciesMeta": {
-        "ember-source": {
-          "optional": true
-        }
+      "engines": {
+        "node": "12.* || >= 14"
       }
     },
     "node_modules/ember-modifier-manager-polyfill": {
@@ -17081,23 +16991,6 @@
       },
       "engines": {
         "node": "14.* || >= 16"
-      }
-    },
-    "node_modules/ember-style-modifier/node_modules/ember-modifier": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.5"
-      },
-      "engines": {
-        "node": "12.* || >= 14"
       }
     },
     "node_modules/ember-template-imports": {
@@ -32236,21 +32129,6 @@
         "inputmask": "^5.0.7",
         "merge-anything": "^5.1.3",
         "tracked-toolbox": "^1.2.3"
-      },
-      "dependencies": {
-        "ember-modifier": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-          "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^7.26.6",
-            "ember-cli-normalize-entity-name": "^1.0.0",
-            "ember-cli-string-utils": "^1.1.0",
-            "ember-cli-typescript": "^5.0.0",
-            "ember-compatibility-helpers": "^1.2.5"
-          }
-        }
       }
     },
     "@babel/code-frame": {
@@ -35694,21 +35572,6 @@
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.0.1",
         "ember-modifier": "^3.2.7"
-      },
-      "dependencies": {
-        "ember-modifier": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-          "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^7.26.6",
-            "ember-cli-normalize-entity-name": "^1.0.0",
-            "ember-cli-string-utils": "^1.1.0",
-            "ember-cli-typescript": "^5.0.0",
-            "ember-compatibility-helpers": "^1.2.5"
-          }
-        }
       }
     },
     "abbrev": {
@@ -40527,41 +40390,6 @@
             "walk-sync": "^2.2.0"
           }
         },
-        "ember-modifier": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-          "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ember-cli-babel": "^7.26.6",
-            "ember-cli-normalize-entity-name": "^1.0.0",
-            "ember-cli-string-utils": "^1.1.0",
-            "ember-cli-typescript": "^5.0.0",
-            "ember-compatibility-helpers": "^1.2.5"
-          },
-          "dependencies": {
-            "ember-cli-typescript": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-              "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ansi-to-html": "^0.6.15",
-                "broccoli-stew": "^3.0.0",
-                "debug": "^4.0.0",
-                "execa": "^4.0.0",
-                "fs-extra": "^9.0.1",
-                "resolve": "^1.5.0",
-                "rsvp": "^4.8.1",
-                "semver": "^7.3.2",
-                "stagehand": "^1.0.0",
-                "walk-sync": "^2.2.0"
-              }
-            }
-          }
-        },
         "execa": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -43976,21 +43804,6 @@
         "ember-auto-import": "^2.0.0",
         "ember-modifier": "^3.2.7",
         "tracked-built-ins": "^3.0.0"
-      },
-      "dependencies": {
-        "ember-modifier": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-          "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^7.26.6",
-            "ember-cli-normalize-entity-name": "^1.0.0",
-            "ember-cli-string-utils": "^1.1.0",
-            "ember-cli-typescript": "^5.0.0",
-            "ember-compatibility-helpers": "^1.2.5"
-          }
-        }
       }
     },
     "ember-focus-trap": {
@@ -45453,13 +45266,15 @@
       }
     },
     "ember-modifier": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.1.0.tgz",
-      "integrity": "sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
       "requires": {
-        "@embroider/addon-shim": "^1.8.4",
+        "ember-cli-babel": "^7.26.6",
         "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0"
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-typescript": "^5.0.0",
+        "ember-compatibility-helpers": "^1.2.5"
       }
     },
     "ember-modifier-manager-polyfill": {
@@ -45773,22 +45588,6 @@
       "requires": {
         "ember-cli-babel": "^7.26.11",
         "ember-modifier": "^3.2.7"
-      },
-      "dependencies": {
-        "ember-modifier": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-          "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ember-cli-babel": "^7.26.6",
-            "ember-cli-normalize-entity-name": "^1.0.0",
-            "ember-cli-string-utils": "^1.1.0",
-            "ember-cli-typescript": "^5.0.0",
-            "ember-compatibility-helpers": "^1.2.5"
-          }
-        }
       }
     },
     "ember-template-imports": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,7 @@
         "ember-disable-prototype-extensions": "^1.1.3",
         "ember-functions-as-helper-polyfill": "^2.1.1",
         "ember-load-initializers": "^2.1.2",
+        "ember-modifier": "^3.2.7",
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^6.0.0",
         "ember-resolver": "^8.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,7 @@
         "ember-disable-prototype-extensions": "^1.1.3",
         "ember-functions-as-helper-polyfill": "^2.1.1",
         "ember-load-initializers": "^2.1.2",
+        "ember-modifier": "^4.1.0",
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^6.0.0",
         "ember-resolver": "^8.0.3",
@@ -213,6 +214,22 @@
       },
       "peerDependencies": {
         "ember-source": "^3.28.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-modifier": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-typescript": "^5.0.0",
+        "ember-compatibility-helpers": "^1.2.5"
+      },
+      "engines": {
+        "node": "12.* || >= 14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4671,6 +4688,22 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@zestia/ember-auto-focus/node_modules/ember-modifier": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-typescript": "^5.0.0",
+        "ember-compatibility-helpers": "^1.2.5"
+      },
+      "engines": {
+        "node": "12.* || >= 14"
       }
     },
     "node_modules/abbrev": {
@@ -10597,6 +10630,45 @@
         "node": "10.* || >= 12.*"
       }
     },
+    "node_modules/ember-basic-dropdown/node_modules/ember-modifier": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-typescript": "^5.0.0",
+        "ember-compatibility-helpers": "^1.2.5"
+      },
+      "engines": {
+        "node": "12.* || >= 14"
+      }
+    },
+    "node_modules/ember-basic-dropdown/node_modules/ember-modifier/node_modules/ember-cli-typescript": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ansi-to-html": "^0.6.15",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "fs-extra": "^9.0.1",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^7.3.2",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 12.*"
+      }
+    },
     "node_modules/ember-basic-dropdown/node_modules/execa": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -14768,6 +14840,22 @@
         }
       }
     },
+    "node_modules/ember-file-upload/node_modules/ember-modifier": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-typescript": "^5.0.0",
+        "ember-compatibility-helpers": "^1.2.5"
+      },
+      "engines": {
+        "node": "12.* || >= 14"
+      }
+    },
     "node_modules/ember-focus-trap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.0.2.tgz",
@@ -16577,18 +16665,21 @@
       }
     },
     "node_modules/ember-modifier": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.1.0.tgz",
+      "integrity": "sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==",
       "dependencies": {
-        "ember-cli-babel": "^7.26.6",
+        "@embroider/addon-shim": "^1.8.4",
         "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.5"
+        "ember-cli-string-utils": "^1.1.0"
       },
-      "engines": {
-        "node": "12.* || >= 14"
+      "peerDependencies": {
+        "ember-source": "*"
+      },
+      "peerDependenciesMeta": {
+        "ember-source": {
+          "optional": true
+        }
       }
     },
     "node_modules/ember-modifier-manager-polyfill": {
@@ -16990,6 +17081,23 @@
       },
       "engines": {
         "node": "14.* || >= 16"
+      }
+    },
+    "node_modules/ember-style-modifier/node_modules/ember-modifier": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-typescript": "^5.0.0",
+        "ember-compatibility-helpers": "^1.2.5"
+      },
+      "engines": {
+        "node": "12.* || >= 14"
       }
     },
     "node_modules/ember-template-imports": {
@@ -32128,6 +32236,21 @@
         "inputmask": "^5.0.7",
         "merge-anything": "^5.1.3",
         "tracked-toolbox": "^1.2.3"
+      },
+      "dependencies": {
+        "ember-modifier": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+          "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+          "dev": true,
+          "requires": {
+            "ember-cli-babel": "^7.26.6",
+            "ember-cli-normalize-entity-name": "^1.0.0",
+            "ember-cli-string-utils": "^1.1.0",
+            "ember-cli-typescript": "^5.0.0",
+            "ember-compatibility-helpers": "^1.2.5"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -35571,6 +35694,21 @@
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.0.1",
         "ember-modifier": "^3.2.7"
+      },
+      "dependencies": {
+        "ember-modifier": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+          "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+          "dev": true,
+          "requires": {
+            "ember-cli-babel": "^7.26.6",
+            "ember-cli-normalize-entity-name": "^1.0.0",
+            "ember-cli-string-utils": "^1.1.0",
+            "ember-cli-typescript": "^5.0.0",
+            "ember-compatibility-helpers": "^1.2.5"
+          }
+        }
       }
     },
     "abbrev": {
@@ -40389,6 +40527,41 @@
             "walk-sync": "^2.2.0"
           }
         },
+        "ember-modifier": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+          "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ember-cli-babel": "^7.26.6",
+            "ember-cli-normalize-entity-name": "^1.0.0",
+            "ember-cli-string-utils": "^1.1.0",
+            "ember-cli-typescript": "^5.0.0",
+            "ember-compatibility-helpers": "^1.2.5"
+          },
+          "dependencies": {
+            "ember-cli-typescript": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+              "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-to-html": "^0.6.15",
+                "broccoli-stew": "^3.0.0",
+                "debug": "^4.0.0",
+                "execa": "^4.0.0",
+                "fs-extra": "^9.0.1",
+                "resolve": "^1.5.0",
+                "rsvp": "^4.8.1",
+                "semver": "^7.3.2",
+                "stagehand": "^1.0.0",
+                "walk-sync": "^2.2.0"
+              }
+            }
+          }
+        },
         "execa": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -43803,6 +43976,21 @@
         "ember-auto-import": "^2.0.0",
         "ember-modifier": "^3.2.7",
         "tracked-built-ins": "^3.0.0"
+      },
+      "dependencies": {
+        "ember-modifier": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+          "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+          "dev": true,
+          "requires": {
+            "ember-cli-babel": "^7.26.6",
+            "ember-cli-normalize-entity-name": "^1.0.0",
+            "ember-cli-string-utils": "^1.1.0",
+            "ember-cli-typescript": "^5.0.0",
+            "ember-compatibility-helpers": "^1.2.5"
+          }
+        }
       }
     },
     "ember-focus-trap": {
@@ -45265,15 +45453,13 @@
       }
     },
     "ember-modifier": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.1.0.tgz",
+      "integrity": "sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==",
       "requires": {
-        "ember-cli-babel": "^7.26.6",
+        "@embroider/addon-shim": "^1.8.4",
         "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.5"
+        "ember-cli-string-utils": "^1.1.0"
       }
     },
     "ember-modifier-manager-polyfill": {
@@ -45587,6 +45773,22 @@
       "requires": {
         "ember-cli-babel": "^7.26.11",
         "ember-modifier": "^3.2.7"
+      },
+      "dependencies": {
+        "ember-modifier": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
+          "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ember-cli-babel": "^7.26.6",
+            "ember-cli-normalize-entity-name": "^1.0.0",
+            "ember-cli-string-utils": "^1.1.0",
+            "ember-cli-typescript": "^5.0.0",
+            "ember-compatibility-helpers": "^1.2.5"
+          }
+        }
       }
     },
     "ember-template-imports": {

--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
     "sass": "^1.49.9",
     "sinon": "^15.0.1",
     "typescript": "~5.0.4",
-    "webpack": "^5.74.0"
+    "webpack": "^5.74.0",
+    "ember-modifier": "^3.2.7"
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",
-    "ember-cli-sass": "^11.0.1"
+    "ember-cli-sass": "^11.0.1",
+    "ember-modifier": "^4.1.0"
   },
   "overrides": {
     "ember-intl": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",
     "ember-cli-sass": "^11.0.1",
-    "ember-modifier": "^4.1.0"
+    "ember-modifier": "^3.2.7"
   },
   "overrides": {
     "ember-intl": {


### PR DESCRIPTION
### Overview
Enter-key did nothing in links. This adds the functionality that pressing enter-key leaves the node and puts the cursor after the link-node (which is after the pill).

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4433

### How to test/reproduce
add a link
see that pressing enter leaves the node (sets cursor behind the node)

### Challenges/uncertainties
Created a modifier which is a lot more cleaner than adding code to the component. number-variable has similar logic and should also use this modifier.
I did not test if this is directly useable in the plugins repo without doing some special exporting.

This adds an explicit dependency of `ember-modifier`.
