### PR TITLE
GN-4482: Bugfix - Allow mark toggle with spaces at edge of selection

### DIFF
--- a/.changeset/witty-fireants-punch.md
+++ b/.changeset/witty-fireants-punch.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+GN4482: Bugfix - allow toggling marks if spaces are included at the start or end of the selection

--- a/addon/commands/toggle-mark-add-first.ts
+++ b/addon/commands/toggle-mark-add-first.ts
@@ -1,5 +1,5 @@
 import { PNode } from '@lblod/ember-rdfa-editor';
-import { Attrs, MarkType } from 'prosemirror-model';
+import { Attrs, MarkType, ResolvedPos } from 'prosemirror-model';
 import { Command, SelectionRange, TextSelection } from 'prosemirror-state';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
 
@@ -51,12 +51,36 @@ function markApplies(
   return false;
 }
 
+/* return { from, to } with the positions adjusted so any starting or ending spaces
+ are not part of the range anymore. */
+function fromToWithoutEdgeSpaces(
+  $from: ResolvedPos,
+  $to: ResolvedPos,
+): { from: number; to: number } {
+  let from = $from.pos;
+  let to = $to.pos;
+  const start = $from.nodeAfter;
+  const end = $to.nodeBefore;
+
+  const spaceStart =
+    start && start.isText
+      ? unwrap(/^\s*/.exec(unwrap(start.text)))[0].length
+      : 0;
+  const spaceEnd =
+    end && end.isText ? unwrap(/\s*$/.exec(unwrap(end.text)))[0].length : 0;
+  if (from + spaceStart < to) {
+    from += spaceStart;
+    to -= spaceEnd;
+  }
+  return { from, to };
+}
+
 /**
  * Adapted from https://github.com/ProseMirror/prosemirror-commands/blob/7635496296b2e561a5893b03154bd89c127a6972/src/commands.ts#L579
  * Create a command function that toggles the given mark with the
  * given attributes. Will return `false` when the current selection
- * doesn't support that mark. This will remove the mark if any marks
- * of that type exist in the selection, or add it otherwise. If the
+ * doesn't support that mark. This adds the mark if any marks of that type
+ * are missing in the selection, or remove it from the whole selection otherwise.* If the
  * selection is empty, this applies to the {@link EditorState#storedMarks stored marks}
  * instead of a range of the document.
  *
@@ -84,29 +108,22 @@ export function toggleMarkAddFirst(
         const tr = state.tr;
         for (let i = 0; !has && i < ranges.length; i++) {
           const { $from, $to } = ranges[i];
-          has = rangeHasMarkEverywhere(state.doc, $from.pos, $to.pos, markType);
+          // don't check the spaces before and after, as these might not contain the mark
+          // as expected because of the special `space logic` below.
+          const { from, to } = fromToWithoutEdgeSpaces($from, $to);
+          has = rangeHasMarkEverywhere(state.doc, from, to, markType);
         }
         for (let i = 0; i < ranges.length; i++) {
           const { $from, $to } = ranges[i];
           if (has) {
             tr.removeMark($from.pos, $to.pos, markType);
           } else {
-            let from = $from.pos;
-            let to = $to.pos;
-            const start = $from.nodeAfter;
-            const end = $to.nodeBefore;
-            const spaceStart =
-              start && start.isText
-                ? unwrap(/^\s*/.exec(unwrap(start.text)))[0].length
-                : 0;
-            const spaceEnd =
-              end && end.isText
-                ? unwrap(/\s*$/.exec(unwrap(end.text)))[0].length
-                : 0;
-            if (from + spaceStart < to) {
-              from += spaceStart;
-              to -= spaceEnd;
-            }
+            // ### space logic ###
+            // if adding marks, do not add it the starting/final spaces,
+            // to avoid the mark still applying when typing behind this space.
+            // e.g. with text (between * highlighted)= `*ab *some text`, and setting bold
+            // we don't want to have the new typed text be bold if putting the cursor between `*s`.
+            const { from, to } = fromToWithoutEdgeSpaces($from, $to);
             tr.addMark(from, to, markType.create(attrs));
           }
         }


### PR DESCRIPTION
### Overview
Bug from feedback of embeddable.
When selecting text with spaces before/after and toggling the mark, it will not work to toggle it back off.

Toggling a mark would apply this mark to every letter, except spaces at the edge. When toggling back, it would check if *everything* has the mark, to unapply it. And edge space would never have the mark, creating this bug.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4482 "Applying marks with ending-space bug"

### How to test/reproduce
The bug:
1. add a piece of text with before or after a space. e.g. ` text`
2. select *all* the text (including space) and apply a mark
3. Undoing the mark is not possible in any way as long as the space is selected.

Fixed:
Can undo/redo the mark however you want, with whatever selection.
Note that the spaces at the end/beginning of a selection do not get the mark (use prosemirror debug structure tool).

### Challenges/uncertainties
- It wasn't specified why this specific space-logic was added. I made a guess and added this as a comment, but I'm not sure if this is the only reason.
- Because of how it works, you can still bold a line with only spaces (or a space itself). This feels both weird and logical. It might be an idea to not allow mark toggles on selections with only spaces, but that's more (complicated) code to maintain and might create some confusion for edge cases we don't know about. So I chose to leave that as it is.
