### PR TITLE
GN-4130: Remove styles for data-editor-highlight

### DIFF
--- a/.changeset/flat-onions-suffer.md
+++ b/.changeset/flat-onions-suffer.md
@@ -1,0 +1,9 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+GN-4130: Remove "data-editor-highlight" styled
+
+Removes styles that were affecting elements with the "data-editor-highlight" attribute.  
+Styles are moved to [ember-rdfa-editor-lblod-plugins](https://github.com/lblod/ember-rdfa-editor-lblod-plugins) and are  
+applied through the `citation-plugin`.

--- a/app/styles/ember-rdfa-editor/_c-annotation-content-en.scss
+++ b/app/styles/ember-rdfa-editor/_c-annotation-content-en.scss
@@ -4,9 +4,6 @@
 
 [data--language='en'] .rdfa-annotations:not(.show-rdfa-blocks),
 [lang='en'] .rdfa-annotations:not(.show-rdfa-blocks),
-[data--language='en']
-  .rdfa-annotations.show-rdfa-blocks
-  [data-editor-highlight='true'],
 [data--language='en'] .rdfa-annotations.show-rdfa-blocks [property],
 [data--language='en']
   .rdfa-annotations.show-rdfa-blocks
@@ -14,7 +11,6 @@
 [data--language='en'] .rdfa-annotations.show-rdfa-blocks [data-type],
 [data--language='en'] .rdfa-annotations.show-rdfa-blocks .mark-highlight-manual,
 [data--language='en'] .rdfa-annotations.show-rdfa-blocks.show-rdfa-blocks,
-[lang='en'] .rdfa-annotations.show-rdfa-blocks [data-editor-highlight='true'],
 [lang='en'] .rdfa-annotations.show-rdfa-blocks [property],
 [lang='en']
   .rdfa-annotations.show-rdfa-blocks
@@ -314,9 +310,6 @@
   }
 }
 
-[data--language='en']
-  .rdfa-annotations.show-rdfa-blocks
-  [data-editor-highlight='true'],
 [data--language='en'] .rdfa-annotations.show-rdfa-blocks [property],
 [data--language='en']
   .rdfa-annotations.show-rdfa-blocks
@@ -324,7 +317,6 @@
 [data--language='en'] .rdfa-annotations.show-rdfa-blocks [data-type],
 [data--language='en'] .rdfa-annotations.show-rdfa-blocks .mark-highlight-manual,
 [data--language='en'] .rdfa-annotations.show-rdfa-blocks.show-rdfa-blocks,
-[lang='en'] .rdfa-annotations.show-rdfa-blocks [data-editor-highlight='true'],
 [lang='en'] .rdfa-annotations.show-rdfa-blocks [property],
 [lang='en']
   .rdfa-annotations.show-rdfa-blocks
@@ -334,9 +326,7 @@
 [lang='en'] .rdfa-annotations.show-rdfa-blocks {
   /* -------------------- Guiding tags ------------------------- */
 
-  [property^='ext:insert']:before,
-  [data-editor-highlight='true']:before,
-  [data-editor-highlight='true']:not([contenteditable='']):before {
+  [property^='ext:insert']:before {
     content: 'Select an option';
   }
 
@@ -674,8 +664,7 @@
 
 [data--language='en'] .rdfa-annotations.show-rdfa-blocks,
 [lang='en'] .rdfa-annotations.show-rdfa-blocks {
-  .mark-highlight-manual:after,
-  [data-editor-highlight='true']:not([contenteditable='']):after {
+  .mark-highlight-manual:after {
     content: 'Action required';
   }
 }

--- a/app/styles/ember-rdfa-editor/_c-annotation-content-nl.scss
+++ b/app/styles/ember-rdfa-editor/_c-annotation-content-nl.scss
@@ -3,7 +3,6 @@
 //   ================================== */
 
 .rdfa-annotations:not(.show-rdfa-blocks),
-.rdfa-annotations.show-rdfa-blocks [data-editor-highlight='true'],
 .rdfa-annotations.show-rdfa-blocks [property],
 .rdfa-annotations.show-rdfa-blocks [typeof]:not([typeof='foaf:Document']),
 .rdfa-annotations.show-rdfa-blocks [data-type],
@@ -301,7 +300,6 @@
   }
 }
 
-.rdfa-annotations.show-rdfa-blocks [data-editor-highlight='true'],
 .rdfa-annotations.show-rdfa-blocks [property],
 .rdfa-annotations.show-rdfa-blocks [typeof]:not([typeof='foaf:Document']),
 .rdfa-annotations.show-rdfa-blocks [data-type],
@@ -309,9 +307,7 @@
 .rdfa-annotations.show-rdfa-blocks {
   /* -------------------- Guiding tags ------------------------- */
 
-  [property^='ext:insert']:before,
-  [data-editor-highlight='true']:before,
-  [data-editor-highlight='true']:not([contenteditable='']):before {
+  [property^='ext:insert']:before {
     content: 'Selecteer de juiste optie';
   }
 
@@ -745,12 +741,6 @@
     content: 'Ondertekenaars';
   }
 
-  [property='ext:behandelt'] [data-editor-highlight='true'] {
-    &:before {
-      content: 'Selecteer de juiste optie';
-    }
-  }
-
   // rewind
   [typeof='besluit:Zitting'] {
     position: relative;
@@ -939,8 +929,7 @@
 }
 
 .rdfa-annotations.show-rdfa-blocks {
-  .mark-highlight-manual:after,
-  [data-editor-highlight='true']:not([contenteditable='']):after {
+  .mark-highlight-manual:after {
     content: 'Actie nodig';
   }
 }

--- a/app/styles/ember-rdfa-editor/_c-annotation-hover.scss
+++ b/app/styles/ember-rdfa-editor/_c-annotation-hover.scss
@@ -34,7 +34,6 @@
   [property="say:hasPart"],
   [property="openbaar"],
   [property^="ext"]:not([property="ext:heeftAfwezigeBijAgendapunt"]):not(span),
-  [data-editor-highlight="true"]:not(ol):not(ul):not(li):not(span),
   [typeof="http://data.vlaanderen.be/ns/besluit#Besluit http://data.vlaanderen.be/ns/besluit#AanvullendReglement"],
   [typeof="besluit:Artikel"],
   [typeof="say:Article"],
@@ -54,8 +53,7 @@
   // Style before and after elements
   [typeof]:not([typeof='foaf:Document']),
   [property],
-  [data-type],
-  [data-editor-highlight='true']:not([contenteditable='']) {
+  [data-type] {
     &:hover {
       border-bottom-color: tint($au-gray-600, 20);
     }
@@ -155,8 +153,7 @@
     // Hide all hover annotations on small screens
     [typeof]:not([typeof='foaf:Document']),
     [property],
-    [data-type],
-    [data-editor-highlight='true'] {
+    [data-type] {
       &:before {
         display: none !important;
       }

--- a/app/styles/ember-rdfa-editor/_c-annotation.scss
+++ b/app/styles/ember-rdfa-editor/_c-annotation.scss
@@ -58,7 +58,6 @@ $say-annotation-background-color: var(--au-gray-100) !default;
   }
 
   // Show underlines on annotation
-  [data-editor-highlight='true']:not([contenteditable='']),
   [property],
   [typeof]:not([typeof='foaf:Document']),
   [data-type],
@@ -80,8 +79,7 @@ $say-annotation-background-color: var(--au-gray-100) !default;
   }
 
   // Making it easy to discover elements that need to be filled out / take action upon
-  [property^='ext:insert'],
-  [data-editor-highlight='true']:not([contenteditable='']) {
+  [property^='ext:insert'] {
     background-color: $say-editor-highlight-color;
     transition: background-color var(--au-transition);
 

--- a/app/styles/ember-rdfa-editor/_c-annotation.scss
+++ b/app/styles/ember-rdfa-editor/_c-annotation.scss
@@ -182,7 +182,6 @@ $say-annotation-background-color: var(--au-gray-100) !default;
 
 // Show RDFA blocks
 .rdfa-annotations.show-rdfa-blocks {
-  [data-editor-highlight='true'],
   [property],
   [typeof]:not([typeof='foaf:Document']),
   [data-type],
@@ -218,8 +217,7 @@ $say-annotation-background-color: var(--au-gray-100) !default;
   }
 
   // Add help text on highlights
-  .mark-highlight-manual:after,
-  [data-editor-highlight='true']:not([contenteditable='']):after {
+  .mark-highlight-manual:after {
     @include au-font-size($say-smallest-font-size, 1.2);
     font-family: var(--au-font);
     font-weight: var(--au-regular);


### PR DESCRIPTION
### Overview

GN-4130: Move styles for `data-editor-highlight` 

Styles that were applied to elements with the `data-editor-highlight` attribute (used by `citation-plugin`) moved from [editor repository](https://github.com/lblod/ember-rdfa-editor/pull/1013) to [ember-rdfa-editor-lblod-plugins](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/343) as part of the `citation-plugin`.

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4130

### Setup
1. Checkout https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/343
2. Checkout https://github.com/lblod/ember-rdfa-editor/pull/1013
3. Build `ember-rdfa-editor`
4. `yalc publish` the `ember-rdfa-editor`
5. `yalc add @lblod/ember-rdfa-editor` inside `ember-rdfa-editor-lblod-plugins`

### How to test/reproduce

Confirm that styling is still shown correctly for inline citation search, note the styles on "hello" word in the below screenshot

<img width="118" alt="CleanShot 2023-11-02 at 11 21 27@2x" src="https://github.com/lblod/ember-rdfa-editor-lblod-plugins/assets/769698/a6b7edaa-2e3b-4135-9c00-b649b0571f00">

### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check if dummy app is correctly updated
- [X] Check cancel/go-back flows
- [X] changelog
- [X] npm lint
- [X] no new deprecations
