### PR TITLE
Fix leaveOnEnterKey Bug + extra modifiers LeaveWithArrowKeys and SelectNodeOnClick

### DIFF
--- a/.changeset/silent-oranges-impress.md
+++ b/.changeset/silent-oranges-impress.md
@@ -1,0 +1,7 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+- Fix `leave-on-enter-key` modifier to always use the correct position to leave a node from.
+- Add `leave-with-arrow-keys` modifier, which can be used to leave an node's element with the left and right arrow key.
+- Add `select-node-on-click` modifier, which can be used to select a given node when clicking the bound element.

--- a/addon/components/ember-node/link.hbs
+++ b/addon/components/ember-node/link.hbs
@@ -18,7 +18,7 @@
       @placeholder={{t 'ember-rdfa-editor.link.placeholder.text'}}
       @decorations={{@decorations}}
       @contentDecorations={{@contentDecorations}}
-      {{leave-on-enter-key this.controller this.pos}}
+      {{leave-on-enter-key this.controller @getPos}}
     />
   </Pill>
   {{#if (and this.selected this.interactive)}}
@@ -38,7 +38,7 @@
         @value={{this.href}}
         placeholder={{t 'ember-rdfa-editor.link.placeholder.href'}}
         {{on 'focus' this.selectHref}}
-        {{leave-on-enter-key this.controller this.pos}}
+        {{leave-on-enter-key this.controller @getPos}}
       />
       <AuButton
         @icon='link-broken'

--- a/addon/components/ember-node/link.ts
+++ b/addon/components/ember-node/link.ts
@@ -19,10 +19,6 @@ export default class Link extends Component<EmberNodeArgs> {
     return this.args.node;
   }
 
-  get pos() {
-    return this.args.getPos();
-  }
-
   get selected() {
     return this.args.selected;
   }
@@ -45,7 +41,7 @@ export default class Link extends Component<EmberNodeArgs> {
 
   @action
   remove() {
-    const pos = this.pos;
+    const pos = this.args.getPos();
     if (pos !== undefined) {
       this.controller.withTransaction(
         (tr) => {

--- a/addon/modifiers/leave-on-enter-key.ts
+++ b/addon/modifiers/leave-on-enter-key.ts
@@ -8,9 +8,9 @@ export default modifier(
     [controller, getPos]: [SayController, () => number | undefined],
   ) {
     const leaveOnEnter = (event: KeyboardEvent) => {
-      if (event.key !== 'Enter' || getPos === undefined) return;
-
       const startPosNode = getPos();
+      if (event.key !== 'Enter' || startPosNode === undefined) return;
+
       const state = controller.mainEditorState;
       const node = state.doc.resolve(startPosNode).nodeAfter;
       if (!node) return;

--- a/addon/modifiers/leave-on-enter-key.ts
+++ b/addon/modifiers/leave-on-enter-key.ts
@@ -1,13 +1,16 @@
 import { modifier } from 'ember-modifier';
 import { SayController, TextSelection } from '..';
 
+/* Set the cursor behind the node after `startPosNode` when pressing enter in the bound element. */
 export default modifier(
   function leaveOnEnterKey(
     element: HTMLElement,
-    [controller, startPosNode]: [SayController, number],
+    [controller, getPos]: [SayController, () => number | undefined],
   ) {
     const leaveOnEnter = (event: KeyboardEvent) => {
-      if (event.key !== 'Enter') return;
+      if (event.key !== 'Enter' || getPos === undefined) return;
+
+      const startPosNode = getPos();
       const state = controller.mainEditorState;
       const node = state.doc.resolve(startPosNode).nodeAfter;
       if (!node) return;

--- a/addon/modifiers/leave-with-arrow-keys.ts
+++ b/addon/modifiers/leave-with-arrow-keys.ts
@@ -1,0 +1,89 @@
+import Modifier from 'ember-modifier';
+import { SayController, TextSelection } from '..';
+import { registerDestructor } from '@ember/destroyable';
+
+function removeListeners(instance: LeaveWithArrowKeysModifier) {
+  instance.element?.removeEventListener(
+    'keydown',
+    instance.setPositionBeforeArrowKeyLoose,
+  );
+  instance.element?.removeEventListener('keyup', instance.leaveEdgeOnArrowKey);
+}
+
+/* Set the cursor before or behind the node after `startPosNode`
+ * when pressing the left or right arrow key respectively.
+ */
+export default class LeaveWithArrowKeysModifier extends Modifier {
+  // We only want to move out if the cursor was already at the edge
+  // This can only be known by getting the position before the keypress
+  // and comparing after the keypress, when the cursor move already happened.
+  cursorPositionKeyDown: number | null = null;
+  element: HTMLElement = null;
+  controller: SayController = null;
+  getPos: () => number | undefined;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    registerDestructor(this, removeListeners);
+  }
+
+  modify(
+    element: HTMLElement,
+    [controller, getPos]: [SayController, () => number | undefined],
+  ) {
+    if (!this.element) {
+      // initialize element once as `modify` will get called everytime a parameter changes.
+      // Although in practice changes to `getPos` will make the descructor get called instead.
+      this.element = element;
+      this.element.addEventListener(
+        'keydown',
+        this.setPositionBeforeArrowKeyLoose,
+      );
+      this.element.addEventListener('keyup', this.leaveEdgeOnArrowKey);
+    }
+    this.getPos = getPos;
+    this.controller = controller;
+  }
+
+  setPositionBeforeArrowKeyLoose = (event: KeyboardEvent) => {
+    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      this.cursorPositionKeyDown = (
+        event.target as HTMLInputElement
+      ).selectionStart;
+    }
+  };
+
+  leaveEdgeOnArrowKey = (event: KeyboardEvent) => {
+    const finalPos = (event.target as HTMLInputElement).value.length;
+    if (event.key === 'ArrowRight' && this.cursorPositionKeyDown === finalPos) {
+      this.selectAfterNode();
+    }
+    if (event.key === 'ArrowLeft' && this.cursorPositionKeyDown === 0) {
+      this.selectBeforeNode();
+    }
+    this.cursorPositionKeyDown = null;
+  };
+
+  setSelectionAt(pos: number) {
+    const tr = this.controller.mainEditorState.tr;
+    tr.setSelection(
+      TextSelection.create(this.controller.mainEditorState.doc, pos),
+    );
+    this.controller.mainEditorView.dispatch(tr);
+    this.controller.focus();
+  }
+
+  selectAfterNode() {
+    const node = this.controller.mainEditorState.doc.resolve(
+      this.getPos(),
+    ).nodeAfter;
+    if (node) {
+      this.setSelectionAt(this.getPos() + node.nodeSize);
+    }
+  }
+
+  selectBeforeNode() {
+    this.setSelectionAt(this.getPos());
+  }
+}

--- a/addon/modifiers/leave-with-arrow-keys.ts
+++ b/addon/modifiers/leave-with-arrow-keys.ts
@@ -25,6 +25,7 @@ export default class LeaveWithArrowKeysModifier extends Modifier {
   constructor(owner, args) {
     super(owner, args);
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     registerDestructor(this, removeListeners);
   }
 

--- a/addon/modifiers/select-node-on-click.ts
+++ b/addon/modifiers/select-node-on-click.ts
@@ -1,5 +1,6 @@
 import { modifier } from 'ember-modifier';
 import { NodeSelection } from 'prosemirror-state';
+import { SayController } from '..';
 
 /* Set the node selection of the node given by `getPos` when clicking the bound element. */
 export default modifier(

--- a/addon/modifiers/select-node-on-click.ts
+++ b/addon/modifiers/select-node-on-click.ts
@@ -9,9 +9,9 @@ export default modifier(
     [controller, getPos]: [SayController, () => number | undefined],
   ) {
     const selectOnClick = () => {
-      if (getPos === undefined) return;
-
       const startPosNode = getPos();
+      if (startPosNode === undefined) return;
+
       const state = controller.mainEditorState;
 
       const tr = state.tr;

--- a/addon/modifiers/select-node-on-click.ts
+++ b/addon/modifiers/select-node-on-click.ts
@@ -1,0 +1,28 @@
+import { modifier } from 'ember-modifier';
+import { NodeSelection } from 'prosemirror-state';
+
+/* Set the node selection of the node given by `getPos` when clicking the bound element. */
+export default modifier(
+  function selectNodeOnClick(
+    element: HTMLElement,
+    [controller, getPos]: [SayController, () => number | undefined],
+  ) {
+    const selectOnClick = () => {
+      if (getPos === undefined) return;
+
+      const startPosNode = getPos();
+      const state = controller.mainEditorState;
+
+      const tr = state.tr;
+      tr.setSelection(NodeSelection.create(state.doc, startPosNode));
+      controller.mainEditorView.dispatch(tr);
+    };
+
+    element.addEventListener('click', selectOnClick);
+
+    return () => {
+      element.removeEventListener('click', selectOnClick);
+    };
+  },
+  { eager: false },
+);

--- a/app/modifiers/leave-with-arrow-keys.js
+++ b/app/modifiers/leave-with-arrow-keys.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/modifiers/leave-with-arrow-keys';

--- a/app/modifiers/select-node-on-click.js
+++ b/app/modifiers/select-node-on-click.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/modifiers/select-node-on-click';

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "@types/ember__component": "~4.0",
         "@types/ember__controller": "~4.0",
         "@types/ember__debug": "~4.0",
+        "@types/ember__destroyable": "^4.0.2",
         "@types/ember__engine": "~4.0",
         "@types/ember__error": "~4.0",
         "@types/ember__object": "~4.0",
@@ -4760,6 +4761,12 @@
         "@types/ember__object": "*",
         "@types/ember__owner": "*"
       }
+    },
+    "node_modules/@types/ember__destroyable": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ember__destroyable/-/ember__destroyable-4.0.2.tgz",
+      "integrity": "sha512-1aBorZlXN06iAo51qE04xF5VH+KiULLVIfCu4bV7cW/bgGaV5myTS7C38xrtua1sPSpZDMMvHeqFOzmFnVJZEw==",
+      "dev": true
     },
     "node_modules/@types/ember__engine": {
       "version": "4.0.4",
@@ -38981,6 +38988,12 @@
         "@types/ember__object": "*",
         "@types/ember__owner": "*"
       }
+    },
+    "@types/ember__destroyable": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/ember__destroyable/-/ember__destroyable-4.0.2.tgz",
+      "integrity": "sha512-1aBorZlXN06iAo51qE04xF5VH+KiULLVIfCu4bV7cW/bgGaV5myTS7C38xrtua1sPSpZDMMvHeqFOzmFnVJZEw==",
+      "dev": true
     },
     "@types/ember__engine": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@types/ember__component": "~4.0",
     "@types/ember__controller": "~4.0",
     "@types/ember__debug": "~4.0",
+    "@types/ember__destroyable": "^4.0.2",
     "@types/ember__engine": "~4.0",
     "@types/ember__error": "~4.0",
     "@types/ember__object": "~4.0",
@@ -139,6 +140,7 @@
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.2",
+    "ember-modifier": "^3.2.7",
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^6.0.0",
     "ember-resolver": "^11.0.1",
@@ -164,8 +166,7 @@
     "sass": "^1.49.9",
     "sinon": "^15.0.1",
     "typescript": "~5.0.4",
-    "webpack": "^5.74.0",
-    "ember-modifier": "^3.2.7"
+    "webpack": "^5.74.0"
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.4.2",


### PR DESCRIPTION
### Overview
https://github.com/lblod/ember-rdfa-editor/pull/946 seemed to still have a problem sometimes where pressing enter did not place the cursor correctly. With console logging, it seemed that the getter did not get the updated position value. (note: this getter is also done in embeddable-editor, but didn't come across the same problem there).
The fix is to just pass the `getPos` function and use that to get the position. This way it is definitely the correct (updated) position and the whole ember-tracking is fully skipped instead.

This also adds two other modifiers that keep the same syntax for ease of understanding.
Both are used in number-variable (usage not changed, this is purely a "refactor")
`leave-with-arrow-keys` lets you use the left and right arrow key to leave a certain element.
`select-node-on-click` selects the node passed when the given bound element is clicked. 


##### connected issues and PRs:
https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?selectedIssue=GN-4433
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/285


### Setup
for the fix, no setup needed.
For the extra modifiers, `npm link` this repo and `npm link @lblod/ember-rdfa-editor` in the plugins repo. Then `ember serve` the plugins repo.

### How to test/reproduce
add a link, see that enter puts the cursor `after` the node, always. Even when typing in extra text.

For the other modifiers: see no change in usage of arrow keys and enter for a number variable.

### Challenges/uncertainties
This started out as a sort of test to see if modifier could work and clean up the code.
I am convinced these are amazing to use. They decrease a lot of the code in the components and keep related code together, help reusability and abstract away harder-to-grasp "on 'keyup' " listeners.

Class based modifiers feel very ugly because of all the null checking. But as the `modifier` function sets what is needed, I don't think there is a better way to handle this?