### PR TITLE
fix: don't clean elements if they have rdfa

### DIFF
--- a/addon/utils/_private/ce/paste-handler-helper-functions/cleanEmptyElements.ts
+++ b/addon/utils/_private/ce/paste-handler-helper-functions/cleanEmptyElements.ts
@@ -1,10 +1,22 @@
 import { traverseElements } from './traverseElements';
+import { RDFA_ATTRIBUTES } from '../../constants';
 
 const ALLOWED_EMPTY_ELEMENTS = ['BR', 'IMG'];
 const NOTRIM_ELEMENTS = ['SPAN'];
 
+function hasRdfaAttributes(element: Element) {
+  for (const attr of RDFA_ATTRIBUTES) {
+    if (element.hasAttribute(attr)) {
+      return true;
+    }
+  }
+  return false;
+}
 function isEmpty(element: Element): boolean {
   if (ALLOWED_EMPTY_ELEMENTS.includes(element.nodeName)) {
+    return false;
+  }
+  if (hasRdfaAttributes(element)) {
     return false;
   }
   let content;

--- a/addon/utils/_private/constants.ts
+++ b/addon/utils/_private/constants.ts
@@ -110,3 +110,19 @@ export const LUMP_NODE_PROPERTY =
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const NOOP = () => {};
 export const INLINE_COMPONENT_CHILDREN_SELECTOR = '[data-slot]';
+export const RDFA_ATTRIBUTES = [
+  'resource',
+  'about',
+  'rel',
+  'rev',
+  'content',
+  'datatype',
+  'property',
+  'href',
+  'src',
+  'inlist',
+  'prefix',
+  'vocab',
+  'typeof',
+  'lang',
+];


### PR DESCRIPTION
-------

### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Now that we're always cleaning, we need to make sure we don't delete empty elements with rdfa
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->

the original case for the copy from word needs to be retested


### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations