### PR TITLE
GN-4624: paragraph/heading alignment

### DIFF
--- a/.changeset/chatty-forks-whisper.md
+++ b/.changeset/chatty-forks-whisper.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Add `alignment` attribute to the `heading` and `paragraph` node-specs

--- a/.changeset/stale-mangos-fail.md
+++ b/.changeset/stale-mangos-fail.md
@@ -1,0 +1,10 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Add shortcuts for setting the alignment of paragraphs/headers:
+
+- `Ctrl`+`Shift`+`L`: left align
+- `Ctrl`+`Shift`+`E`: center align
+- `Ctrl`+`Shift`+`R`: right align
+- `Ctrl`+`Shift`+`J`: justify

--- a/.changeset/warm-onions-sip.md
+++ b/.changeset/warm-onions-sip.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Add toolbar dropdown which allows users to modify the `alignment` of their current selection

--- a/addon/commands/indent-node.ts
+++ b/addon/commands/indent-node.ts
@@ -25,7 +25,7 @@ export function indentNode({
     const applicableNodes: { node: PNode; pos: number }[] = [];
     state.doc.nodesBetween(from, to, (node, pos, parent) => {
       if (
-        node.attrs.indentationLevel !== undefined &&
+        'indentationLevel' in node.attrs &&
         predicate(node, pos, parent) &&
         ((direction === -1 && node.attrs.indentationLevel > 0) ||
           (direction === 1 && node.attrs.indentationLevel < maxLevel))

--- a/addon/components/plugins/alignment/alignment-menu.hbs
+++ b/addon/components/plugins/alignment/alignment-menu.hbs
@@ -1,0 +1,18 @@
+<Toolbar::Dropdown
+  @label={{this.labelFor this.currentAlignment}}
+  @icon="nav-down"
+  @iconSize="small"
+  @controller={{@controller}}
+  @disabled={{not this.enabled}}
+  title={{t 'ember-rdfa-editor.alignment.label'}}
+  as |Menu|
+>
+  {{#each this.options as |option|}}
+    <Menu.Item
+      @menuAction={{fn this.setAlignment option}}
+      title={{this.labelFor option}}
+    >
+      {{this.labelFor option}}
+    </Menu.Item>
+  {{/each}}
+</Toolbar::Dropdown>

--- a/addon/components/plugins/alignment/alignment-menu.ts
+++ b/addon/components/plugins/alignment/alignment-menu.ts
@@ -1,0 +1,46 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { SayController } from '@lblod/ember-rdfa-editor';
+import {
+  ALIGNMENT_OPTIONS,
+  AlignmentOption,
+  DEFAULT_ALIGNMENT,
+} from '@lblod/ember-rdfa-editor/plugins/alignment';
+import { setAlignment } from '@lblod/ember-rdfa-editor/plugins/alignment/commands';
+import IntlService from 'ember-intl/services/intl';
+
+type Args = {
+  controller?: SayController;
+};
+export default class AlignmentMenu extends Component<Args> {
+  @service declare intl: IntlService;
+  options = ALIGNMENT_OPTIONS;
+
+  get controller() {
+    return this.args.controller;
+  }
+
+  get currentAlignment() {
+    if (this.controller) {
+      const { selection } = this.controller.mainEditorState;
+      const anchorAlignment = selection.$anchor.parent.attrs.alignment as
+        | AlignmentOption
+        | undefined;
+      return anchorAlignment ?? DEFAULT_ALIGNMENT;
+    } else {
+      return DEFAULT_ALIGNMENT;
+    }
+  }
+
+  get enabled() {
+    return this.controller?.checkCommand(setAlignment({ option: 'left' }));
+  }
+
+  setAlignment = (option: AlignmentOption) => {
+    this.controller?.doCommand(setAlignment({ option }));
+  };
+
+  labelFor = (option: AlignmentOption) => {
+    return this.intl.t(`ember-rdfa-editor.alignment.options.${option}`);
+  };
+}

--- a/addon/components/toolbar/dropdown.hbs
+++ b/addon/components/toolbar/dropdown.hbs
@@ -8,7 +8,6 @@
       aria-expanded='{{if this.dropdownOpen "true" "false"}}'
       type='button'
       {{on 'click' this.toggleDropdown}}
-      title={{@label}}
       disabled={{@disabled}}
       {{velcro.hook}}
     >
@@ -30,8 +29,8 @@
         tabindex="-1"
         {{velcro.loop}}
       >
-        {{yield 
-          (hash 
+        {{yield
+          (hash
             Item=(component 'toolbar/dropdown-item' onActivate=this.closeDropdown)
           )
         }}

--- a/addon/core/keymap.ts
+++ b/addon/core/keymap.ts
@@ -32,6 +32,7 @@ import {
 import selectParentNodeOfType from '../commands/select-parent-node-of-type';
 import { hasParentNodeOfType } from '@curvenote/prosemirror-utils';
 import { undoInputRule } from 'prosemirror-inputrules';
+import { setAlignment } from '../plugins/alignment/commands';
 
 export type KeymapOptions = {
   backspace?: {
@@ -136,6 +137,11 @@ export const pcBaseKeymap: Keymap = (schema, options) => ({
   'Mod-a': selectAll,
   Tab: sinkListItem(schema.nodes.list_item),
   'Shift-Tab': liftListItem(schema.nodes.list_item),
+  // Alignment shortcuts
+  'Mod-Shift-L': setAlignment({ option: 'left' }),
+  'Mod-Shift-E': setAlignment({ option: 'center' }),
+  'Mod-Shift-R': setAlignment({ option: 'right' }),
+  'Mod-Shift-J': setAlignment({ option: 'justify' }),
 });
 
 /// A copy of `pcBaseKeymap` that also binds **Ctrl-h** like Backspace,

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -2,6 +2,7 @@ import { NodeSpec } from 'prosemirror-model';
 import { getRdfaAttrs } from '@lblod/ember-rdfa-editor';
 import { NON_BLOCK_NODES } from '@lblod/ember-rdfa-editor/utils/_private/constants';
 import { optionMapOr } from '../utils/_private/option';
+import { DEFAULT_ALIGNMENT, getAlignment } from '../plugins/alignment';
 
 export type ParagraphDataAttributes = {
   'data-indentation-level': number;
@@ -45,6 +46,9 @@ export const paragraphWithConfig: (
     group: config?.group || 'block paragraphGroup',
     subType: config.subType,
     attrs: {
+      alignment: {
+        default: DEFAULT_ALIGNMENT,
+      },
       indentationLevel: {
         default: 0,
       },
@@ -61,6 +65,7 @@ export const paragraphWithConfig: (
                 parseInt,
                 node.dataset.indentationLevel,
               ),
+              alignment: getAlignment(node),
             };
           }
           return false;
@@ -83,20 +88,26 @@ export const paragraphWithConfig: (
               parseInt,
               node.dataset.indentationLevel,
             ),
+            alignment: getAlignment(node),
           };
         },
         consuming: false,
       },
     ],
     toDOM(node) {
+      const { alignment, indentationLevel } = node.attrs;
+      let style = '';
+      if (alignment && alignment !== DEFAULT_ALIGNMENT) {
+        style += `text-align: ${alignment}`;
+      }
       const attrs: ParagraphDataAttributes = {
-        'data-indentation-level': node.attrs.indentationLevel as number,
+        'data-indentation-level': indentationLevel as number,
       };
       const subType = (node.type.spec as ParagraphNodeSpec).subType;
       if (subType) {
         attrs['data-sub-type'] = subType;
       }
-      return ['p', attrs, 0];
+      return ['p', { ...attrs, style }, 0];
     },
   };
 };

--- a/addon/plugins/alignment/commands.ts
+++ b/addon/plugins/alignment/commands.ts
@@ -1,0 +1,32 @@
+import { Command } from 'prosemirror-state';
+import { AlignmentOption } from '.';
+
+type SetAlignmentArgs = {
+  option: AlignmentOption;
+};
+
+export function setAlignment({ option }: SetAlignmentArgs): Command {
+  return function (state, dispatch) {
+    const { selection } = state;
+    const applicableNodes: number[] = [];
+    for (const { $from, $to } of selection.ranges) {
+      state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
+        if ('alignment' in node.attrs) {
+          applicableNodes.push(pos);
+        }
+      });
+    }
+
+    if (!applicableNodes.length) {
+      return false;
+    }
+    if (dispatch) {
+      const tr = state.tr;
+      applicableNodes.forEach((pos) => {
+        tr.setNodeAttribute(pos, 'alignment', option);
+      });
+      dispatch(tr);
+    }
+    return true;
+  };
+}

--- a/addon/plugins/alignment/index.ts
+++ b/addon/plugins/alignment/index.ts
@@ -1,0 +1,19 @@
+export const ALIGNMENT_OPTIONS = [
+  'left',
+  'right',
+  'center',
+  'justify',
+] as const;
+
+export const DEFAULT_ALIGNMENT = 'left';
+
+export type AlignmentOption = (typeof ALIGNMENT_OPTIONS)[number];
+
+export function getAlignment(node: HTMLElement): AlignmentOption | undefined {
+  const textAlign = node.style.textAlign;
+  if ((ALIGNMENT_OPTIONS as ReadonlyArray<string>).includes(textAlign)) {
+    return textAlign as AlignmentOption;
+  } else {
+    return;
+  }
+}

--- a/addon/plugins/heading/nodes/heading.ts
+++ b/addon/plugins/heading/nodes/heading.ts
@@ -1,11 +1,13 @@
 import { Node as PNode, NodeSpec } from 'prosemirror-model';
 import { getRdfaAttrs, rdfaAttrs } from '@lblod/ember-rdfa-editor';
 import { optionMapOr } from '@lblod/ember-rdfa-editor/utils/_private/option';
+import { DEFAULT_ALIGNMENT, getAlignment } from '../../alignment';
 
 export const heading: NodeSpec = {
   attrs: {
     level: { default: 1 },
     indentationLevel: { default: 0 },
+    alignment: { default: DEFAULT_ALIGNMENT },
     ...rdfaAttrs,
   },
   content: 'inline*',
@@ -22,6 +24,7 @@ export const heading: NodeSpec = {
             parseInt,
             node.dataset.indentationLevel,
           ),
+          alignment: getAlignment(node),
           ...getRdfaAttrs(node),
         };
       },
@@ -36,6 +39,7 @@ export const heading: NodeSpec = {
             parseInt,
             node.dataset.indentationLevel,
           ),
+          alignment: getAlignment(node),
           ...getRdfaAttrs(node),
         };
       },
@@ -50,6 +54,7 @@ export const heading: NodeSpec = {
             parseInt,
             node.dataset.indentationLevel,
           ),
+          alignment: getAlignment(node),
           ...getRdfaAttrs(node),
         };
       },
@@ -64,6 +69,7 @@ export const heading: NodeSpec = {
             parseInt,
             node.dataset.indentationLevel,
           ),
+          alignment: getAlignment(node),
           ...getRdfaAttrs(node),
         };
       },
@@ -78,6 +84,7 @@ export const heading: NodeSpec = {
             parseInt,
             node.dataset.indentationLevel,
           ),
+          alignment: getAlignment(node),
           ...getRdfaAttrs(node),
         };
       },
@@ -92,16 +99,21 @@ export const heading: NodeSpec = {
             parseInt,
             node.dataset.indentationLevel,
           ),
+          alignment: getAlignment(node),
           ...getRdfaAttrs(node),
         };
       },
     },
   ],
   toDOM(node: PNode) {
-    const { level, indentationLevel, ...attrs } = node.attrs;
+    const { level, indentationLevel, alignment, ...attrs } = node.attrs;
+    let style = '';
+    if (alignment && alignment !== DEFAULT_ALIGNMENT) {
+      style += `text-align: ${alignment}`;
+    }
     return [
       `h${(level as number).toString()}`,
-      { 'data-indentation-level': indentationLevel as number, ...attrs },
+      { 'data-indentation-level': indentationLevel as number, style, ...attrs },
       0,
     ];
   },

--- a/app/components/plugins/alignment/alignment-menu.js
+++ b/app/components/plugins/alignment/alignment-menu.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/components/plugins/alignment/alignment-menu';

--- a/tests/dummy/app/components/sample-toolbar-responsive.hbs
+++ b/tests/dummy/app/components/sample-toolbar-responsive.hbs
@@ -39,6 +39,9 @@
     <Tb.Group>
       <Plugins::Heading::HeadingMenu @controller={{@controller}}/>
     </Tb.Group>
+    <Tb.Group>
+      <Plugins::Alignment::AlignmentMenu @controller={{@controller}}/>
+    </Tb.Group>
   </:main>
   <:side as |Tb|>
     <Tb.Group>

--- a/tests/dummy/app/components/sample-toolbar.hbs
+++ b/tests/dummy/app/components/sample-toolbar.hbs
@@ -1,16 +1,16 @@
 <Toolbar as |Tb|>
   <Tb.Group>
-    <Plugins::History::Undo @controller={{@controller}}/>
-    <Plugins::History::Redo @controller={{@controller}}/>
+    <Plugins::History::Undo @controller={{@controller}} />
+    <Plugins::History::Redo @controller={{@controller}} />
   </Tb.Group>
   <Tb.Group>
-    <Plugins::TextStyle::Bold @controller={{@controller}}/>
-    <Plugins::TextStyle::Italic @controller={{@controller}}/>
-    <Plugins::TextStyle::Strikethrough @controller={{@controller}}/>
-    <Plugins::TextStyle::Underline @controller={{@controller}}/>
-    <Plugins::TextStyle::Subscript @controller={{@controller}}/>
-    <Plugins::TextStyle::Superscript @controller={{@controller}}/>
-    <CodeMark::ToolbarButton @controller={{@controller}}/>
+    <Plugins::TextStyle::Bold @controller={{@controller}} />
+    <Plugins::TextStyle::Italic @controller={{@controller}} />
+    <Plugins::TextStyle::Strikethrough @controller={{@controller}} />
+    <Plugins::TextStyle::Underline @controller={{@controller}} />
+    <Plugins::TextStyle::Subscript @controller={{@controller}} />
+    <Plugins::TextStyle::Superscript @controller={{@controller}} />
+    <CodeMark::ToolbarButton @controller={{@controller}} />
     <Plugins::TextStyle::Highlight
       @controller={{@controller}}
       @defaultColor="#FFEA00"
@@ -21,24 +21,27 @@
     />
   </Tb.Group>
   <Tb.Group>
-    <Plugins::List::Unordered @controller={{@controller}}/>
-    <Plugins::List::Ordered @controller={{@controller}}/>
+    <Plugins::List::Unordered @controller={{@controller}} />
+    <Plugins::List::Ordered @controller={{@controller}} />
   </Tb.Group>
   <Tb.Group>
-    <Plugins::Indentation::IndentationMenu @controller={{@controller}}/>
+    <Plugins::Indentation::IndentationMenu @controller={{@controller}} />
   </Tb.Group>
   <Tb.Group>
-    <Plugins::Link::LinkMenu @controller={{@controller}}/>
+    <Plugins::Link::LinkMenu @controller={{@controller}} />
   </Tb.Group>
   <Tb.Group>
-    <Plugins::Table::TableMenu @controller={{@controller}}/>
+    <Plugins::Table::TableMenu @controller={{@controller}} />
   </Tb.Group>
   <Tb.Group>
-    <Plugins::Heading::HeadingMenu @controller={{@controller}}/>
+    <Plugins::Heading::HeadingMenu @controller={{@controller}} />
+  </Tb.Group>
+  <Tb.Group>
+    <Plugins::Alignment::AlignmentMenu @controller={{@controller}} />
   </Tb.Group>
   <Tb.Spacer />
   <Tb.Group>
-    <Plugins::Formatting::FormattingToggle @controller={{@controller}}/>
-    <Plugins::RdfaBlockRender::RdfaBlocksToggle @controller={{@controller}}/>
+    <Plugins::Formatting::FormattingToggle @controller={{@controller}} />
+    <Plugins::RdfaBlockRender::RdfaBlocksToggle @controller={{@controller}} />
   </Tb.Group>
 </Toolbar>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -68,3 +68,10 @@ ember-rdfa-editor:
   dummy:
     counter:
       label: Counter
+  alignment:
+    label: Alignment
+    options:
+      left: Left align
+      center: Center align
+      right: Right align
+      justify: Justify

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -67,5 +67,10 @@ ember-rdfa-editor:
   dummy:
     counter:
       label: Teller
-
-
+  alignment:
+    label: Uitlijning
+    options:
+      left: Links uitlijnen
+      center: Centreren
+      right: Rechts uitlijnen
+      justify: Uitvullen


### PR DESCRIPTION
### Overview
This PR includes changes in order to support setting the text-alignment of paragraphs and headings.
Specifically it includes the following changes:
- Addition of an `alignment` attribute to `heading` and `paragraph` nodes (including serializing and parsing it to and from inline styles). The supported alignment options are: left, center, right and justify
- Addition of a `setAlignment` command which allows for setting the alignment of a selection.
- Addition of a dropdown component (to be used in the toolbar) which allows for setting the alignment of a selection and showing the current alignment present at the `anchor` of the selection.
- Addition of shortcuts which can be used to set the alignment of a selection
  - `Mod`+`Shift`+`L`: left align
  - `Mod`+`Shift`+`E`: center align
  - `Mod`+`Shift`+`R`: right align
  - `Mod`+`Shift`+`J`: justify

##### connected issues and PRs:
- Solution to [GN-4624](https://binnenland.atlassian.net/browse/GN-4624?atlOrigin=eyJpIjoiY2NkMTg1MDgyNDlhNDhhN2E1YjYwMDI4ZTM4ZjAwZTkiLCJwIjoiaiJ9)
- Includes work needed for [GN-4623](https://binnenland.atlassian.net/browse/GN-4623?atlOrigin=eyJpIjoiNmQwMDIzYmVhMTJiNGY2ZGJjZmNiZjMzNGM2ZDRlMDEiLCJwIjoiaiJ9)

### How to test/reproduce
- Type a paragraph/heading/text
- Check if the different alignment options do what expected

### Challenges/uncertainties
- It is possible to set the alignment for the content of individual table-cells, series of table-cells, but not for a whole column/row/table.
- The current alignment shown in the toolbar button is not always correct. Currently the code checks for the alignment of the parent of the anchor (with a default of 'left' if no alignment is present).
- Icons have not been added yet. I don't think this is a blocker for this PR per se.
- The shortcuts have been selected based on other web-based editors. The `Shift` keys has been added to prevent overriding built-in browser shortcuts.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
