### PR TITLE
GN-4617: disable `space` invisible in dummy app

### DIFF
--- a/.changeset/warm-guests-rule.md
+++ b/.changeset/warm-guests-rule.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+update formatting-toggle to use custom `au-native-toggle` component

--- a/addon/components/au-native-toggle.hbs
+++ b/addon/components/au-native-toggle.hbs
@@ -1,0 +1,21 @@
+<label
+  for={{@identifier}}
+  class="au-c-toggle-switch
+    {{if (and (not (has-block)) (not @label)) 'au-c-toggle-switch--labelless'}}
+    {{if @disabled 'is-disabled'}}"
+  data-test-toggle-switch-label
+>
+  <input
+    type="checkbox"
+    class="au-c-toggle-switch__input au-u-hidden-visually"
+    id={{@identifier}}
+    name={{@name}}
+    disabled={{@disabled}}
+    data-test-toggle-switch-input
+    ...attributes
+  />
+  <span class="au-c-toggle-switch__toggle"></span>
+  {{#if (has-block)}}
+    {{yield}}
+  {{/if}}
+</label>

--- a/addon/components/plugins/formatting/formatting-toggle.hbs
+++ b/addon/components/plugins/formatting/formatting-toggle.hbs
@@ -1,6 +1,5 @@
 <div class="say-rdfa-toggle">
-  <AuToggleSwitch
-    {{on 'click' this.toggle}}
-    @label={{ t 'ember-rdfa-editor.show-formatting-marks'}}
-  />
+  <AuNativeToggle {{on "change" this.toggle}} checked={{this.isActive}}>
+    {{t "ember-rdfa-editor.show-formatting-marks"}}
+  </AuNativeToggle>
 </div>

--- a/addon/components/plugins/formatting/formatting-toggle.ts
+++ b/addon/components/plugins/formatting/formatting-toggle.ts
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { commands } from '@guardian/prosemirror-invisibles';
+import { commands, selectActiveState } from '@guardian/prosemirror-invisibles';
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 
 type Args = {
@@ -10,6 +10,14 @@ type Args = {
 export default class RdfaBlocksToggleComponent extends Component<Args> {
   get controller() {
     return this.args.controller;
+  }
+
+  get isActive() {
+    if (this.controller) {
+      return selectActiveState(this.controller.mainEditorState);
+    } else {
+      return false;
+    }
   }
   @action
   toggle() {

--- a/app/components/au-native-toggle.js
+++ b/app/components/au-native-toggle.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/components/au-native-toggle';

--- a/tests/dummy/app/controllers/backspace.ts
+++ b/tests/dummy/app/controllers/backspace.ts
@@ -51,7 +51,6 @@ import {
   hardBreak,
   heading as headingInvisible,
   paragraph as paragraphInvisible,
-  space,
 } from '@lblod/ember-rdfa-editor/plugins/invisibles';
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
@@ -135,12 +134,9 @@ export default class BackspaceController extends Controller {
     tablePlugin,
     tableKeymap,
     linkPasteHandler(this.schema.nodes.link),
-    createInvisiblesPlugin(
-      [space, hardBreak, paragraphInvisible, headingInvisible],
-      {
-        shouldShowInvisibles: false,
-      },
-    ),
+    createInvisiblesPlugin([hardBreak, paragraphInvisible, headingInvisible], {
+      shouldShowInvisibles: false,
+    }),
     inputRules({
       rules: [
         bullet_list_input_rule(this.schema.nodes.bullet_list),

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -57,7 +57,6 @@ import {
 import {
   createInvisiblesPlugin,
   hardBreak,
-  space,
   paragraph as paragraphInvisible,
   heading as headingInvisible,
 } from '@lblod/ember-rdfa-editor/plugins/invisibles';
@@ -145,12 +144,9 @@ export default class IndexController extends Controller {
     tablePlugin,
     tableKeymap,
     linkPasteHandler(this.schema.nodes.link),
-    createInvisiblesPlugin(
-      [space, hardBreak, paragraphInvisible, headingInvisible],
-      {
-        shouldShowInvisibles: false,
-      },
-    ),
+    createInvisiblesPlugin([hardBreak, paragraphInvisible, headingInvisible], {
+      shouldShowInvisibles: false,
+    }),
     inputRules({
       rules: [
         bullet_list_input_rule(this.schema.nodes.bullet_list),

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -51,6 +51,7 @@ import {
   hardBreak,
   heading as headingInvisible,
   paragraph as paragraphInvisible,
+  space,
 } from '@lblod/ember-rdfa-editor/plugins/invisibles';
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
@@ -66,7 +67,7 @@ import { PluginConfig } from '@lblod/ember-rdfa-editor';
 import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 import { getOwner } from '@ember/application';
 
-export default class IndexController extends Controller {
+export default class SpaceInvisibleController extends Controller {
   @tracked rdfaEditor?: SayController;
   @service declare intl: IntlService;
   schema = new Schema({
@@ -125,9 +126,12 @@ export default class IndexController extends Controller {
     tablePlugin,
     tableKeymap,
     linkPasteHandler(this.schema.nodes.link),
-    createInvisiblesPlugin([hardBreak, paragraphInvisible, headingInvisible], {
-      shouldShowInvisibles: false,
-    }),
+    createInvisiblesPlugin(
+      [hardBreak, paragraphInvisible, headingInvisible, space],
+      {
+        shouldShowInvisibles: false,
+      },
+    ),
     inputRules({
       rules: [
         bullet_list_input_rule(this.schema.nodes.bullet_list),

--- a/tests/dummy/app/router.ts
+++ b/tests/dummy/app/router.ts
@@ -9,4 +9,5 @@ Router.map(function () {
   this.route('plugins');
   this.route('vendors');
   this.route('backspace');
+  this.route('space-invisible');
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,5 +5,6 @@
   <LinkTo class='navigation-link' @route='plugins'>With Dummy Plugins</LinkTo>
   <LinkTo class='navigation-link' @route='vendors'>Vendor Environment</LinkTo>
   <LinkTo class='navigation-link' @route='backspace'>Alternative Backspace for RDFA nodes</LinkTo>
+  <LinkTo class='navigation-link' @route='space-invisible'>Space Invisible</LinkTo>
 </nav>
 {{outlet}}

--- a/tests/dummy/app/templates/space-invisible.hbs
+++ b/tests/dummy/app/templates/space-invisible.hbs
@@ -1,0 +1,33 @@
+<DummyContainer>
+  <:header>
+    <DebugTools @controller={{this.rdfaEditor}}/>
+  </:header>
+  <:content>
+    <EditorContainer
+      @editorOptions={{hash
+        showRdfa='true'
+        showRdfaHighlight='true'
+        showRdfaHover='true'
+        showPaper='true'
+        showToolbarBottom=null
+      }}
+      @showRdfaBlocks={{this.showRdfaBlocks}}
+    >
+      <:top>
+        <SampleToolbarResponsive @controller={{this.rdfaEditor}}/>
+      </:top>
+      <:default>
+        <Editor
+          @plugins={{this.plugins}}
+          @schema={{this.schema}}
+          @nodeViews={{this.nodeViews}}
+          @rdfaEditorInit={{this.rdfaEditorInit}}/>
+      </:default>
+      <:aside>
+        <Sidebar>
+            <Plugins::Link::LinkEditor @controller={{this.rdfaEditor}}/>
+        </Sidebar>
+      </:aside>
+    </EditorContainer>
+  </:content>
+</DummyContainer>


### PR DESCRIPTION
### Overview
This PR disables the `space` invisible in the dummy application as it causes large slowdowns when pasting large documents/typing in large documents.
Additionally, this PR add a new route to the dummy app with the `space` invisible enabled.

The other formatting marks (pilcrow and carriage return) do not cause a large slowdown as they are way more sparse.

This PR also updates the `formatting-toggle` component to use the custom `au-native-toggle` component.

##### connected issues and PRs:
[GN-4617](https://binnenland.atlassian.net/browse/GN-4617?atlOrigin=eyJpIjoiODUxN2E2NWYzZWQ0NGMxMDk0NzNlNmUxNDEwY2I4ZTUiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the dummy app in firefox/chromium
- Import the `notulen` sample document
- Notice that pasting this document is slower in the `Space Invisible` route.
- Toggling the formatting marks in the `Space Invisible` route with the `notulen` document slows down/crashes both browsers. With the `space` mark enabled, typing happens very slowly.
- When testing the same document in the other routes, no significant slowdown should happen.

### Challenges/uncertainties
- It is (AFAIK) not possible to implement the `space` invisible with css only.
- It is possible (this is also the word-online approach) to use a custom font in which spaces are replaced by dots. This is (IMO) the best way to go forward with this. Jira ticket tracking this: [GN-4643](https://binnenland.atlassian.net/browse/GN-4643?atlOrigin=eyJpIjoiNDYwMDg2NTRkOTFhNDZmOGI4YzZjNWM2NGFjOTVhY2QiLCJwIjoiaiJ9)
- The `prosemirror-invisibles` plugin is a lot more performant when leaving out the `space` invisible.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
