### PR TITLE
Add support for `about` attributes when parsing rdfa relationships

### DIFF
--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -75,6 +75,8 @@ export function getRdfaAttrs(node: Element): RdfaAttrs | false {
           logger('rdfaNodeType is not a valid type', value, node);
         }
         if (type === 'resource') {
+          // Attrs of resource nodeTypes have non-optional resource and properties fields, so
+          // ensure that they're set, either to the already parsed values or []/''
           attrs = {
             ...attrs,
             rdfaNodeType: type,


### PR DESCRIPTION
### Overview
Adds `about` to the parsing of rdfa to establish properties and backlinks.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/358

### Setup
Easiest used with the PR from plugins with article structure plugin changes.

### How to test/reproduce
In the latest version of that PR, look at the properties and backlinks for `say:heading` nodes. After refresh, these were not correctly maintained, this PR corrects that.

### Challenges/uncertainties

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
