### PR TITLE
GN-4482: color-selector UX - make button bigger and more easily clickable

### DIFF
--- a/.changeset/chilly-tables-melt.md
+++ b/.changeset/chilly-tables-melt.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+GN-4482: Color Picker UX - increase the clickable size of the color picker color-buttons

--- a/app/styles/ember-rdfa-editor/_c-color-selector.scss
+++ b/app/styles/ember-rdfa-editor/_c-color-selector.scss
@@ -6,8 +6,8 @@
     justify-items: center;
     padding: 5px;
     > * {
-      width: 15px;
-      height: 15px;
+      width: 20px;
+      height: 20px;
       border-radius: 50%;
       border: none;
     
@@ -15,6 +15,17 @@
         border: 1px solid black;
         cursor: pointer;
       }
+    }
+    // make clickable outside of button too
+    button::before {
+      content:'';
+      position:relative;
+      padding-left: 20px;
+      padding-right: 20px;
+      padding-top: 5px;
+      padding-bottom: 5px;
+      left: -10px;
+      top: -5px;
     }
   }
 

--- a/app/styles/ember-rdfa-editor/_c-color-selector.scss
+++ b/app/styles/ember-rdfa-editor/_c-color-selector.scss
@@ -5,27 +5,29 @@
     gap: 10px 5px;
     justify-items: center;
     padding: 5px;
-    > * {
+
+    >* {
       width: 20px;
       height: 20px;
       border-radius: 50%;
       border: none;
-    
+
       &:hover {
         border: 1px solid black;
         cursor: pointer;
       }
-    }
-    // make clickable outside of button too
-    button::before {
-      content:'';
-      position:relative;
-      padding-left: 20px;
-      padding-right: 20px;
-      padding-top: 5px;
-      padding-bottom: 5px;
-      left: -10px;
-      top: -5px;
+
+      // make clickable outside of element too
+      &::before {
+        content: '';
+        position: relative;
+        padding-left: 20px;
+        padding-right: 20px;
+        padding-top: 5px;
+        padding-bottom: 5px;
+        left: -10px;
+        top: -5px;
+      }
     }
   }
 


### PR DESCRIPTION
### Overview
Feedback embeddable:
The color picker has too small buttons to click (the round color buttons).

This is fixed in two ways:
- make color-circles (buttons) a bit bigger, but keeping the general look
- increase clickable space for color-circles outside of the button.


##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4482 : Highlight color picker

### How to test/reproduce
open the color picker (in the toolbar).
Before: had to perfectly click the circle.
Now: there is some leeway to click a button. 

Note that clicking should always be what is show with a black circle and there should be no weird "bugs".

### Challenges/uncertainties
To make the space to click bigger, a small "css hack" is used by using an element with `::before`. This is a well known way to do this.
The margins and placement of the element didn't seem to make a ton of sense (but definitely partially me not being a CSS wizard yet :) ). So I mostly got the values via trail&error.
The placement is also not centered, but more to the right, which I think is the typical way to support something like this, but I'm not sure.
