### PR TITLE
Replace `ember-get-config` with `@embroider/macros`

### DIFF
--- a/.changeset/weak-shirts-wink.md
+++ b/.changeset/weak-shirts-wink.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Replace ember-get-config

--- a/addon/utils/_private/logging-utils.ts
+++ b/addon/utils/_private/logging-utils.ts
@@ -1,4 +1,4 @@
-import config from 'ember-get-config';
+import { isDevelopingApp, macroCondition } from '@embroider/macros';
 import { debug } from 'debug';
 
 /**
@@ -28,7 +28,7 @@ window.setLogFilter = setLogFilter;
 
 // Setup default loglevel based on environment.
 if (!localStorage.getItem('debug')) {
-  if (config.environment === 'development') {
+  if (macroCondition(isDevelopingApp())) {
     setLogFilter('ember-rdfa-editor:*');
   } else {
     setLogFilter('');

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@curvenote/prosemirror-utils": "^1.0.5",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.5",
+        "@embroider/macros": "^1.13.1",
         "@glimmer/tracking": "^1.1.2",
         "@graphy/memory.dataset.fast": "4.3.3",
         "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",
@@ -31,7 +32,6 @@
         "ember-cli-typescript": "^5.1.0",
         "ember-focus-trap": "~1.0.1",
         "ember-functions-as-helper-polyfill": "^2.1.2",
-        "ember-get-config": "^2.0.0",
         "ember-intl": "^5.7.2",
         "ember-truth-helpers": "^3.0.0",
         "ember-unique-id-helper-polyfill": "^1.2.2",
@@ -68,6 +68,7 @@
         "@ember/test-helpers": "^2.9.3",
         "@embroider/test-setup": "^3.0.1",
         "@glimmer/component": "^1.1.2",
+        "@glint/template": "^1.1.0",
         "@rdfjs/types": "^1.1.0",
         "@release-it/keep-a-changelog": "^4.0.0",
         "@types/common-tags": "^1.8.0",
@@ -3134,13 +3135,13 @@
       }
     },
     "node_modules/@embroider/macros": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.10.0.tgz",
-      "integrity": "sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.1.tgz",
+      "integrity": "sha512-4htraP/rNIht8uCxXoc59Bw2EsBFfc4YUQD9XSpzJ4xUr1V0GQf9wL/noeSuYSxIhwRfZOErnJhsdyf1hH+I/A==",
       "dependencies": {
-        "@embroider/shared-internals": "2.0.0",
+        "@embroider/shared-internals": "2.4.0",
         "assert-never": "^1.2.1",
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
         "find-up": "^5.0.0",
         "lodash": "^4.17.21",
@@ -3149,14 +3150,31 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/babel-import-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+      "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@embroider/shared-internals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
-      "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.4.0.tgz",
+      "integrity": "sha512-pFE05ebenWMC9XAPRjadYCXXb6VmqjkhYN5uqkhPo+VUmMHnx7sZYYxqGjxfVuhC/ghS/BNlOffOCXDOoE7k7g==",
       "dependencies": {
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
         "ember-rfc176-data": "^0.3.17",
         "fs-extra": "^9.1.0",
         "js-string-escape": "^1.0.1",
@@ -3167,6 +3185,14 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/shared-internals/node_modules/babel-import-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+      "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@embroider/test-setup": {
@@ -3682,6 +3708,12 @@
       "dependencies": {
         "babel-plugin-debug-macros": "^0.3.4"
       }
+    },
+    "node_modules/@glint/template": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@glint/template/-/template-1.1.0.tgz",
+      "integrity": "sha512-gK4tifrw7mIMYECzGeG5jrez2lY0TlwE584cnoYOFhzxXKrsuungdiebd7LDwjvfQpImQd1JUSQr3u/uF/XYJg==",
+      "devOptional": true
     },
     "node_modules/@graphy/core.data.factory": {
       "version": "4.3.4",
@@ -16336,6 +16368,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-2.1.1.tgz",
       "integrity": "sha512-uNmv1cPG/4qsac8oIf5txJ2FZ8p88LEpG4P3dNcjsJS98Y8hd0GPMFwVqpnzI78Lz7VYRGQWY4jnE4qm5R3j4g==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "@embroider/macros": "^0.50.0 || ^1.0.0",
         "ember-cli-babel": "^7.26.6"
@@ -37615,26 +37649,34 @@
       }
     },
     "@embroider/macros": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.10.0.tgz",
-      "integrity": "sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.1.tgz",
+      "integrity": "sha512-4htraP/rNIht8uCxXoc59Bw2EsBFfc4YUQD9XSpzJ4xUr1V0GQf9wL/noeSuYSxIhwRfZOErnJhsdyf1hH+I/A==",
       "requires": {
-        "@embroider/shared-internals": "2.0.0",
+        "@embroider/shared-internals": "2.4.0",
         "assert-never": "^1.2.1",
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
         "find-up": "^5.0.0",
         "lodash": "^4.17.21",
         "resolve": "^1.20.0",
         "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "babel-import-util": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+          "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw=="
+        }
       }
     },
     "@embroider/shared-internals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.0.0.tgz",
-      "integrity": "sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.4.0.tgz",
+      "integrity": "sha512-pFE05ebenWMC9XAPRjadYCXXb6VmqjkhYN5uqkhPo+VUmMHnx7sZYYxqGjxfVuhC/ghS/BNlOffOCXDOoE7k7g==",
       "requires": {
-        "babel-import-util": "^1.1.0",
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
         "ember-rfc176-data": "^0.3.17",
         "fs-extra": "^9.1.0",
         "js-string-escape": "^1.0.1",
@@ -37642,6 +37684,13 @@
         "resolve-package-path": "^4.0.1",
         "semver": "^7.3.5",
         "typescript-memoize": "^1.0.1"
+      },
+      "dependencies": {
+        "babel-import-util": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
+          "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw=="
+        }
       }
     },
     "@embroider/test-setup": {
@@ -38064,6 +38113,12 @@
       "requires": {
         "babel-plugin-debug-macros": "^0.3.4"
       }
+    },
+    "@glint/template": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@glint/template/-/template-1.1.0.tgz",
+      "integrity": "sha512-gK4tifrw7mIMYECzGeG5jrez2lY0TlwE584cnoYOFhzxXKrsuungdiebd7LDwjvfQpImQd1JUSQr3u/uF/XYJg==",
+      "devOptional": true
     },
     "@graphy/core.data.factory": {
       "version": "4.3.4",
@@ -48397,6 +48452,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-2.1.1.tgz",
       "integrity": "sha512-uNmv1cPG/4qsac8oIf5txJ2FZ8p88LEpG4P3dNcjsJS98Y8hd0GPMFwVqpnzI78Lz7VYRGQWY4jnE4qm5R3j4g==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "@embroider/macros": "^0.50.0 || ^1.0.0",
         "ember-cli-babel": "^7.26.6"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@curvenote/prosemirror-utils": "^1.0.5",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.5",
+    "@embroider/macros": "^1.13.1",
     "@glimmer/tracking": "^1.1.2",
     "@graphy/memory.dataset.fast": "4.3.3",
     "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",
@@ -57,7 +58,6 @@
     "ember-cli-typescript": "^5.1.0",
     "ember-focus-trap": "~1.0.1",
     "ember-functions-as-helper-polyfill": "^2.1.2",
-    "ember-get-config": "^2.0.0",
     "ember-intl": "^5.7.2",
     "ember-truth-helpers": "^3.0.0",
     "ember-unique-id-helper-polyfill": "^1.2.2",
@@ -94,6 +94,7 @@
     "@ember/test-helpers": "^2.9.3",
     "@embroider/test-setup": "^3.0.1",
     "@glimmer/component": "^1.1.2",
+    "@glint/template": "^1.1.0",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^4.0.0",
     "@types/common-tags": "^1.8.0",
@@ -139,6 +140,7 @@
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.2",
+    "ember-modifier": "^3.2.7",
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^6.0.0",
     "ember-resolver": "^11.0.1",
@@ -164,8 +166,7 @@
     "sass": "^1.49.9",
     "sinon": "^15.0.1",
     "typescript": "~5.0.4",
-    "webpack": "^5.74.0",
-    "ember-modifier": "^3.2.7"
+    "webpack": "^5.74.0"
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -4,7 +4,3 @@ declare module '@lblod/ember-rdfa-editor/templates/*' {
   const tmpl: TemplateFactory;
   export default tmpl;
 }
-
-declare module 'ember-get-config' {
-  const environment: string;
-}


### PR DESCRIPTION
`ember-get-config` uses loader.js APIs internally which are going to be removed in the future. For our use-case, it can easily be replaced with the `isDevelopingApp` macro.
