### PR TITLE
GN-4614: automatically add http or mailto to links

### DIFF
--- a/.changeset/mean-dancers-agree.md
+++ b/.changeset/mean-dancers-agree.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+When adding the href for a link, automatically add `http://` or `mailto:` to the href attribute to generate a valid `<a>` tag.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,11 @@ module.exports = {
         semi: 'off',
         '@typescript-eslint/no-unused-vars': [
           'error',
-          { argsIgnorePattern: '^_' },
+          {
+            argsIgnorePattern: '^_',
+            args: 'after-used',
+            ignoreRestSiblings: true,
+          },
         ],
         '@typescript-eslint/semi': ['error', 'always'],
 

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -58,8 +58,6 @@ type Args = EmberNodeArgs & {
   nodeViews?: {
     [node: string]: NodeViewConstructor;
   };
-  /** Should we call the internal onSelected callback when there is no lastKeyPressed? */
-  selectInnerOnCreation?: boolean;
 };
 
 /**
@@ -196,14 +194,10 @@ export default class EmbeddedEditor extends Component<Args> {
       );
 
       const lastKeyPressed = lastKeyPressedPluginState?.lastKeyPressed;
-      if (
-        lastKeyPressed === 'ArrowLeft' ||
-        lastKeyPressed === 'ArrowRight' ||
-        (!lastKeyPressed && this.args.selectInnerOnCreation)
-      ) {
+      if (!this.innerView.hasFocus()) {
         this.innerView.dispatch(
           this.innerView.state.tr.setSelection(
-            Selection[lastKeyPressed === 'ArrowRight' ? 'atStart' : 'atEnd'](
+            Selection[lastKeyPressed === 'ArrowLeft' ? 'atEnd' : 'atStart'](
               this.innerView.state.doc,
             ),
           ),

--- a/addon/components/ember-node/embedded-editor.ts
+++ b/addon/components/ember-node/embedded-editor.ts
@@ -58,6 +58,8 @@ type Args = EmberNodeArgs & {
   nodeViews?: {
     [node: string]: NodeViewConstructor;
   };
+  /** Should we call the internal onSelected callback when there is no lastKeyPressed? */
+  selectInnerOnCreation?: boolean;
 };
 
 /**
@@ -194,7 +196,11 @@ export default class EmbeddedEditor extends Component<Args> {
       );
 
       const lastKeyPressed = lastKeyPressedPluginState?.lastKeyPressed;
-      if (lastKeyPressed === 'ArrowLeft' || lastKeyPressed === 'ArrowRight') {
+      if (
+        lastKeyPressed === 'ArrowLeft' ||
+        lastKeyPressed === 'ArrowRight' ||
+        (!lastKeyPressed && this.args.selectInnerOnCreation)
+      ) {
         this.innerView.dispatch(
           this.innerView.state.tr.setSelection(
             Selection[lastKeyPressed === 'ArrowRight' ? 'atStart' : 'atEnd'](

--- a/addon/components/ember-node/link.hbs
+++ b/addon/components/ember-node/link.hbs
@@ -35,8 +35,9 @@
         title='Link openen'
       />
       <AuInput
-        @value={{this.href}}
+        value={{this.href}}
         placeholder={{t 'ember-rdfa-editor.link.placeholder.href'}}
+        {{on 'change' this.setHref}}
         {{on 'focus' this.selectHref}}
         {{leave-on-enter-key this.controller @getPos}}
       />

--- a/addon/components/ember-node/link.hbs
+++ b/addon/components/ember-node/link.hbs
@@ -18,7 +18,6 @@
       @placeholder={{t 'ember-rdfa-editor.link.placeholder.text'}}
       @decorations={{@decorations}}
       @contentDecorations={{@contentDecorations}}
-      @selectInnerOnCreation={{true}}
       {{leave-on-enter-key this.controller @getPos}}
     />
   </Pill>

--- a/addon/components/ember-node/link.hbs
+++ b/addon/components/ember-node/link.hbs
@@ -18,6 +18,7 @@
       @placeholder={{t 'ember-rdfa-editor.link.placeholder.text'}}
       @decorations={{@decorations}}
       @contentDecorations={{@contentDecorations}}
+      @selectInnerOnCreation={{true}}
       {{leave-on-enter-key this.controller @getPos}}
     />
   </Pill>

--- a/addon/components/ember-node/link.hbs
+++ b/addon/components/ember-node/link.hbs
@@ -32,7 +32,7 @@
         href={{this.href}}
         @skin='naked'
         @icon='link-external'
-        title='Link openen'
+        title={{t "ember-rdfa-editor.link.open"}}
       />
       <AuInput
         value={{this.href}}
@@ -46,7 +46,7 @@
         @skin='naked'
         @size='small'
         {{on 'click' this.remove}}
-        title='Link ontkoppelen'
+        title={{t "ember-rdfa-editor.link.edit.uncouple"}}
       />
     </Pill>
   {{/if}}

--- a/addon/components/ember-node/link.ts
+++ b/addon/components/ember-node/link.ts
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
+import { linkToHref } from '@lblod/ember-rdfa-editor/utils/_private/string-utils';
 import { Velcro } from 'ember-velcro';
 
 export default class Link extends Component<EmberNodeArgs> {
@@ -28,6 +29,13 @@ export default class Link extends Component<EmberNodeArgs> {
 
   get interactive() {
     return this.node.attrs.interactive as boolean;
+  }
+
+  @action
+  setHref(event: InputEvent) {
+    const text = (event.target as HTMLInputElement).value;
+    const href = linkToHref(text);
+    this.href = href || text;
   }
 
   @action

--- a/addon/components/plugins/link/link-editor.hbs
+++ b/addon/components/plugins/link/link-editor.hbs
@@ -4,7 +4,13 @@
     <AuHeading @level="3" @skin="5">{{t "ember-rdfa-editor.link.edit.title"}}</AuHeading>
   </c.header>
   <c.content class="au-c-content--small">
-    <AuInput @value={{this.href}} @width="block" {{on 'focus' this.selectHref}} placeholder={{t 'ember-rdfa-editor.link.placeholder.href'}}/>
+    <AuInput
+      value={{this.href}}
+      @width="block"
+      {{on 'change' this.setHref}}
+      {{on 'focus' this.selectHref}}
+      placeholder={{t 'ember-rdfa-editor.link.placeholder.href'}}
+    />
   </c.content>
   <c.footer>
     <AuLinkExternal @icon="link-external" @skin="button-secondary" href={{this.href}}>{{t "ember-rdfa-editor.link.open"}}</AuLinkExternal>

--- a/addon/components/plugins/link/link-editor.ts
+++ b/addon/components/plugins/link/link-editor.ts
@@ -19,9 +19,11 @@ export default class LinkEditor extends Component<Args> {
   set href(value: string | undefined) {
     if (this.link && this.controller) {
       const { pos } = this.link;
-      this.controller.withTransaction((tr) => {
-        return tr.setNodeAttribute(pos, 'href', value);
-      });
+      this.controller.withTransaction(
+        (tr) => tr.setNodeAttribute(pos, 'href', value),
+        // After reload the default (activeEditorView) is just the link text, so use the main view
+        { view: this.controller.mainEditorView },
+      );
     }
   }
 

--- a/addon/components/plugins/link/link-editor.ts
+++ b/addon/components/plugins/link/link-editor.ts
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { NodeSelection } from 'prosemirror-state';
 import { SayController } from '@lblod/ember-rdfa-editor';
+import { linkToHref } from '@lblod/ember-rdfa-editor/utils/_private/string-utils';
 
 type Args = {
   controller?: SayController;
@@ -22,6 +23,13 @@ export default class LinkEditor extends Component<Args> {
         return tr.setNodeAttribute(pos, 'href', value);
       });
     }
+  }
+
+  @action
+  setHref(event: InputEvent) {
+    const text = (event.target as HTMLInputElement).value;
+    const href = linkToHref(text);
+    this.href = href || text;
   }
 
   @action

--- a/addon/plugins/link/nodes/link.ts
+++ b/addon/plugins/link/nodes/link.ts
@@ -43,7 +43,6 @@ const emberNodeConfig: (options: LinkOptions) => EmberNodeConfig = (
       },
     ],
     toDOM(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { interactive, placeholder, ...attrs } = node.attrs;
       return ['a', attrs, 0];
     },

--- a/addon/utils/_private/linkify-fragment.ts
+++ b/addon/utils/_private/linkify-fragment.ts
@@ -1,6 +1,6 @@
 import { PNode } from '@lblod/ember-rdfa-editor';
 import { Fragment, MarkType, NodeType, Schema } from 'prosemirror-model';
-import * as linkify from 'linkifyjs';
+import { find as linkifyFind } from 'linkifyjs';
 
 /**
  *
@@ -36,7 +36,7 @@ export default function linkifyFragment(
   const transformedContent: PNode[] = [];
   fragment.forEach((child) => {
     if (child.isText && child.text) {
-      const links = linkify.find(child.text);
+      const links = linkifyFind(child.text);
       let pos = 0;
       for (const link of links) {
         if (pos < link.start) {

--- a/addon/utils/_private/string-utils.ts
+++ b/addon/utils/_private/string-utils.ts
@@ -1,11 +1,13 @@
-import { INVISIBLE_SPACE } from './constants';
+import { find as linkifyFind, test as linkifyTest } from 'linkifyjs';
 
-export default class StringUtils {
-  static isAllWhiteSpace(text: string): boolean {
-    return !/[^\t\n\r \u00A0]/.test(text);
+/**
+ * If passed a link *and just a link* (ignoring leading and trailing whitespace), return the href
+ * for that link, including mailto: for email addresses (using linkify.js).
+ */
+export function linkToHref(text: string) {
+  if (!linkifyTest(text.trim())) {
+    // Either isn't a link or contains additional text
+    return '';
   }
-
-  static getInvisibleSpaceCount(text: string): number {
-    return text.split('').filter((c) => c === INVISIBLE_SPACE).length;
-  }
+  return linkifyFind(text)?.[0]?.href;
 }


### PR DESCRIPTION
### Overview
Uses Linkify.js to match links and add http or mailto when relevant. Also fixes a few usability bugs around links:
- Fix a crash after reloading the page and using the sidebar
- Some missing translations
- Selection when inserting a link (so hitting insert and then typing writes the text of the link instead of replacing the new link node with the character typed)

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4614

### Setup
N/A

### How to test/reproduce
Type a valid or invalid link (or email) into either of the href boxes (in pop-over or sidebar) and see that the http: or mailto: part is added automatically.

### Challenges/uncertainties
There are more usability problems I wanted to fix, but I wasn't able to figure out how to do them as embedded-editor nodes seem to have problems around reactivity in the ember components (e.g. changing a property with a `@tracked` decorator not updating in the UI).

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
