### PR TITLE
Export say-content styling as a Sass mixin

### DIFF
--- a/.changeset/tender-poems-ring.md
+++ b/.changeset/tender-poems-ring.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+export a Sass mixin `say-content` that contains the style of the class `say-content`

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -39,7 +39,7 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
 /* Component
   ========================================================================== */
 
-.say-content {
+@mixin say-content() {
   // Set base font size for elements
   &,
   ul,
@@ -421,3 +421,6 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
   }
 }
 
+.say-content {
+  @include say-content();
+}


### PR DESCRIPTION
### Overview
needed for [GN PR 585](https://github.com/lblod/frontend-gelinkt-notuleren/pull/585)
Exports the say-content styling as a mixin, so it can be included in other classes.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4210 (note: this PR does not fix the ticket)
needed for https://github.com/lblod/frontend-gelinkt-notuleren/pull/585

### Setup/How to test/reproduce
see https://github.com/lblod/frontend-gelinkt-notuleren/pull/585 for specific tests.

