### PR TITLE
fix: do not remove empty table cells and rows

### DIFF
--- a/.changeset/warm-years-shout.md
+++ b/.changeset/warm-years-shout.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+`HTMLInputParser` - Do not remove empty table cells and rows 

--- a/addon/utils/_private/ce/paste-handler-helper-functions/cleanEmptyElements.ts
+++ b/addon/utils/_private/ce/paste-handler-helper-functions/cleanEmptyElements.ts
@@ -1,7 +1,7 @@
 import { traverseElements } from './traverseElements';
 import { RDFA_ATTRIBUTES } from '../../constants';
 
-const ALLOWED_EMPTY_ELEMENTS = ['BR', 'IMG'];
+const ALLOWED_EMPTY_ELEMENTS = ['BR', 'IMG', 'TR', 'TD'];
 const NOTRIM_ELEMENTS = ['SPAN'];
 
 function hasRdfaAttributes(element: Element) {

--- a/addon/utils/_private/html-input-parser.ts
+++ b/addon/utils/_private/html-input-parser.ts
@@ -359,6 +359,11 @@ export default class HTMLInputParser {
       );
 
       const totalWidth = cellWidths.reduce((acc, width) => acc + width, 0);
+
+      if (!totalWidth) {
+        return;
+      }
+
       const scaleFactor = this.editorViewWidth / totalWidth;
 
       for (let i = 0; i < cellWidths.length; i++) {

--- a/tests/unit/utils/html-input-parser-test.ts
+++ b/tests/unit/utils/html-input-parser-test.ts
@@ -63,6 +63,17 @@ module('Utils | CS | HTMLInputParser', function () {
     assert.strictEqual(actualHtml, expectedHtml);
   });
 
+  test('it should not remove empty table cells and rows', function (assert) {
+    const expectedHtml = oneLineTrim`<table><tbody><tr><td></td></tr></tbody></table>`;
+    const inputParser = new HTMLInputParser({ editorView });
+    const htmlContent = oneLineTrim`
+            <!--StartFragment--><table><tbody><tr><td></td></tr></tbody></table><!--EndFragment-->
+    `;
+
+    const actualHtml = inputParser.prepareHTML(htmlContent);
+    assert.strictEqual(actualHtml, expectedHtml);
+  });
+
   test('It should remove unsafe url schemes', function (assert) {
     const expectedHtml = oneLineTrim`<a style="color:green">Lorem Ipsum</a>`;
     const inputParser = new HTMLInputParser({ editorView });


### PR DESCRIPTION
### Overview

`HTMLInputParser` was a bit too blood thirsty and was removing empty cells and rows of the table. 

### Setup

1. Checkout

### How to test/reproduce

1. Paste table with empty cells and rows, see that they are not removed.


### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations
