### PR TITLE
Fix issue with backspacing after inline ember-node in firefox

### DIFF
--- a/.changeset/green-fireants-approve.md
+++ b/.changeset/green-fireants-approve.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Fix issue in firefox with backspacing after inline ember-nodes

--- a/addon/plugins/firefox-cursor-fix/index.ts
+++ b/addon/plugins/firefox-cursor-fix/index.ts
@@ -27,10 +27,12 @@ export function firefoxCursorFix(): ProsePlugin {
           }
           // The problematic position is reached AFTER we backspace the char right after the problematic node
           // so we have to check one position in advance
-          const $posToCheck = $from.parent.resolve($from.parentOffset - 1);
+          const $posToCheck = view.state.doc.resolve($from.pos - 1);
           const nodeBefore = $posToCheck.nodeBefore;
           if (nodeBefore && nodeBefore.type.spec.needsFFKludge) {
-            view.dispatch(view.state.tr.deleteRange($posToCheck.pos, from));
+            const tr = view.state.tr;
+            tr.deleteRange($posToCheck.pos, from);
+            view.dispatch(tr);
             return true;
           }
         }


### PR DESCRIPTION
### Overview
This PR fixes an issue with backspacing after inline ember-nodes (such as the link node). 
The issue comprised the deletion of a too large range in the backspace handler of the `firefoxCursorFix` plugin.

### How to test/reproduce

Without this fix:
- Insert a link (without text) at the start of the document
- Type some characters after the link: e.g. <link>test
- Backspace all characters but one after the link: <link>t
- Backspace again. Notice that the link is also removed

With this fix:
- Insert a link (without text) at the start of the document
- Type some characters after the link: e.g. <link>test
- Backspace all characters but one after the link: <link>t
- Backspace again. Notice that the link is not removed



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
