### PR TITLE
Improve handling of datatype

### DIFF
--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -177,7 +177,7 @@ export function renderRdfaAttrs(
             nodeOrMark.attrs.resource) as string,
           property: contentPred.predicate,
           resource: null,
-          datatype: (nodeOrMark.attrs.datatype as string) ?? null,
+          datatype: nodeOrMark.attrs.datatype as string,
         }
       : {
           about: (nodeOrMark.attrs.subject ||
@@ -195,7 +195,7 @@ export function renderRdfaAttrs(
       about: backlinks[0].subject,
       property: backlinks[0].predicate,
       'data-literal-node': 'true',
-      datatype: (nodeOrMark.attrs.datatype as string) ?? null,
+      datatype: nodeOrMark.attrs.datatype as string,
     };
   }
 }
@@ -231,19 +231,21 @@ export function renderRdfaAware({
   delete clone.resource;
   delete clone.__rdfaId;
   delete clone.rdfaNodeType;
-  const renderAttrs = renderRdfaAttrs(renderable);
+  const renderAttrs = { ...clone, ...renderRdfaAttrs(renderable) };
   let { property } = renderAttrs;
-  if (renderable.attrs.datatype === 'rdf:XMLLiteral') {
+  let datatype = renderAttrs.datatype || clone.datatype;
+  if (datatype === 'rdf:XMLLiteral') {
     contentContainerAttrs = {
       ...contentContainerAttrs,
-      datatype: renderable.attrs.datatype,
+      datatype,
       property,
     };
     property = null;
+    datatype = null;
   }
   return [
     tag,
-    { ...clone, ...renderAttrs, property },
+    { ...renderAttrs, property, datatype },
     renderInvisibleRdfa(renderable, rdfaContainerTag, rdfaContainerAttrs),
     [
       contentContainerTag,

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -231,9 +231,19 @@ export function renderRdfaAware({
   delete clone.resource;
   delete clone.__rdfaId;
   delete clone.rdfaNodeType;
+  const renderAttrs = renderRdfaAttrs(renderable);
+  let { property } = renderAttrs;
+  if (renderable.attrs.datatype === 'rdf:XMLLiteral') {
+    contentContainerAttrs = {
+      ...contentContainerAttrs,
+      datatype: renderable.attrs.datatype,
+      property,
+    };
+    property = null;
+  }
   return [
     tag,
-    { ...clone, ...renderRdfaAttrs(renderable) },
+    { ...clone, ...renderAttrs, property },
     renderInvisibleRdfa(renderable, rdfaContainerTag, rdfaContainerAttrs),
     [
       contentContainerTag,

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -16,6 +16,7 @@ export const rdfaAttrSpec = {
   rdfaNodeType: { default: undefined },
   resource: { default: null },
   subject: { default: null },
+  datatype: { default: null },
 };
 /** @deprecated Renamed to rdfaAttrSpec */
 export const rdfaAttrs = rdfaAttrSpec;
@@ -27,6 +28,7 @@ export const rdfaDomAttrs = {
   about: { default: null },
   __rdfaId: { default: undefined },
   'data-rdfa-node-type': { default: undefined },
+  datatype: { default: null },
 };
 
 export const rdfaNodeTypes = ['resource', 'literal'] as const;
@@ -126,7 +128,10 @@ export function renderInvisibleRdfa(
   for (const prop of properties) {
     const { type, predicate } = prop;
     if (type === 'attribute') {
-      if (prop.object && (isFullUri(prop.object) || isPrefixedUri(prop.object))) {
+      if (
+        prop.object &&
+        (isFullUri(prop.object) || isPrefixedUri(prop.object))
+      ) {
         propElements.push([
           'span',
           { property: predicate, resource: prop.object },
@@ -172,6 +177,7 @@ export function renderRdfaAttrs(
             nodeOrMark.attrs.resource) as string,
           property: contentPred.predicate,
           resource: null,
+          datatype: (nodeOrMark.attrs.datatype as string) ?? null,
         }
       : {
           about: (nodeOrMark.attrs.subject ||
@@ -189,6 +195,7 @@ export function renderRdfaAttrs(
       about: backlinks[0].subject,
       property: backlinks[0].predicate,
       'data-literal-node': 'true',
+      datatype: (nodeOrMark.attrs.datatype as string) ?? null,
     };
   }
 }

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -233,6 +233,8 @@ export function renderRdfaAware({
   delete clone.rdfaNodeType;
   const renderAttrs = { ...clone, ...renderRdfaAttrs(renderable) };
   let { property } = renderAttrs;
+  // The return from renderRdfaAttrs can include a null datatype, so in this case we want to still
+  // use the one from the passed attrs.
   let datatype = renderAttrs.datatype || clone.datatype;
   if (datatype === 'rdf:XMLLiteral') {
     contentContainerAttrs = {

--- a/addon/utils/_private/datastore/graphy-dataset.ts
+++ b/addon/utils/_private/datastore/graphy-dataset.ts
@@ -96,6 +96,11 @@ export class GraphyDataset implements QuadDataSet {
     return new GraphyDataset(this.fastDataset.difference(gds.fastDataset));
   }
 
+  minus(other: QuadDataSet): QuadDataSet {
+    const gds = new GraphyDataset(other);
+    return new GraphyDataset(this.fastDataset.minus(gds.fastDataset));
+  }
+
   equals(other: RDF.Dataset<RDF.Quad, RDF.Quad>): boolean {
     const gds = new GraphyDataset(other);
     return this.fastDataset.equals(gds.fastDataset);

--- a/tests/integration/rdfa/blackbox-test.ts
+++ b/tests/integration/rdfa/blackbox-test.ts
@@ -83,12 +83,16 @@ module('Integration | RDFa blackbox test ', function () {
       controller.initialize(outputHTML);
 
       const finalHTML = controller.htmlContent;
-      assert.strictEqual(outputHTML, finalHTML);
+      assert.strictEqual(finalHTML, outputHTML);
       const resultingDataset = calculateDataset(finalHTML);
       const isEqual = initialDataset.equals(resultingDataset);
       const initialTurtle = (await toTurtle(initialDataset)).trim();
       const resultingTurtle = (await toTurtle(resultingDataset)).trim();
       const message = `
+        In initial dataset but not in result:
+        ${(await toTurtle(initialDataset.minus(resultingDataset))) || '<empty>'}
+        In resulting dataset but not in initial data:
+        ${(await toTurtle(resultingDataset.minus(initialDataset))) || '<empty>'}
         Before:
         ${initialTurtle || '<empty>'}
         After:

--- a/tests/integration/rdfa/test-cases.ts
+++ b/tests/integration/rdfa/test-cases.ts
@@ -3,7 +3,7 @@ import { oneLineTrim } from 'common-tags';
 /**
  * test cases imported from https://www.w3.org/2006/07/SWD/RDFa/testsuite/
  */
-const TEST_CASES = {
+const IMPORTED_TEST_CASES = {
   //   '000002': `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
   // 	"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
   // <html xmlns="http://www.w3.org/1999/xhtml"
@@ -675,4 +675,13 @@ const TEST_CASES = {
 </div>`,
 };
 
-export default TEST_CASES;
+export default {
+  ...IMPORTED_TEST_CASES,
+  datatype: oneLineTrim(`
+  <div lang="nl-BE" data-say-document="true" resource="http://example.com/test/5">
+    <div property="say:body" datatype="rdf:XMLLiteral">
+      <p>test</p>
+    </div>
+  </div>
+  `),
+}


### PR DESCRIPTION
### Overview
I wasn't going to make this a PR to a PR but then I realised that some parts of it are questionable, so we should think about which of the commits to keep.

In trying to correct the handling of `datatype` attributes when parsing RDFa, I realised that the datatype `XMLLiteral` has the difficult side-effect that any changes to the HTML content of that element are reflected in the RDF data, so it will be incredibly hard to pass an element with this attribute through the editor without modifying the data. These changes are enough to make a very minimal blackbox test work, but they will fail as soon as there are elements which are picked up as RDFa aware within the element with datatype `XMLLiteral`.

I'm not sure of the value of value of having this artificially simple example working, but some of the parts should be kept and it highlights the need to handle this in some way for this kind of test, either by handling triples with an object which is an `XMLLiteral` typed string differently (or ignoring them), or by stripping this attribute for these tests.

##### connected issues and PRs:
Made to #1077.
#1086 split out and those commits removed from this PR.

### Setup

### How to test/reproduce
Changes most easily seen in tests, but can also copy the `dataset` test from `test-cases.ts` into `sample-data.ts` to insert it into the editor dummy app.

### Challenges/uncertainties
N/A
