### PR TITLE
Run the Embroider "safe" and "strict" scenarios in CI

### DIFF
--- a/.woodpecker/.embroider-scenarios.yml
+++ b/.woodpecker/.embroider-scenarios.yml
@@ -1,0 +1,15 @@
+# These can be merged into the ember-scenarios job once they pass
+matrix:
+  scenario:
+    - embroider-safe
+    - embroider-optimized
+steps:
+  - name: ${scenario}
+    image: danlynn/ember-cli:4.8.0
+    failure: ignore
+    commands:
+      - npm ci
+      - npx ember try:one ${scenario}
+when:
+  event:
+    - pull_request

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -49,8 +49,8 @@ module.exports = async function () {
         },
         allowedToFail: true,
       },
-      embroiderSafe({ allowedToFail: true }),
-      embroiderOptimized({ allowedToFail: true }),
+      embroiderSafe(),
+      embroiderOptimized(),
     ],
   };
 };


### PR DESCRIPTION
This adds the Embroider `safe` and `strict` scenarios to Woodpecker again. They are allowed to fail since there are still some issues (which can be resolved in separate PRs. Once they succeed again we can add them to the other `ember-scenarios` job.



