### PR TITLE
Improve behaviour of `delete` and `backspace` keys around atomic inline nodes

### DIFF
--- a/.changeset/curvy-cherries-sniff.md
+++ b/.changeset/curvy-cherries-sniff.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": major
+---
+
+Update logic of entering embedded-editor with arrow-keys

--- a/.changeset/green-files-flash.md
+++ b/.changeset/green-files-flash.md
@@ -1,0 +1,7 @@
+---
+"@lblod/ember-rdfa-editor": major
+---
+
+Introduce custom `select-node-forward` and `select-node-backward` commands with included support for atomic inline nodes. The commands are adapted from the [prosemirror-commands](https://github.com/ProseMirror/prosemirror-commands) package.
+
+These commands are tied to the `delete` and `backspace` keys respectively.

--- a/addon/commands/index.ts
+++ b/addon/commands/index.ts
@@ -11,3 +11,5 @@ export { addType, removeType } from './type-commands';
 export { indentNode } from './indent-node';
 export { reduceIndent } from './reduce-indent';
 export { selectBlockRdfaNode } from './select-block-rdfa';
+export { selectNodeBackward } from './select-node-backward';
+export { selectNodeForward } from './select-node-forward';

--- a/addon/commands/select-node-backward.ts
+++ b/addon/commands/select-node-backward.ts
@@ -1,0 +1,64 @@
+/**
+ * Adapted from https://github.com/ProseMirror/prosemirror-commands with support for selecting atomic inline nodes
+ * Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import { ResolvedPos } from 'prosemirror-model';
+import { Command, NodeSelection } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+
+/// deletion at the selected point.
+export const selectNodeBackward: Command = (state, dispatch, view) => {
+  const { $head, empty } = state.selection;
+  let $cut: ResolvedPos | null = $head;
+  if (!empty) return false;
+
+  if ($head.parent.isTextblock && isAtStartOfTextBlock($head, view)) {
+    $cut = findCutBefore($head);
+  }
+  if (!$cut) {
+    return false;
+  }
+  const node = $cut.nodeBefore;
+  if (!node || !NodeSelection.isSelectable(node)) return false;
+  if (dispatch)
+    dispatch(
+      state.tr
+        .setSelection(NodeSelection.create(state.doc, $cut.pos - node.nodeSize))
+        .scrollIntoView(),
+    );
+  return true;
+};
+
+function findCutBefore($pos: ResolvedPos): ResolvedPos | null {
+  if (!$pos.parent.type.spec.isolating)
+    for (let i = $pos.depth - 1; i >= 0; i--) {
+      if ($pos.index(i) > 0) return $pos.doc.resolve($pos.before(i + 1));
+      if ($pos.node(i).type.spec.isolating) break;
+    }
+  return null;
+}
+
+function isAtStartOfTextBlock($pos: ResolvedPos, view?: EditorView) {
+  return view
+    ? view.endOfTextblock('backward', view.state)
+    : $pos.parentOffset === 0;
+}

--- a/addon/commands/select-node-forward.ts
+++ b/addon/commands/select-node-forward.ts
@@ -1,0 +1,64 @@
+/**
+ * Adapted from https://github.com/ProseMirror/prosemirror-commands with support for selecting atomic inline nodes
+ * Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import { ResolvedPos } from 'prosemirror-model';
+import { Command, NodeSelection } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+
+export const selectNodeForward: Command = (state, dispatch, view) => {
+  const { $head, empty } = state.selection;
+  let $cut: ResolvedPos | null = $head;
+  if (!empty) return false;
+  if ($head.parent.isTextblock && isAtEndOfTextBlock($head, view)) {
+    $cut = findCutAfter($head);
+  }
+  if (!$cut) {
+    return false;
+  }
+  const node = $cut.nodeAfter;
+  if (!node || !NodeSelection.isSelectable(node)) return false;
+  if (dispatch)
+    dispatch(
+      state.tr
+        .setSelection(NodeSelection.create(state.doc, $cut.pos))
+        .scrollIntoView(),
+    );
+  return true;
+};
+
+function findCutAfter($pos: ResolvedPos) {
+  if (!$pos.parent.type.spec.isolating)
+    for (let i = $pos.depth - 1; i >= 0; i--) {
+      const parent = $pos.node(i);
+      if ($pos.index(i) + 1 < parent.childCount)
+        return $pos.doc.resolve($pos.after(i + 1));
+      if (parent.type.spec.isolating) break;
+    }
+  return null;
+}
+
+function isAtEndOfTextBlock($pos: ResolvedPos, view?: EditorView) {
+  return view
+    ? view.endOfTextblock('forward', view.state)
+    : $pos.parentOffset === $pos.parent.content.size;
+}

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -193,18 +193,18 @@ export default class EmbeddedEditor extends Component<Args> {
         this.controller.mainEditorState,
       );
 
-      const lastKeyPressed =
-        lastKeyPressedPluginState?.lastKeyPressed ?? 'ArrowRight';
-
-      this.innerView.dispatch(
-        this.innerView.state.tr.setSelection(
-          Selection[lastKeyPressed === 'ArrowRight' ? 'atStart' : 'atEnd'](
-            this.innerView.state.doc,
+      const lastKeyPressed = lastKeyPressedPluginState?.lastKeyPressed;
+      if (lastKeyPressed === 'ArrowLeft' || lastKeyPressed === 'ArrowRight') {
+        this.innerView.dispatch(
+          this.innerView.state.tr.setSelection(
+            Selection[lastKeyPressed === 'ArrowRight' ? 'atStart' : 'atEnd'](
+              this.innerView.state.doc,
+            ),
           ),
-        ),
-      );
+        );
 
-      this.innerView.focus();
+        this.innerView.focus();
+      }
     } else if (this.innerView) {
       const state = this.innerView.state;
       // De-select the inner node if we're no longer selected

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -17,8 +17,6 @@ import {
   liftEmptyBlock,
   newlineInCode,
   selectAll,
-  selectNodeBackward,
-  selectNodeForward,
   selectTextblockEnd,
   selectTextblockStart,
   splitBlock,
@@ -28,6 +26,8 @@ import {
   reduceIndent,
   liftEmptyBlockChecked,
   selectBlockRdfaNode,
+  selectNodeBackward,
+  selectNodeForward,
 } from '@lblod/ember-rdfa-editor/commands';
 import selectParentNodeOfType from '../commands/select-parent-node-of-type';
 import { hasParentNodeOfType } from '@curvenote/prosemirror-utils';


### PR DESCRIPTION
### Overview
This PR attempts to provide improved behaviour of the `delete` and `backspace` keys around atomic inline nodes in a document. 
Specifically, it includes the following:
- Custom `select-node-forward` and `select-node-backward` commands with included support for atomic inline nodes. The commands are adapted from the [prosemirror-commands](https://github.com/ProseMirror/prosemirror-commands) package. These commands are tied to the `delete` and `backspace` keys respectively.
- An update to the logic of entering an embedded-editor with arrow-keys. Aside from clicking inside the embedded-editor, it is now only possible to enter an embedded-editor with the `arrowleft` and `arrowright` keys.

##### connected issues and PRs:
None

### How to test/reproduce
**Behaviour for inline nodes**
- Start the dummy application
- Insert a link and type some text in the link
- Notice that when putting the cursor after/before the link and pressing backspace/delete, the link gets selected and not directly removed. Another backspace/delete keypress deletes the link.

**Behaviour for block nodes (should be the same as before)**
- Insert a table node
-  Notice that when putting the cursor after/before the table and pressing backspace/delete, the table gets selected and not directly removed. Another backspace/delete keypress deletes the table.


### Challenges/uncertainties
- This PR is marked as `breaking`, not because it changes the API of this package, but because of the modified default behaviour around atomic inline nodes.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
