### PR TITLE
Deprecate custom `SetDocAttributeStep` step

### DIFF
--- a/.changeset/mighty-bears-play.md
+++ b/.changeset/mighty-bears-play.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Deprecate usage of `SetDocAttributeStep` in favour of native `DocAttrStep` or `setDocAttribute` method of the `Transform` class

--- a/.changeset/tame-seahorses-smash.md
+++ b/.changeset/tame-seahorses-smash.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Use native `setDocAttribute` method of the `Transform` class to update attributes of the doc node

--- a/addon/core/say-controller.ts
+++ b/addon/core/say-controller.ts
@@ -13,7 +13,6 @@ import {
   Selection,
   Transaction,
 } from 'prosemirror-state';
-import { SetDocAttributeStep } from '@lblod/ember-rdfa-editor/utils/_private/steps';
 import { htmlToDoc } from '@lblod/ember-rdfa-editor/utils/_private/html-utils';
 
 export default class SayController {
@@ -129,14 +128,12 @@ export default class SayController {
   }
 
   set documentLanguage(language: string) {
-    this.withTransaction((tr) => {
-      return tr.step(new SetDocAttributeStep('lang', language));
-    });
+    this.setDocumentAttribute('lang', language);
   }
 
   setDocumentAttribute(key: string, value: unknown) {
     this.withTransaction((tr) => {
-      return tr.step(new SetDocAttributeStep(key, value));
+      return tr.setDocAttribute(key, value);
     });
   }
 

--- a/addon/utils/_private/steps.ts
+++ b/addon/utils/_private/steps.ts
@@ -2,6 +2,10 @@ import { Node, Schema } from 'prosemirror-model';
 import { Step, StepResult } from 'prosemirror-transform';
 
 //Based on https://discuss.prosemirror.net/t/changing-doc-attrs/784/22
+/**
+ * @deprecated
+ * Use the native `DocAttrStep` instead or use the `setDocAttribute` method of the `Transform` class.
+ */
 export class SetDocAttributeStep extends Step {
   private prevValue: unknown;
   static ID = 'setDocAttribute';


### PR DESCRIPTION
### Overview
This PR includes two changes:
- The deprecation of the custom `SetDocAttributeStep` step. The `prosemirror-transform` package now includes a `DocAttrStep`, so our custom step is no longer necessary.
- Replace usages of the custom `SetDocAttributeStep` step by the native `prosemirror-transform` implementation.

##### connected issues and PRs:
None

### How to test/reproduce
- Start the dummy editor with the `dummy plugins` page
- Insert the `counter` ember-node
- Ensure that the document language correctly changes when running `window.__PC.documentLanguage = 'en-US'` or `window.__PC.documentLanguage = 'nl-BE'` 



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
