### PR TITLE
Hide text cursor when `ProseMirror-hideselection` class is applied to editor content

### DIFF
--- a/.changeset/late-cheetahs-share.md
+++ b/.changeset/late-cheetahs-share.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Hide caret when `ProseMirror-hideselection` class is applied

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -423,4 +423,10 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
 
 .say-content {
   @include say-content();
+
+  &.ProseMirror-hideselection {
+    caret-color: transparent;
+  }
 }
+
+


### PR DESCRIPTION
### Overview
This PR ensures that the text-cursor in the editor is hidden when the  `ProseMirror-hideselection`  is applied.
This prevents two cursors from appearing at the same time (one real cursor and one gap-cursor for example)

Bef
[gapcursor-before.webm](https://github.com/lblod/ember-rdfa-editor/assets/24712836/794347b9-bb81-443f-b3da-7814499e0950)
ore:

After:
[gapcursor-after.webm](https://github.com/lblod/ember-rdfa-editor/assets/24712836/facac391-d597-4ed9-866b-4f550894408f)


##### connected issues and PRs:
None

### How to test/reproduce
- Start the dummy app in a chromium-based browser
- Insert a table
- Set the cursor before the table
- Notice that only one (horizontal) cursor shows up

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
