### PR TITLE
GN-4659: do not clean empty elements when they have attributes

### DIFF
--- a/.changeset/loud-cooks-float.md
+++ b/.changeset/loud-cooks-float.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Do not clean up empty elements when they have attributes

--- a/addon/utils/_private/ce/paste-handler-helper-functions/cleanEmptyElements.ts
+++ b/addon/utils/_private/ce/paste-handler-helper-functions/cleanEmptyElements.ts
@@ -1,22 +1,13 @@
 import { traverseElements } from './traverseElements';
-import { RDFA_ATTRIBUTES } from '../../constants';
 
 const ALLOWED_EMPTY_ELEMENTS = ['BR', 'IMG', 'TR', 'TD'];
 const NOTRIM_ELEMENTS = ['SPAN'];
 
-function hasRdfaAttributes(element: Element) {
-  for (const attr of RDFA_ATTRIBUTES) {
-    if (element.hasAttribute(attr)) {
-      return true;
-    }
-  }
-  return false;
-}
 function isEmpty(element: Element): boolean {
   if (ALLOWED_EMPTY_ELEMENTS.includes(element.nodeName)) {
     return false;
   }
-  if (hasRdfaAttributes(element)) {
+  if (element.hasAttributes()) {
     return false;
   }
   let content;

--- a/tests/unit/utils/html-input-parser-test.ts
+++ b/tests/unit/utils/html-input-parser-test.ts
@@ -168,15 +168,19 @@ module('Utils | CS | HTMLInputParser', function () {
        <ol>
          <li>
            <span style=\"font-size:18.0pt;mso-ansi-language:EN-US\" lang=\"EN-US\">Test1</span>
+           <span style=\"font-size:18.0pt\"></span>
            <ol>
              <li>
                <span style=\"font-size:18.0pt; mso-ansi-language:EN-US\" lang=\"EN-US\">Subtest1</span>
+               <span style=\"font-size:18.0pt\"></span>
                <ol>
                  <li>
                    <span style=\"font-size:18.0pt;mso-ansi-language:EN-US\" lang=\"EN-US\">Subsubset1.1</span>
+                   <span style=\"font-size:18.0pt\"></span>
                    <ol>
                      <li>
                        <span style=\"font-size:18.0pt;mso-ansi-language:EN-US\" lang=\"EN-US\">Sub-sub-subet1.1</span>
+                       <span style=\"font-size:18.0pt\"></span>
                      </li>
                    </ol>
                  </li>
@@ -186,6 +190,7 @@ module('Utils | CS | HTMLInputParser', function () {
          </li>
          <li>
            <span style=\"font-size:18.0pt;mso-ansi-language:EN-US\" lang=\"EN-US\">Test 2</span>
+           <span style=\"font-size:18.0pt\"></span>
          </li>
        </ol>`;
     const htmlContent = oneLineTrim`
@@ -680,23 +685,44 @@ module('Utils | CS | HTMLInputParser', function () {
   test('It should display a complex nested list correctly as HTML', function (assert) {
     const inputParser = new HTMLInputParser({ editorView });
     const expectedHtml = oneLineTrim`<ol>
-    <li><span style="font-size:18.0pt;mso-ansi-language:EN-US" lang="EN-US">1</span>
+    <li>
+        <span style="font-size:18.0pt;mso-ansi-language:EN-US" lang="EN-US">1</span>
+        <span style=\"font-size:18.0pt\"></span>
         <ol>
-            <li><span style="font-size:18.0pt; mso-ansi-language:EN-US" lang="EN-US">1.1</span></li>
-            <li><span style="font-size:18.0pt; mso-ansi-language:EN-US" lang="EN-US">1.2</span>
-                <ol>
-                    <li><span style="font-size:18.0pt;mso-ansi-language:EN-US" lang="EN-US">1.2.1</span>
-                        <ol>
-                            <li><span style="font-size:18.0pt;mso-ansi-language:EN-US" lang="EN-US">1.2.1.1</span></li>
-                            <li><span style="font-size:18.0pt;mso-ansi-language:EN-US" lang="EN-US">1.2.1.2</span></li>
-                        </ol>
-                    </li>
-                </ol>
+            <li>
+              <span style="font-size:18.0pt; mso-ansi-language:EN-US" lang="EN-US">1.1</span>
+              <span style=\"font-size:18.0pt\"></span>
             </li>
-            <li><span style="font-size:18.0pt; mso-ansi-language:EN-US" lang="EN-US">1.3</span></li>
+            <li>
+              <span style="font-size:18.0pt; mso-ansi-language:EN-US" lang="EN-US">1.2</span>
+              <span style=\"font-size:18.0pt\"></span>
+              <ol>
+                <li>
+                  <span style="font-size:18.0pt;mso-ansi-language:EN-US" lang="EN-US">1.2.1</span>
+                  <span style=\"font-size:18.0pt\"></span>
+                  <ol>
+                    <li>
+                      <span style="font-size:18.0pt;mso-ansi-language:EN-US" lang="EN-US">1.2.1.1</span>
+                      <span style=\"font-size:18.0pt\"></span>
+                    </li>
+                    <li>
+                      <span style="font-size:18.0pt;mso-ansi-language:EN-US" lang="EN-US">1.2.1.2</span>
+                      <span style=\"font-size:18.0pt\"></span>
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <span style="font-size:18.0pt; mso-ansi-language:EN-US" lang="EN-US">1.3</span>
+              <span style=\"font-size:18.0pt\"></span>
+            </li>
         </ol>
     </li>
-    <li><span style="font-size:18.0pt;mso-ansi-language:EN-US" lang="EN-US">2</span></li>
+    <li>
+      <span style="font-size:18.0pt;mso-ansi-language:EN-US" lang="EN-US">2</span>
+      <span style=\"font-size:18.0pt\"></span>
+    </li>
 </ol>
     `;
     const htmlContent = oneLineTrim`


### PR DESCRIPTION
### Overview
This PR includes a possible solution to [GN-4659](https://binnenland.atlassian.net/browse/GN-4659?atlOrigin=eyJpIjoiNjE5YmUzM2I0NzQwNGQzZmFiZTY1ZWRhYmE1ZGY4M2MiLCJwIjoiaiJ9), which describes a bug with empty elements containing relevant attributes being removed when pasting/setting the content of the editor.

This PR ensures that empty elements containing any attribute are not pruned away.

Additionally, this PR includes some changes to tests of the `html-input-parser` module to ensure that empty elements with attributes are allowed.

##### connected issues and PRs:
[GN-4659](https://binnenland.atlassian.net/browse/GN-4659?atlOrigin=eyJpIjoiNjE5YmUzM2I0NzQwNGQzZmFiZTY1ZWRhYmE1ZGY4M2MiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the dummy app
- Create an empty document
- Set the alignment of the first empty paragraph to right/center
- Reload the document
- Ensure that the alignment is not reset

### Challenges/uncertainties
The bug this PR is trying to solve is caused by the fact that the the docx-cleaner is now always executed when:
- Pasting html content to the editor
- When setting the html content of the editor

Two alternative solutions to this problem are:
- Add the p and header tags to the allowed empty elements
- Only run the docx-cleaner when pasting, not when setting the whole content of the editor. (This issue will then still occur when pasting from word/anywhere else)

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
