### PR TITLE
fix(placeholders): fix placeholders not being selectable

### DIFF
--- a/.changeset/lovely-rivers-kneel.md
+++ b/.changeset/lovely-rivers-kneel.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+fix placeholders no longer being selectable with mouse

--- a/addon/plugins/gap-cursor/index.ts
+++ b/addon/plugins/gap-cursor/index.ts
@@ -83,7 +83,6 @@ function arrow(axis: 'vert' | 'horiz', dir: number): Command {
 }
 
 function mousedown(view: EditorView, event: MouseEvent) {
-  console.log('mousedown');
   const clickPos = view.posAtCoords({
     left: event.clientX,
     top: event.clientY,
@@ -111,19 +110,11 @@ function resolvePosition(
   if (parent?.isAtom) {
     return result;
   }
-  while (result.parent !== parent) {
+  while (result.depth > 0 && result.parent !== parent) {
     if (result.index() <= 0) {
       result = view.state.doc.resolve(result.before());
     } else if (result.index() >= result.parent.childCount - 1) {
-      // result.after errors if you call it on a postion at depth 0
-      if (result.depth > 0) {
-        result = view.state.doc.resolve(result.after());
-      } else {
-        console.warn(
-          'GapCursor tried but failed to find a sensible position, returning best guess',
-        );
-        break;
-      }
+      result = view.state.doc.resolve(result.after());
     } else {
       break;
     }

--- a/addon/plugins/gap-cursor/index.ts
+++ b/addon/plugins/gap-cursor/index.ts
@@ -1,6 +1,6 @@
 import { keydownHandler } from 'prosemirror-keymap';
 import { TextSelection, Plugin, Command, EditorState } from 'prosemirror-state';
-import { Fragment, Slice } from 'prosemirror-model';
+import { Fragment, ResolvedPos, Slice } from 'prosemirror-model';
 import { Decoration, DecorationSet, EditorView } from 'prosemirror-view';
 import { GapCursor } from './gap-cursor';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
@@ -83,6 +83,7 @@ function arrow(axis: 'vert' | 'horiz', dir: number): Command {
 }
 
 function mousedown(view: EditorView, event: MouseEvent) {
+  console.log('mousedown');
   const clickPos = view.posAtCoords({
     left: event.clientX,
     top: event.clientY,
@@ -104,14 +105,25 @@ function mousedown(view: EditorView, event: MouseEvent) {
 function resolvePosition(
   view: EditorView,
   { pos, inside }: { pos: number; inside: number },
-) {
+): ResolvedPos {
   let result = view.state.doc.resolve(pos);
   const parent = inside === -1 ? view.state.doc : view.state.doc.nodeAt(inside);
+  if (parent?.isAtom) {
+    return result;
+  }
   while (result.parent !== parent) {
     if (result.index() <= 0) {
       result = view.state.doc.resolve(result.before());
     } else if (result.index() >= result.parent.childCount - 1) {
-      result = view.state.doc.resolve(result.after());
+      // result.after errors if you call it on a postion at depth 0
+      if (result.depth > 0) {
+        result = view.state.doc.resolve(result.after());
+      } else {
+        console.warn(
+          'GapCursor tried but failed to find a sensible position, returning best guess',
+        );
+        break;
+      }
     } else {
       break;
     }


### PR DESCRIPTION
-------

### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

After the improvements to the gapcursor/position resolution from mouseclicks, placeholder nodes
threw erros when clicked on. This was because the position resolution logic tries to
find a position with a parent that is the same parent that the text cursor would have if
it would be standing where you clicked. It does this by walking upwards and comparing the value
of parent with the value of the node at the "inside" position (which prosemirror already calculates).
However, in the case of atom nodes, the first position checked already starts with a parent that
is the parent of the atom, meaning the walk upwards will never result in the correct position.
Additionally, the loop was missing a bounds check for depth=0, which caused the error

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->
best way to test is npm link in the plugin repo, and try out the article structures and their
placeholders

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->

Switching on the node being an atom is an educated and afaict a relatively conservative bet.
There might be more scenarios where the walk upwards will not find the right position.
Additionally this may result in some more scenarios where a good gapcursor can not be found,
since I don't have a reproduction of the cases the original code was trying to solve.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations