### PR TITLE
Ensure links in outputted html open in new tab

### DIFF
--- a/.changeset/three-forks-try.md
+++ b/.changeset/three-forks-try.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Add `target: '_blank'` attribute to outputted html of a link

--- a/addon/plugins/link/mark/link.ts
+++ b/addon/plugins/link/mark/link.ts
@@ -19,7 +19,7 @@ export const link: MarkSpec = {
     },
   ],
   toDOM(mark) {
-    return ['a', mark.attrs, 0];
+    return ['a', { target: '_blank', ...mark.attrs }, 0];
   },
   hasRdfa: true,
   parseTag: 'a',

--- a/addon/plugins/link/nodes/link.ts
+++ b/addon/plugins/link/nodes/link.ts
@@ -45,7 +45,8 @@ const emberNodeConfig: (options: LinkOptions) => EmberNodeConfig = (
     toDOM(node) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { interactive, placeholder, ...attrs } = node.attrs;
-      return ['a', attrs, 0];
+      const outputAttrs = { target: '_blank', ...attrs };
+      return ['a', outputAttrs, 0];
     },
   };
 };


### PR DESCRIPTION
### Overview
This PR ensures that a `target: "_blank"` attribute is added to the `toDOM` of both the link mark and node to ensure that links in the outputted html is opened in a new tab.

### How to test/reproduce
- Start the dummy app
- Insert a link with a valid url and text
- Export the editor content to static html
- Ensure that when clicking the outputted links, they are opened in a new tab.

### Challenges/uncertainties
Technically, this change is breaking, as links in the exported html now open in a new tab by default. However, this change streamlines the behaviour with the behaviour of links in-editor.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] changelog
- [x] npm lint
- [x] no new deprecations
