### PR TITLE
Remove unnecessary z-index css declaration from image resize-handles

### DIFF
--- a/.changeset/tiny-moose-fix.md
+++ b/.changeset/tiny-moose-fix.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Remove unnecessary z-index: 1 css declaration from image resize-handles

--- a/app/styles/ember-rdfa-editor/_c-image.scss
+++ b/app/styles/ember-rdfa-editor/_c-image.scss
@@ -44,7 +44,6 @@
     padding: 0;
 
     .say-image__resize__handle {
-      z-index: 1;
       width: 8px;
       height: 8px;
       background-color: var(--au-blue-500);
@@ -81,7 +80,7 @@
       left: 0;
       right: 0;
       margin-left: auto;
-      margin-right: auto; 
+      margin-right: auto;
       top: -5px;
       cursor: n-resize;
     }


### PR DESCRIPTION
### Overview
This PR removes the unnecessary `z-index: 1` css declaration from the image resize handles.
This solves an issue with the handles being displayed above the editor toolbar on small screen sizes.


##### connected issues and PRs:
[GN-4205](https://binnenland.atlassian.net/browse/GN-4205?atlOrigin=eyJpIjoiYTBhYmVmNTY4YjIxNGU3OTk0MDI3YzQ5MTI4OTA2MDIiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the dummy app
- Insert an image
- Resize the editor so that the toolbar is collapsed
- Notice that when toggling the toolbar popup with an image behind it, the handles are no longer visible.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
