### PR TITLE
GN-6404: fix behaviour of embedded editor keymap

### DIFF
--- a/.changeset/eighty-balloons-pump.md
+++ b/.changeset/eighty-balloons-pump.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Fix issue with setting keymap of embedded editor

--- a/.changeset/giant-hairs-applaud.md
+++ b/.changeset/giant-hairs-applaud.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Add shift+enter handler to `embeddedEditorBaseKeymap`

--- a/.changeset/spotty-rabbits-hunt.md
+++ b/.changeset/spotty-rabbits-hunt.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Only run `leave-on-enter` modifier when `Enter` has been pressed without modifier keys

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -114,7 +114,7 @@ export default class EmbeddedEditor extends Component<Args> {
         ...undoRedoMap,
       };
     } else {
-      return { ...embeddedEditorBaseKeymap, ...undoRedoMap };
+      return { ...embeddedEditorBaseKeymap(this.schema), ...undoRedoMap };
     }
   }
 

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -172,6 +172,7 @@ export const embeddedEditorBaseKeymap: Keymap = (schema) => {
       splitBlock,
       insertHardBreak,
     ),
+    'Shift-Enter': chainCommands(exitCode, insertHardBreak),
   };
 };
 

--- a/addon/modifiers/leave-on-enter-key.ts
+++ b/addon/modifiers/leave-on-enter-key.ts
@@ -9,7 +9,14 @@ export default modifier(
   ) {
     const leaveOnEnter = (event: KeyboardEvent) => {
       const startPosNode = getPos();
-      if (event.key !== 'Enter' || startPosNode === undefined) return;
+      const modifierKeyPressed =
+        event.shiftKey || event.ctrlKey || event.metaKey || event.altKey;
+      if (
+        modifierKeyPressed ||
+        event.key !== 'Enter' ||
+        startPosNode === undefined
+      )
+        return;
 
       const state = controller.mainEditorState;
       const node = state.doc.resolve(startPosNode).nodeAfter;


### PR DESCRIPTION
### Overview
This PR solves issues with the keymap initialization of an embedded editor instance:
- The default keymap of an embedded editor is now correctly initialized
- An additional `shift+Enter` handler has been added to the default embedded editor keymap
- Only run `leave-on-enter` modifier when `Enter` has been pressed without modifier keys (`Ctrl`, `Alt`, `Shift` or `Cmd`)

##### connected issues and PRs:
[GN-6404](https://binnenland.atlassian.net/browse/GN-4604?atlOrigin=eyJpIjoiMGRiMjJmNTdhNDY0NDRjZmE0NDY0ZDEzNjgwZTQ2NDgiLCJwIjoiaiJ9)

### How to test/reproduce
**Before this fix**
- Set the allowed content of a link to `inline*`
- Insert a link with some text inside
- Notice that none of the editor shortcuts work inside the link (`Mod+b`, `Enter`, `Mod+i` etc.)

**After this fix**
- Set the allowed content of a link to `inline*`
- Disable the `leave-on-enter` modifiers in the link component
- Insert a link with some text inside
- Notice that the editor shortcuts work inside the link (`Mod+b`, `Enter`, `Mod+i` etc.), as well as `shift+Enter`

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
