### PR TITLE
GN-4622: Column resizing

### DIFF
--- a/.changeset/sharp-queens-whisper.md
+++ b/.changeset/sharp-queens-whisper.md
@@ -1,0 +1,30 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+GN-4622: Introduce column resizing for tables
+
+If upgrading from previous version you have to either:
+
+Import `tableColumnResizingPlugin` from `@lblod/ember-rdfa-editor/plugins/table` and add it to the list of plugins
+before the `tablePlugin` (see example below)
+
+```ts
+import { tableColumnResizingPlugin, tablePlugin } from "@lblod/ember-rdfa-editor/plugins/table";
+
+get plugins() {
+  return [tableColumnResizingPlugin, tablePlugin, tableKeymap];
+}
+```
+
+**OR**
+
+Import `tablePlugins` from `@lblod/ember-rdfa-editor/plugins/table` and spread it into plugins array instead of `tablePlugin`
+
+```ts
+import { tablePlugins } from "@lblod/ember-rdfa-editor/plugins/table";
+
+get plugins() {
+  return [...tablePlugins, tableKeymap];
+}
+```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ import {
   tableKeymap,
   tableMenu,
   tableNodes,
-  tablePlugin,
+  tablePlugins,
 } from '@lblod/ember-rdfa-editor/plugins/table';
 import { heading } from '@lblod/ember-rdfa-editor/plugins/heading';
 import { Schema } from 'prosemirror-model';
@@ -112,7 +112,7 @@ export default class EditorComponent extends Component {
 
   get plugins(){
     // A list of prosemirror plugins you want to enable. More information about prosemirror plugins can be found on https://prosemirror.net/docs/guide/#state.plugins.
-    return [tablePlugin, tableKeymap];
+    return [...tablePlugins, tableKeymap];
   }
 
   @action

--- a/addon/plugins/table/index.ts
+++ b/addon/plugins/table/index.ts
@@ -29,7 +29,10 @@ export class TableView extends PluginTableView {
     public cellMinWidth: number,
   ) {
     super(node, cellMinWidth);
+    this.addClasses(node);
+  }
 
+  private addClasses(node: Node): void {
     const nodeClasses = node.attrs.class as string | undefined;
     if (typeof nodeClasses === 'string') {
       this.table.classList.add(...nodeClasses.split(' '));

--- a/addon/plugins/table/index.ts
+++ b/addon/plugins/table/index.ts
@@ -1,15 +1,18 @@
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import { keymap } from 'prosemirror-keymap';
 import { NodeSelection, Plugin, TextSelection } from 'prosemirror-state';
+import { Node } from 'prosemirror-model';
 
 import {
   addRow,
   CellSelection,
+  columnResizing,
   goToNextCell,
   isInTable,
   moveCellForward,
   selectedRect,
   tableEditing,
+  TableView as PluginTableView,
 } from 'prosemirror-tables';
 import { findNextCell, selectionCell } from './utils';
 
@@ -19,6 +22,27 @@ export { insertTable } from './commands/insertTable';
 export const tablePlugin: Plugin = tableEditing({
   allowTableNodeSelection: true,
 });
+
+export class TableView extends PluginTableView {
+  constructor(
+    public node: Node,
+    public cellMinWidth: number,
+  ) {
+    super(node, cellMinWidth);
+
+    const nodeClasses = node.attrs.class as string | undefined;
+    if (typeof nodeClasses === 'string') {
+      this.table.classList.add(...nodeClasses.split(' '));
+    }
+  }
+}
+
+export const tableColumnResizingPlugin: Plugin = columnResizing({
+  View: TableView,
+  lastColumnResizable: false,
+});
+
+export const tablePlugins: Plugin[] = [tableColumnResizingPlugin, tablePlugin];
 
 export const tableKeymap = keymap({
   Tab: (state, dispatch) => {

--- a/app/styles/ember-rdfa-editor/_c-table.scss
+++ b/app/styles/ember-rdfa-editor/_c-table.scss
@@ -22,6 +22,8 @@
     padding: $au-unit-small $au-unit-small;
     min-height: $au-unit-large;
     position: relative;
+    // Fixes Firefox bug - https://bugzilla.mozilla.org/show_bug.cgi?id=688556
+    background-clip: padding-box;
   }
 
   th {

--- a/app/styles/ember-rdfa-editor/_c-table.scss
+++ b/app/styles/ember-rdfa-editor/_c-table.scss
@@ -21,6 +21,7 @@
     text-align: left;
     padding: $au-unit-small $au-unit-small;
     min-height: $au-unit-large;
+    position: relative;
   }
 
   th {
@@ -48,10 +49,33 @@
     outline: none;
   }
 
+  // Element with a class that columnResizing plugin adds
+  .column-resize-handle {
+    position: absolute !important;
+    right: -2px;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    z-index: 20;
+    background-color: #adf;
+    pointer-events: none;
+    margin-top: 0;
+  }
 }
 
-table.ProseMirror-selectednode {
+.tableWrapper {
+  overflow-y: hidden;
+}
+
+table.ProseMirror-selectednode,
+// `tableWrapper` is a class that columnResizing plugin adds
+.tableWrapper.ProseMirror-selectednode {
   background-color: var(--au-blue-200);
   outline: 2px solid var(--au-blue-500);
   color: var(--au-black);
+}
+
+// Class that columnResizing plugin adds
+.resize-cursor {
+  cursor: col-resize;
 }

--- a/tests/dummy/app/controllers/backspace.ts
+++ b/tests/dummy/app/controllers/backspace.ts
@@ -25,7 +25,7 @@ import { invisible_rdfa } from '@lblod/ember-rdfa-editor/nodes/invisible-rdfa';
 import {
   tableKeymap,
   tableNodes,
-  tablePlugin,
+  tablePlugins,
 } from '@lblod/ember-rdfa-editor/plugins/table';
 import { image, imageView } from '@lblod/ember-rdfa-editor/plugins/image';
 import { blockquote } from '@lblod/ember-rdfa-editor/plugins/blockquote';
@@ -132,7 +132,7 @@ export default class BackspaceController extends Controller {
   @tracked plugins: PluginConfig = [
     firefoxCursorFix(),
     lastKeyPressedPlugin,
-    tablePlugin,
+    ...tablePlugins,
     tableKeymap,
     linkPasteHandler(this.schema.nodes.link),
     createInvisiblesPlugin(

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -25,7 +25,7 @@ import { invisible_rdfa } from '@lblod/ember-rdfa-editor/nodes/invisible-rdfa';
 import {
   tableKeymap,
   tableNodes,
-  tablePlugin,
+  tablePlugins,
 } from '@lblod/ember-rdfa-editor/plugins/table';
 import { image, imageView } from '@lblod/ember-rdfa-editor/plugins/image';
 import { blockquote } from '@lblod/ember-rdfa-editor/plugins/blockquote';
@@ -123,7 +123,7 @@ export default class IndexController extends Controller {
     firefoxCursorFix(),
     chromeHacksPlugin(),
     lastKeyPressedPlugin,
-    tablePlugin,
+    ...tablePlugins,
     tableKeymap,
     linkPasteHandler(this.schema.nodes.link),
     createInvisiblesPlugin(

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -27,7 +27,7 @@ import {
 import {
   tableKeymap,
   tableNodes,
-  tablePlugin,
+  tablePlugins,
 } from '@lblod/ember-rdfa-editor/plugins/table';
 import { image, imageView } from '@lblod/ember-rdfa-editor/plugins/image';
 import { blockquote } from '@lblod/ember-rdfa-editor/plugins/blockquote';
@@ -142,7 +142,7 @@ export default class IndexController extends Controller {
     firefoxCursorFix(),
     chromeHacksPlugin(),
     highlightPlugin({ testKey: 'yeet' }),
-    tablePlugin,
+    ...tablePlugins,
     tableKeymap,
     linkPasteHandler(this.schema.nodes.link),
     createInvisiblesPlugin(


### PR DESCRIPTION
### Overview

GN-4622: Column resizing

Introduces a non-breaking way to add column resizing.

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4622


### Setup

1. Checkout

### How to test/reproduce

![CleanShot 2023-12-06 at 14 26 46](https://github.com/lblod/ember-rdfa-editor/assets/769698/e804a579-046e-4fee-a8fd-e6acf676639f)


### Challenges/uncertainties

Widths don't carryover when copy pasted from another "table" editor. `columnResising` does not have it's own `handlePaste` and we end up being at the mercy of our own `pasteHandler` essentially using `pasteHTML` from `prosemirror-view`.  To be implemented in another PR.





### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations
