### PR TITLE
Fix `when` statement of changeset CI pipeline

### DIFF
--- a/.woodpecker/.changeset.yml
+++ b/.woodpecker/.changeset.yml
@@ -5,5 +5,4 @@ steps:
       - git fetch origin master
       - git diff -wb --name-only origin/master..HEAD | grep "\.changeset/.*\.md"
 when:
-  event: pull_request
-  evaluate: 'not (CI_COMMIT_PULL_REQUEST_LABELS contains "dependabot")'
+  - evaluate: 'CI_PIPELINE_EVENT == "pull_request" && not (CI_COMMIT_PULL_REQUEST_LABELS contains "dependabot")'


### PR DESCRIPTION
### Overview
Modifies `changeset` woodpecker pipeline so that the event type and pull request labels are both checked in the `evaluate` condition.
