### PR TITLE
GN-4531: Deselect nested nodes when deselecting embedded editor

### DIFF
--- a/.changeset/lemon-ants-dream.md
+++ b/.changeset/lemon-ants-dream.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+GN-4531 Fix unfocusing of nested variable nodes when clicking main editor

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -36,6 +36,7 @@ import {
   Selection,
   Step,
   StepMap,
+  TextSelection,
   Transaction,
 } from '@lblod/ember-rdfa-editor';
 import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
@@ -204,6 +205,12 @@ export default class EmbeddedEditor extends Component<Args> {
       );
 
       this.innerView.focus();
+    } else if (this.innerView) {
+      const state = this.innerView.state;
+      // De-select the inner node if we're no longer selected
+      this.dispatchInner(
+        state.tr.setSelection(TextSelection.create(state.doc, 0, 0)),
+      );
     }
   }
 


### PR DESCRIPTION
### Overview
Handle selected state of nested variable nodes when deselecting the parent node, so we no longer have a nested node remaining in a 'selected' state visually.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4531

### Setup
N/A

### How to test/reproduce
- Log in as a schrijver
- create an agenda point using the "Aanvullend Reglement besluit" template
- insert a traffic measure with a location
- select the location and insert an address (the address should be nested in the location and selected)
- Click into the main editor, the blue outline for the address remains

### Challenges/uncertainties
N/A



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
