### PR TITLE
Make rdfa preprocessor handle more cases correctly

### DIFF
--- a/.changeset/proud-balloons-complain.md
+++ b/.changeset/proud-balloons-complain.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Improved parser based on a better definition of resource and literal nodes

--- a/addon/components/_private/rdfa-editor/relationship-editor/index.hbs
+++ b/addon/components/_private/rdfa-editor/relationship-editor/index.hbs
@@ -88,6 +88,17 @@
       <p>This node does not have any backlinks</p>
     {{/if}}
   </div>
+  {{#if this.statusMessage}}
+  <div>
+    <AuAlert
+      @skin={{this.statusMessage.type}}
+      @closable={{true}}
+      @onClose={{this.closeStatusMessage}}
+    >
+      {{this.statusMessage.message}}
+    </AuAlert>
+  </div>
+  {{/if}}
 </AuContent>
 
 <this.Modal

--- a/addon/components/_private/rdfa-editor/relationship-editor/index.ts
+++ b/addon/components/_private/rdfa-editor/relationship-editor/index.ts
@@ -30,17 +30,29 @@ type Args = {
   node: ResolvedPNode;
 };
 
+interface StatusMessage {
+  message: string;
+  type: 'info' | 'warning' | 'error' | 'success';
+}
+interface StatusMessageForNode extends StatusMessage {
+  node: PNode;
+}
+
 export default class RdfaRelationshipEditor extends Component<Args> {
   @tracked addRelationshipType?: AddRelationshipType;
+  @tracked _statusMessage: StatusMessageForNode | null = null;
 
   Modal = RelationshipEditorModal;
+  get node(): PNode {
+    return this.args.node.value;
+  }
 
   get backlinks() {
-    return this.args.node.value.attrs.backlinks as Backlink[] | undefined;
+    return this.node.attrs.backlinks as Backlink[] | undefined;
   }
 
   get properties() {
-    return this.args.node.value.attrs.properties as Property[] | undefined;
+    return this.node.attrs.properties as Property[] | undefined;
   }
 
   get hasOutgoing() {
@@ -52,15 +64,29 @@ export default class RdfaRelationshipEditor extends Component<Args> {
   }
 
   get showOutgoingSection() {
-    return isResourceNode(this.args.node.value);
+    return isResourceNode(this.node);
   }
 
   get currentResource() {
-    return this.args.node.value.attrs.resource as string | undefined;
+    return this.node.attrs.resource as string | undefined;
   }
 
   get currentRdfaId() {
-    return this.args.node.value.attrs.__rdfaId as string;
+    return this.node.attrs.__rdfaId as string;
+  }
+  get statusMessage(): StatusMessage | null {
+    // show only if a message is relevant for the current node
+    if (this._statusMessage && this.node === this._statusMessage.node) {
+      return this._statusMessage;
+    }
+    return null;
+  }
+  set statusMessage(val: StatusMessage | null) {
+    if (val) {
+      this._statusMessage = { ...val, node: this.node };
+    } else {
+      this._statusMessage = val;
+    }
   }
 
   get allRdfaids() {
@@ -87,22 +113,47 @@ export default class RdfaRelationshipEditor extends Component<Args> {
         })
       : [];
   }
+  closeStatusMessage = () => {
+    this.statusMessage = null;
+  };
 
   goToOutgoing = (outgoing: ExternalProperty) => {
+    this.closeStatusMessage();
     const { object } = outgoing;
     if (object.type === 'literal') {
-      this.controller?.doCommand(selectNodeByRdfaId({ rdfaId: object.rdfaId }));
+      const result = this.controller?.doCommand(
+        selectNodeByRdfaId({ rdfaId: object.rdfaId }),
+      );
+      if (!result) {
+        this.statusMessage = {
+          message: `No literal node found for id ${object.rdfaId}.`,
+          type: 'error',
+        };
+      }
     } else {
-      this.controller?.doCommand(
+      const result = this.controller?.doCommand(
         selectNodeByResource({ resource: object.resource }),
       );
+      if (!result) {
+        this.statusMessage = {
+          message: `No resource node found for ${object.resource}.`,
+          type: 'info',
+        };
+      }
     }
   };
 
   goToBacklink = (backlink: Backlink) => {
-    this.controller?.doCommand(
+    this.closeStatusMessage();
+    const result = this.controller?.doCommand(
       selectNodeByResource({ resource: backlink.subject }),
     );
+    if (!result) {
+      this.statusMessage = {
+        message: `No resource node found for ${backlink.subject}.`,
+        type: 'info',
+      };
+    }
   };
 
   removeBacklink = (index: number) => {
@@ -131,7 +182,7 @@ export default class RdfaRelationshipEditor extends Component<Args> {
   };
 
   get canAddRelationship() {
-    if (isResourceNode(this.args.node.value)) {
+    if (isResourceNode(this.node)) {
       return true;
     } else {
       // Content nodes may only have 1 backlink

--- a/addon/core/say-view.ts
+++ b/addon/core/say-view.ts
@@ -2,7 +2,6 @@ import {
   AllSelection,
   EditorState,
   Selection,
-  Transaction,
 } from 'prosemirror-state';
 import { DirectEditorProps, EditorView } from 'prosemirror-view';
 import { tracked } from '@glimmer/tracking';

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -55,6 +55,9 @@ export function getRdfaAttrs(node: Element): RdfaAttrs | false {
   };
 
   let hasAnyRdfaAttributes = false;
+  if (!node.hasAttribute('data-rdfa-node-type')) {
+    return false;
+  }
   for (const key of Object.keys(rdfaDomAttrs)) {
     const value = node.attributes.getNamedItem(key)?.value;
     if (isSome(value)) {

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -21,6 +21,7 @@ export const rdfaDomAttrs = {
   'data-incoming-props': { default: [] },
   'data-outgoing-props': { default: [] },
   resource: { default: null },
+  about: { default: null },
   __rdfaId: { default: undefined },
   'data-rdfa-node-type': { default: undefined },
 };
@@ -86,6 +87,8 @@ export function getRdfaAttrs(node: Element): RdfaAttrs | false {
             resource:
               attrs.resource && typeof attrs.resource === 'string'
                 ? attrs.resource
+                : attrs.about && typeof attrs.about === 'string'
+                ? attrs.about
                 : '',
             properties:
               attrs.properties && attrs.properties instanceof Array

--- a/addon/nodes/block-rdfa.ts
+++ b/addon/nodes/block-rdfa.ts
@@ -1,8 +1,5 @@
 import { Node as PNode } from 'prosemirror-model';
-import {
-  isElement,
-  tagName,
-} from '@lblod/ember-rdfa-editor/utils/_private/dom-helpers';
+import { isElement } from '@lblod/ember-rdfa-editor/utils/_private/dom-helpers';
 import {
   getRdfaAttrs,
   renderRdfaAware,

--- a/addon/utils/_private/rdfa-parser/post-process-as-rdfa-nodes.ts
+++ b/addon/utils/_private/rdfa-parser/post-process-as-rdfa-nodes.ts
@@ -1,0 +1,179 @@
+import { unwrap } from '../option';
+import { IActiveTag } from './active-tag';
+import { ModelBlankNode, ModelNamedNode } from './rdfa-parser';
+export interface PostProcessArgs<N> {
+  activeTag: IActiveTag<N>;
+  attributes: Record<string, string>;
+  isRootTag: boolean;
+  typedResource: true | ModelBlankNode<N> | ModelNamedNode<N> | null;
+  markAsLiteralNode: (
+    node: N,
+    activeTag: IActiveTag<N>,
+    attributes: Record<string, string>,
+    predicateAttribute?: string,
+  ) => void;
+  markAsResourceNode: (
+    node: N,
+    resource: boolean | ModelBlankNode<N> | ModelNamedNode<N>,
+    activeTag: IActiveTag<N>,
+  ) => void;
+}
+
+/**
+ * How the preprocessor works:
+ *
+ * some definitions:
+ *
+ * say you have a triple `<uri> predicate "object"`,
+ * where "object" is the value of an attribute (such as content),
+ * we call the tuple (predicate, "object") a property of <uri>
+ *
+ * if you have a triple <uri> predicate <uri2>, we call the tuple (predicate, <uri2>) a relationship of <uri>
+ *
+ * if you have a triple <uri> predicate "object",
+ * where "object" is derived from the concatenated text content of a node,
+ * we call the tuple (predicate, node) also a relationship of <uri>
+ *
+ * The core idea of the preprocessor is this: turn a random rdfa document,
+ * which has resources and predicates all over the place, into a document with 2 types of nodes:
+ *
+ * - a resource node: defines a resource and, crucially, holds ALL properties and relationships of that resource, in both directions
+
+ * - a literal node: the "manifestation" of a literal relationship on a resource
+ *
+ * now, this split maps nicely on the spec for the rdfa parsing algorithm.
+ * Essentially, when visiting a node, there are 4 possible outcomes (that are relevant for us):
+ *
+ *     a. the node defines a new subject (we mark it as a resource node)
+ *     b. it "closes" a triple by defining its value with the concatenated textcontent (we mark it as a literal node)
+ *     c. it does both a and b (we mark it as a literal node, see below)
+ *     d. it does anything else (we don't mark it)
+ *
+ * in the case of d, we can safely ignore it because of how the resource and literal nodes get processed later on.
+ * We attach all their properties and relationships after we fully parse the document,
+ * and the parser doesn't ignore d, so it captures all cases.
+ *
+ * This also means that before the nodes ever get to prosemirror,
+ * all the relationships and properties are correctly attached, taking the entire document into account.
+
+ * ## Special note
+ *
+ * the case where an element has both an about and a property attribute,
+ * (this is case "c" from above) it will always get parsed as a literal node,
+ * even if it technically also defines a subject.
+ *
+ * This means there can be literal nodes that point to a resource which does not have a resource node in the document.
+ * This doesn't break anything and is actually completely sensible.
+ * A node like this effectively defines a complete triple,
+ * completely independant from the context it's in, with the value of about as the subject,
+ * the value of property as predicate and the concatenated textcontent as the object.
+ **/
+export function postProcessTagAsRdfaNode<N>(args: PostProcessArgs<N>): void {
+  const {
+    activeTag,
+    attributes,
+    isRootTag,
+    typedResource,
+    markAsLiteralNode,
+    markAsResourceNode,
+  } = args;
+  const node = activeTag.node;
+  if (!activeTag.skipElement && node) {
+    // no rel or rev
+    if (!('rel' in attributes) && !('rev' in attributes)) {
+      /* asdf*/
+      /**/
+      /**/
+      if (
+        'property' in attributes &&
+        !('content' in attributes) &&
+        !('datatype' in attributes)
+      ) {
+        if ('about' in attributes) {
+          // !! content node
+          // this combo BOTH sets a new subject, AND sets the value of the triple to its textcontent.
+          // we choose to interpret as a literal rather than a resource
+          markAsLiteralNode(node, activeTag, attributes);
+          return;
+        } else if (isRootTag) {
+          // root resource
+          markAsResourceNode(node, unwrap(activeTag.subject), activeTag);
+          return;
+        } else {
+          if ('typeof' in attributes) {
+            this.setResourceNode(node, unwrap(typedResource), activeTag);
+            return;
+          }
+        }
+      } else {
+        if ('about' in attributes) {
+          // same exception as above, we always interpret (property +about -content) cases as literal nodes
+          if ('property' in attributes && !('content' in attributes)) {
+            markAsLiteralNode(node, activeTag, attributes);
+            return;
+          } else {
+            markAsResourceNode(node, unwrap(activeTag.subject), activeTag);
+            return;
+          }
+        } else if (
+          'href' in attributes ||
+          'src' in attributes ||
+          'resource' in attributes
+        ) {
+          markAsResourceNode(node, unwrap(activeTag.subject), activeTag);
+          return;
+        } else if (isRootTag) {
+          // root resource node
+          markAsResourceNode(node, unwrap(activeTag.subject), activeTag);
+          return;
+        } else if ('typeof' in attributes) {
+          // blank resource node
+          markAsResourceNode(node, unwrap(activeTag.subject), activeTag);
+          return;
+        } else if (activeTag.object) {
+          // intentionally empty, to preserve structure from algorithm in spec
+        }
+      }
+    } else {
+      if ('about' in attributes) {
+        markAsResourceNode(node, unwrap(activeTag.subject), activeTag);
+        return;
+      } else if ('typeof' in attributes) {
+        markAsResourceNode(node, unwrap(typedResource), activeTag);
+        return;
+      } else if (isRootTag) {
+        // root resource node
+        markAsResourceNode(node, unwrap(activeTag.subject), activeTag);
+        return;
+      } else if (activeTag.object) {
+        // intentionally empty, to preserve structure from algorithm in spec
+      }
+    }
+
+    // no-op returns are intentional
+    if ('property' in attributes) {
+      if ('datatype' in attributes) {
+        if (!('content' in attributes)) {
+          markAsLiteralNode(node, activeTag, attributes);
+          return;
+        }
+      } else if ('content' in attributes) {
+        return;
+      } else if (
+        !('rel' in attributes) &&
+        !('rev' in attributes) &&
+        !('content' in attributes) &&
+        ('resource' in attributes ||
+          'href' in attributes ||
+          'src' in attributes)
+      ) {
+        return;
+      } else if ('typeof' in attributes && !('about' in attributes)) {
+        return;
+      } else {
+        markAsLiteralNode(node, activeTag, attributes);
+        return;
+      }
+    }
+  }
+}

--- a/addon/utils/_private/rdfa-parser/rdfa-parser.ts
+++ b/addon/utils/_private/rdfa-parser/rdfa-parser.ts
@@ -1017,8 +1017,16 @@ export class RdfaParser<N> {
             }
           }
         } else {
-          if (
-            'about' in attributes ||
+          if ('about' in attributes) {
+            // same exception as above, we always interpret (property +about -content) cases as literal nodes
+            if ('property' in attributes && !('content' in attributes)) {
+              this.setContentNode(node, activeTag, attributes);
+              return;
+            } else {
+              this.setResourceNode(node, unwrap(activeTag.subject), activeTag);
+              return;
+            }
+          } else if (
             'href' in attributes ||
             'src' in attributes ||
             'resource' in attributes


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->
How the preprocessor works:

some definitions:

- say you have a triple `<uri> predicate "object"`, where `"object"` is the value of an attribute (such as `content`), we call the tuple `(predicate, "object")` a **property** of `<uri>`
- if you have a triple `<uri> predicate <uri2>`, we call the tuple `(predicate, <uri2>)` a **relationship** of `<uri>`
- if you have a triple `<uri> predicate "object"`, where `"object"` is derived from the concatenated text content of a `node`, we call the tuple `(predicate, node)` also a **relationship** of `<uri>`


The core idea of the preprocessor is this: turn a random rdfa document, which has resources and predicates all over the place, into a document with 2 types of nodes:

- a resource node: defines a resource and, crucially, holds ALL properties and relationships of that resource, in both directions
- a literal node: the "manifestation" of a literal relationship on a resource


now, this split maps nicely on the spec for the rdfa parsing algorithm. Essentially, when visiting a node, there are 4 possible outcomes (that are relevant for us):

- a. the node defines a new subject (we mark it as a resource node)
- b. it "closes" a triple by defining its value with the concatenated textcontent (we mark it as a literal node)
- c. it does both a and b (we mark it as a literal node, see below)
- d. it does anything else (we don't mark it)

in the case of d, we can safely ignore it because of how the resource and literal nodes get processed later on. We attach all their properties and relationships after we fully parse the document, and the parser doesn't ignore d, so it captures all cases.
This also means that before the nodes ever get to prosemirror, all the relationships and properties are correctly attached, taking the entire document into account. 

### Special note
the case where an element has both an `about` and a `property` attribute, (this is case "c" from above) it will always get parsed as a literal node, even if it technically also defines a subject. This means there can be literal nodes
that point to a resource which does not have a resource node in the document. This doesn't break anything and is actually completely sensible. A node like this effectively defines a complete triple,
completely independant from the context it's in, with the value of `about` as the subject, the value of `property` as predicate and the concatenated textcontent as the object.

Because of this, I've also added a message in the link-ui that informs the user that no node was found for a backlink when it is clicked. It's an info message, not an error, cause it should signify
the above valid case.

I could have disabled the link instead when no valid node could be found, but that's quite costly as we'd run over the entire document every state change, and defeats the point of
calculating the resource mapping in a lazy way. It's a rare case anyway, so I much prefer this solution.

Note this also signals a legitimate usecase for a literal->resource-with-nested-literal conversion feature.

Once a resource node for the resource in question is created, the link "goto" behavior will work again, as it's completely dynamic. The only thing that will be missing is the outgoing link on the newly
created node. This link will get populated on refresh, but should also be populated on insert. However, it's a rare case, so I'm keeping that out of scope here.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->
try to come up with weird rdfa edge cases and see if they get parsed/serialized correctly, using [rdfa play](https://rdfa.info/play) as a reference
note: inline rdfa isn't parsed yet in this branch, so use blocks only

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->

`in-list` is not yet supported (it may work, I didn't try yet)

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations