### PR TITLE
Add ember-source as a peerdependency

### DIFF
--- a/.changeset/rich-scissors-allow.md
+++ b/.changeset/rich-scissors-allow.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add ember-source as a peerdependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,7 +150,8 @@
         "@appuniversum/ember-appuniversum": "^2.4.2",
         "@glint/template": "^1.1.0",
         "ember-cli-sass": "^11.0.1",
-        "ember-modifier": "^3.2.7"
+        "ember-modifier": "^3.2.7",
+        "ember-source": "^3.28.0 || ^4.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,8 @@
     "@appuniversum/ember-appuniversum": "^2.4.2",
     "@glint/template": "^1.1.0",
     "ember-cli-sass": "^11.0.1",
-    "ember-modifier": "^3.2.7"
+    "ember-modifier": "^3.2.7",
+    "ember-source": "^3.28.0 || ^4.0.0"
   },
   "overrides": {
     "ember-intl": {


### PR DESCRIPTION
### Overview
While `ember-source` was always a requirement in order to use this project, it was never explicitly added as a peer-dependency. This PR adds the `ember-source` package as a required peer-dependency, with the following semver range: `"^3.28.0 || ^4.0.0"`.
