### PR TITLE
GN-4621: Add styling for selected table cell

### DIFF
--- a/.changeset/slow-jokes-return.md
+++ b/.changeset/slow-jokes-return.md
@@ -1,0 +1,8 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+GN-4621: Add styling for selected table cell
+
+* `.selectedCell` to style the cell that is selected. `.selectedCell` comes from the `prosemirror-tables` plugin. 
+* `::selection` to hide the selection on the text inside the cell.

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -426,6 +426,14 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
 
   &.ProseMirror-hideselection {
     caret-color: transparent;
+
+    *::selection {
+      background: transparent;
+    }
+
+    .selectedCell {
+      background-color: var(--au-blue-100);
+    }
   }
 }
 


### PR DESCRIPTION
### Overview

GN-4621: Add styling for selected table cell

* `.selectedCell` to style the cell that is selected. `.selectedCell` comes from the `prosemirror-tables` plugin. 
* `::selection` to hide the selection on the text inside the cell.


##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4621

### Setup

1. Checkout

### How to test/reproduce

#### Before

https://github.com/lblod/ember-rdfa-editor/assets/769698/cd64f355-4942-4b31-8b00-1a562fd16267
 
#### After

https://github.com/lblod/ember-rdfa-editor/assets/769698/2afeb3e3-51b8-42c2-bfb4-b0a12bdde909 

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations

Closes https://github.com/lblod/ember-rdfa-editor/issues/845
