### PR TITLE
Improve `mousedown` handler of gap-cursor

### DIFF
--- a/.changeset/rare-pumas-return.md
+++ b/.changeset/rare-pumas-return.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Limit `mousedown` handling in gap-cursor plugin to main mouse-button

--- a/.changeset/slimy-camels-vanish.md
+++ b/.changeset/slimy-camels-vanish.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Focus editor-view explicitely in `mousedown` handler of gap-cursor plugin

--- a/addon/plugins/gap-cursor/index.ts
+++ b/addon/plugins/gap-cursor/index.ts
@@ -43,11 +43,10 @@ export function gapCursor(): Plugin {
           : null;
       },
 
-      // handleClick,
       handleKeyDown,
       handleDOMEvents: {
         beforeinput,
-        mousedown: mousedown,
+        mousedown,
       },
     },
   });
@@ -83,6 +82,10 @@ function arrow(axis: 'vert' | 'horiz', dir: number): Command {
 }
 
 function mousedown(view: EditorView, event: MouseEvent) {
+  // Only handle the event in the main mouse button is pressed
+  if (event.button !== 0) {
+    return false;
+  }
   const clickPos = view.posAtCoords({
     left: event.clientX,
     top: event.clientY,
@@ -94,6 +97,7 @@ function mousedown(view: EditorView, event: MouseEvent) {
   if (!GapCursor.valid($pos)) return false;
   event.preventDefault();
   view.dispatch(view.state.tr.setSelection(new GapCursor($pos)));
+  view.focus();
   return true;
 }
 


### PR DESCRIPTION
### Overview
This PR ensures that the editor view is correctly focused in the `mousedown` handler of the gap-cursor plugin.
This solves an issue with trying to set a gap-cursor when the editor is unfocused.
Additionally it also limit the `mousedown` handler to the main mouse button.

### How to test/reproduce
**Before this PR**
- Insert a table
- Unfocus the editor-view
- Click before the table
- In the prosemirror-inspector, notice that a gap-cursor is created (but not shown)

**When testing with this PR**
- Insert a table
- Unfocus the editor-view
- Click before the table
- In the prosemirror-inspector, notice that a gap-cursor is created, and shown in the editor

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
