### PR TITLE
GN-4599: removal of obsolete `__rdfaId` attribute

### DIFF
--- a/.changeset/late-stingrays-clean.md
+++ b/.changeset/late-stingrays-clean.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Introduction of `_guid` attribute on inline-rdfa markspec

--- a/.changeset/sixty-pets-unite.md
+++ b/.changeset/sixty-pets-unite.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Removal of obsolete `__tag` attribute from inline-rdfa markspec and block-rdfa nodespec

--- a/.changeset/wicked-pumpkins-rest.md
+++ b/.changeset/wicked-pumpkins-rest.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Removal of obsolete `__rdfaId` node and mark attribute

--- a/addon/core/say-editor.ts
+++ b/addon/core/say-editor.ts
@@ -97,7 +97,7 @@ export default class SayEditor {
         recreateUuidsOnPaste,
         defaultAttributeValueGeneration([
           {
-            attribute: '__rdfaId',
+            attribute: '_guid',
             generator() {
               return uuidv4();
             },

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import { isSome } from '../utils/_private/option';
 
 export const rdfaAttrs = {

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -20,7 +20,6 @@ export const rdfaAttrs = {
   role: { default: undefined },
   inlist: { default: undefined },
   datetime: { default: undefined },
-  __rdfaId: { default: undefined },
 };
 
 export function getRdfaAttrs(node: Element): Record<string, string> | false {
@@ -34,9 +33,6 @@ export function getRdfaAttrs(node: Element): Record<string, string> | false {
     }
   }
   if (hasAnyRdfaAttributes) {
-    if (!attrs['__rdfaId']) {
-      attrs['__rdfaId'] = uuidv4();
-    }
     return attrs;
   }
   return false;

--- a/addon/marks/inline-rdfa.ts
+++ b/addon/marks/inline-rdfa.ts
@@ -1,10 +1,12 @@
 import { Mark, MarkSpec } from 'prosemirror-model';
 import { getRdfaAttrs, rdfaAttrs } from '@lblod/ember-rdfa-editor';
+import { v4 as uuidv4 } from 'uuid';
 
 export const inline_rdfa: MarkSpec = {
   attrs: {
     ...rdfaAttrs,
     __tag: { default: 'span' },
+    _guid: { default: null },
   },
   group: 'rdfa',
   excludes: '',
@@ -16,14 +18,16 @@ export const inline_rdfa: MarkSpec = {
       getAttrs(node: HTMLElement) {
         const attrs = getRdfaAttrs(node);
         if (attrs) {
-          return attrs;
+          return { ...attrs, _guid: uuidv4() };
         }
         return false;
       },
     },
   ],
   toDOM(mark: Mark) {
-    return ['span', mark.attrs, 0];
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { _guid, ...rdfaAttrs } = mark.attrs;
+    return ['span', rdfaAttrs, 0];
   },
   hasRdfa: true,
   parseTag: 'span',

--- a/addon/marks/inline-rdfa.ts
+++ b/addon/marks/inline-rdfa.ts
@@ -5,7 +5,6 @@ import { v4 as uuidv4 } from 'uuid';
 export const inline_rdfa: MarkSpec = {
   attrs: {
     ...rdfaAttrs,
-    __tag: { default: 'span' },
     _guid: { default: null },
   },
   group: 'rdfa',

--- a/addon/nodes/block-rdfa.ts
+++ b/addon/nodes/block-rdfa.ts
@@ -6,7 +6,6 @@ export const block_rdfa: NodeSpec = {
   group: 'block',
   attrs: {
     ...rdfaAttrs,
-    __tag: { default: 'div' },
   },
   defining: true,
   parseDOM: [
@@ -18,6 +17,6 @@ export const block_rdfa: NodeSpec = {
     },
   ],
   toDOM(node: PNode) {
-    return [node.attrs.__tag, node.attrs, 0];
+    return ['div', node.attrs, 0];
   },
 };

--- a/addon/nodes/invisible-rdfa.ts
+++ b/addon/nodes/invisible-rdfa.ts
@@ -34,11 +34,7 @@ export const invisible_rdfa: NodeSpec = {
     },
   ],
   toDOM(node: PNode) {
-    return [
-      node.attrs.__tag,
-      {
-        ...node.attrs,
-      },
-    ];
+    const { __tag, ...attrs } = node.attrs;
+    return [__tag, attrs];
   },
 };

--- a/addon/utils/_private/rdfa-utils.ts
+++ b/addon/utils/_private/rdfa-utils.ts
@@ -19,8 +19,7 @@ export type RdfaAttr =
   | 'id'
   | 'role'
   | 'inlist'
-  | 'datetime'
-  | '__rdfaId';
+  | 'datetime';
 /**
  * this is used when reading the full editor document to fetch any prefixes defined above the editor
  * NOTE: it adds the active vocab as a prefix with an empty string as key, which makes it a bit easier to pass down

--- a/app/styles/ember-rdfa-editor/_a-custom-components.scss
+++ b/app/styles/ember-rdfa-editor/_a-custom-components.scss
@@ -24,4 +24,3 @@
 @import 'c-annotation-content-nl';
 @import 'c-annotation-content-en';
 @import 'c-formatting-marks';
-@import 'c-block-rdfa';

--- a/app/styles/ember-rdfa-editor/_c-block-rdfa.scss
+++ b/app/styles/ember-rdfa-editor/_c-block-rdfa.scss
@@ -1,5 +1,0 @@
-.ProseMirror-selectednode[__rdfaid] {
-  outline: 2px solid var(--au-blue-500);
-  background-color: var(--au-blue-200);
-  color: var(--au-black);
-}

--- a/tests/unit/prosemirror/marks-test.ts
+++ b/tests/unit/prosemirror/marks-test.ts
@@ -1,0 +1,52 @@
+import { module, test } from 'qunit';
+import TEST_SCHEMA from 'dummy/tests/test-utils';
+import { DOMSerializer } from 'prosemirror-model';
+import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
+
+module('ProseMirror | marks', function () {
+  test('Adjacent styling marks should be merged', function (assert) {
+    const schema = TEST_SCHEMA;
+    const doc = schema.node('doc', {}, [
+      schema.node('paragraph', null, [
+        schema.text('ab', [schema.marks.strong.create()]),
+        schema.text('cd', [schema.marks.strong.create()]),
+      ]),
+    ]);
+    assert.strictEqual(doc.firstChild?.childCount, 1);
+    assert.strictEqual(doc.firstChild?.firstChild?.textContent, 'abcd');
+  });
+  test('Adjacent rdfa marks (with different guids) should not be merged', function (assert) {
+    const schema = TEST_SCHEMA;
+    const doc = schema.node('doc', {}, [
+      schema.node('paragraph', null, [
+        schema.text('ab', [schema.marks.inline_rdfa.create({ _guid: '1' })]),
+        schema.text('cd', [schema.marks.inline_rdfa.create({ _guid: '2' })]),
+      ]),
+    ]);
+    const paragraph = unwrap(doc.firstChild);
+    assert.strictEqual(paragraph.childCount, 2);
+    assert.strictEqual(paragraph.child(0).textContent, 'ab');
+    assert.strictEqual(paragraph.child(1).textContent, 'cd');
+    const html = DOMSerializer.fromSchema(schema).serializeNode(doc);
+    const p_element = unwrap(html.firstChild);
+    assert.strictEqual(p_element.childNodes.length, 2);
+    assert.strictEqual(p_element.childNodes[0].textContent, 'ab');
+    assert.strictEqual(p_element.childNodes[1].textContent, 'cd');
+  });
+  test('Adjacent rdfa marks (with identical guids) should be merged', function (assert) {
+    const schema = TEST_SCHEMA;
+    const doc = schema.node('doc', {}, [
+      schema.node('paragraph', null, [
+        schema.text('ab', [schema.marks.inline_rdfa.create({ _guid: '1' })]),
+        schema.text('cd', [schema.marks.inline_rdfa.create({ _guid: '1' })]),
+      ]),
+    ]);
+    const paragraph = unwrap(doc.firstChild);
+    assert.strictEqual(paragraph.childCount, 1);
+    assert.strictEqual(paragraph.child(0).textContent, 'abcd');
+    const html = DOMSerializer.fromSchema(schema).serializeNode(doc);
+    const p_element = unwrap(html.firstChild);
+    assert.strictEqual(p_element.childNodes.length, 1);
+    assert.strictEqual(p_element.childNodes[0].textContent, 'abcd');
+  });
+});


### PR DESCRIPTION
### Overview
This PR includes the following changes:
- Removal of the obsolete `__rdfaId` node and mark attribute
- Introduction of the `_guid` attribute on the `inline_rdfa` mark: this is to ensure that adjacent marks of this type do not get merged automatically
- Removal of the obsolete `__tag` attribute from the `inline_rdfa` markspec and the `block_rdfa` nodespec

Because of the changes this PR introduces, the  `__tag` and `__rdfaId` attributes are omitted from the produced html. This should result in cleaner and more human-readable html documents.

##### connected issues and PRs:
- [GN-4599](https://binnenland.atlassian.net/browse/GN-4599?atlOrigin=eyJpIjoiYWRmN2RlNWI4NjMzNDkwZThmZDhlYjg1NGMwZGI2MjUiLCJwIjoiaiJ9)

### How to test/reproduce
**Removal of the `__rdfaId` and `__tag` attributes**
- Insert the sample `DecisionTemplate`
- Notice that the outputted html no longer includes the `__rdfaId` and `__tag` attributes
- When inspecting the different nodes in the prosemirror inspector, notice that the `__rdfaId` and `__tag` attributes have been removed from (most) of the nodes

**Introduction of the new `__guid` attribute on `inline_rdfa` marks**
- Import the following html in the dummy editor: 
```html
<p>
   <span resource='a'>ab</span>
   <span resource='a'>cd</span>
</p>
```
- Notice that this results in two seperate text-nodes with two seperate `inline_rdfa` marks containing two seperate `__guid` attributes. The marks are not joined in the resulting html document.

- Import the following html in the dummy editor:
```html
<span resource="a">
foo 
<span property="ext:bar">baz</span>
qux
</span>
```
- Notice this results in three seperate text-nodes. These 3 nodes share an `inline_rdfa` mark with the same `__guid` and attributes. The middle text-node also has an additional `inline_rdfa` mark with the `ext:bar` property-attribute.

The following html should be correctly parsed and serialized:
```html
<span vocab="http://xmlns.com/foaf/0.1/">
  <span resource="#manu" typeof="Person">
    <span property="name">Manu Sporny</span> knows
    <a property="knows" href="#alex">Alex</a> and
    <a property="knows" href="#brian">Brian</a>.
  </span>
  <span resource="#alex" typeof="Person">
    <span property="name">Alex Milowski</span> wrote the RDFa processor for this page.
  </span>
  <span resource="#brian" typeof="Person">
    <span property="name">Brian Sletten</span> wrote the syntax highlighting for the raw data.
  </span>
</span>
```

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
