### PR TITLE
Fix text and highlight colour toggles when selecting multiple table cells

### DIFF
--- a/.changeset/stale-cats-change.md
+++ b/.changeset/stale-cats-change.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Fix highlight and text color behaviour when multiple table cells are selected

--- a/addon/commands/toggle-mark-add-first.ts
+++ b/addon/commands/toggle-mark-add-first.ts
@@ -22,7 +22,7 @@ export function rangeHasMarkEverywhere(
       if (node.isText && keepSearching) {
         const mark = markType.isInSet(node.marks);
         const hasMark =
-          !markAttrs || !mark ? !!mark : shallowEqual(mark.attrs, markAttrs);
+          !!mark && (!markAttrs || shallowEqual(markAttrs, mark.attrs));
         found = hasMark;
         if (!hasMark) {
           keepSearching = false;

--- a/addon/commands/toggle-mark-add-first.ts
+++ b/addon/commands/toggle-mark-add-first.ts
@@ -2,19 +2,27 @@ import { PNode } from '@lblod/ember-rdfa-editor';
 import { Attrs, MarkType, ResolvedPos } from 'prosemirror-model';
 import { Command, SelectionRange, TextSelection } from 'prosemirror-state';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
+import { shallowEqual } from '@lblod/ember-rdfa-editor/utils/_private/object-utils';
 
+/**
+ * Check that between 2 positions in a Node the same mark is set. Optionally only consider marks
+ * equal if they have the same attributes.
+ **/
 export function rangeHasMarkEverywhere(
   root: PNode,
   from: number,
   to: number,
   markType: MarkType,
+  markAttrs?: Attrs | null,
 ) {
   let found = false;
   let keepSearching = true;
   if (to > from) {
     root.nodesBetween(from, to, (node) => {
       if (node.isText && keepSearching) {
-        const hasMark = !!markType.isInSet(node.marks);
+        const mark = markType.isInSet(node.marks);
+        const hasMark =
+          !markAttrs || !mark ? !!mark : shallowEqual(mark.attrs, markAttrs);
         found = hasMark;
         if (!hasMark) {
           keepSearching = false;
@@ -51,8 +59,10 @@ function markApplies(
   return false;
 }
 
-/* return { from, to } with the positions adjusted so any starting or ending spaces
- are not part of the range anymore. */
+/**
+ * return { from, to } with the positions adjusted so any starting or ending spaces
+ * are not part of the range anymore.
+ **/
 function fromToWithoutEdgeSpaces(
   $from: ResolvedPos,
   $to: ResolvedPos,
@@ -98,20 +108,22 @@ export function toggleMarkAddFirst(
     }
     if (dispatch) {
       if ($cursor) {
-        if (markType.isInSet(state.storedMarks || $cursor.marks())) {
+        const mark = markType.isInSet(state.storedMarks || $cursor.marks());
+        if (mark && (!attrs || shallowEqual(attrs, mark.attrs))) {
           dispatch(state.tr.removeStoredMark(markType));
         } else {
           dispatch(state.tr.addStoredMark(markType.create(attrs)));
         }
       } else {
-        let has = false;
+        // 'has' will remain true only if all of the ranges have the mark everywhere
+        let has = true;
         const tr = state.tr;
-        for (let i = 0; !has && i < ranges.length; i++) {
+        for (let i = 0; has && i < ranges.length; i++) {
           const { $from, $to } = ranges[i];
           // don't check the spaces before and after, as these might not contain the mark
           // as expected because of the special `space logic` below.
           const { from, to } = fromToWithoutEdgeSpaces($from, $to);
-          has = rangeHasMarkEverywhere(state.doc, from, to, markType);
+          has = rangeHasMarkEverywhere(state.doc, from, to, markType, attrs);
         }
         for (let i = 0; i < ranges.length; i++) {
           const { $from, $to } = ranges[i];

--- a/addon/components/toolbar/mark.ts
+++ b/addon/components/toolbar/mark.ts
@@ -7,7 +7,7 @@ type Args = {
   controller: SayController;
   mark: string;
 };
-export default class BoldComponent extends Component<Args> {
+export default class MarkComponent extends Component<Args> {
   get controller() {
     return this.args.controller;
   }

--- a/addon/core/say-controller.ts
+++ b/addon/core/say-controller.ts
@@ -1,12 +1,13 @@
 import { SayStore } from '@lblod/ember-rdfa-editor/utils/_private/datastore/say-store';
 import Owner from '@ember/owner';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
+import { shallowEqual } from '@lblod/ember-rdfa-editor/utils/_private/object-utils';
 import { datastoreKey } from '@lblod/ember-rdfa-editor/plugins/datastore';
 import { rangeHasMarkEverywhere } from '@lblod/ember-rdfa-editor/commands/toggle-mark-add-first';
 import SayView from '@lblod/ember-rdfa-editor/core/say-view';
 import SayEditor from '@lblod/ember-rdfa-editor/core/say-editor';
 import { tracked } from '@glimmer/tracking';
-import { MarkType, Schema } from 'prosemirror-model';
+import { Attrs, MarkType, Schema } from 'prosemirror-model';
 import {
   Command,
   EditorState,
@@ -96,13 +97,14 @@ export default class SayController {
     return command(view.state);
   }
 
-  isMarkActive(markType: MarkType) {
+  isMarkActive(markType: MarkType, attrs?: Attrs) {
     const state = this.activeEditorState;
     const { from, $from, to, empty } = state.selection;
     if (empty) {
-      return !!markType.isInSet(state.storedMarks || $from.marks());
+      const mark = markType.isInSet(state.storedMarks || $from.marks());
+      return !!mark && (!attrs || shallowEqual(attrs, mark.attrs));
     } else {
-      return rangeHasMarkEverywhere(state.doc, from, to, markType);
+      return rangeHasMarkEverywhere(state.doc, from, to, markType, attrs);
     }
   }
 

--- a/addon/plugins/color/commands/set-color.ts
+++ b/addon/plugins/color/commands/set-color.ts
@@ -1,16 +1,19 @@
-import { Command, Selection } from 'prosemirror-state';
+import { Command } from 'prosemirror-state';
+import { toggleMarkAddFirst } from '@lblod/ember-rdfa-editor/commands/toggle-mark-add-first';
 
 export function setColor(color: string): Command {
   return function (state, dispatch) {
     if (dispatch) {
       const { schema, selection } = state;
-      const mark = schema.marks.color.create({ color });
+      const markAttrs = { color };
       const tr = state.tr;
       if (selection.empty) {
+        const mark = schema.marks.color.create(markAttrs);
         tr.addStoredMark(mark);
       } else {
-        tr.addMark(tr.selection.from, tr.selection.to, mark).setSelection(
-          Selection.near(tr.selection.$to),
+        return toggleMarkAddFirst(schema.marks.color, markAttrs)(
+          state,
+          dispatch,
         );
       }
       dispatch(tr);

--- a/addon/plugins/highlight/commands/set-highlight.ts
+++ b/addon/plugins/highlight/commands/set-highlight.ts
@@ -1,16 +1,19 @@
-import { Command, Selection } from 'prosemirror-state';
+import { Command } from 'prosemirror-state';
+import { toggleMarkAddFirst } from '@lblod/ember-rdfa-editor/commands/toggle-mark-add-first';
 
 export function setHighlight(color: string): Command {
   return function (state, dispatch) {
     if (dispatch) {
       const { schema, selection } = state;
-      const mark = schema.marks.highlight.create({ value: color });
+      const markAttrs = { value: color };
       const tr = state.tr;
       if (selection.empty) {
+        const mark = schema.marks.highlight.create(markAttrs);
         tr.addStoredMark(mark);
       } else {
-        tr.addMark(tr.selection.from, tr.selection.to, mark).setSelection(
-          Selection.near(tr.selection.$to),
+        return toggleMarkAddFirst(schema.marks.highlight, markAttrs)(
+          state,
+          dispatch,
         );
       }
       dispatch(tr);

--- a/addon/utils/_private/object-utils.ts
+++ b/addon/utils/_private/object-utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Compare two objects for equality using a simple equality check for values
+ */
+export function shallowEqual(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+) {
+  const aEntries = Object.entries(a);
+  return (
+    aEntries.length === Object.entries(b).length &&
+    aEntries.every(([key, val]) => val === b[key])
+  );
+}


### PR DESCRIPTION
### Overview
Fix setting text colors and highlights when multiple table cells are selected (instead of just toggling for the last cell).

This issue was actually in the implementation of the set-color and set-highlight commands as they were not handling some selection types well. In switching to a command which handles these selections well, I realised that our command was based on a prosemirror internal command which [incorrectly treats marks with different attributes as equal](https://github.com/ProseMirror/prosemirror/issues/771). I modified this command to do a shallow comparison of the mark's attributes, so e.g. red and green highlights are treated as if they are different marks, as the user would expect.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4661

### Setup
N/A

### How to test/reproduce
Select multiple table cells and choose a highlight or text colour, see that the colour is applied to all cells. See video in [Jira issue](https://binnenland.atlassian.net/browse/GN-4661) for illustration.

Secondary improved behaviour, selecting text that already has a highlight (or colour) applied, and applying the same highlight again, now clears the highlight instead of having no effect. This mimics e.g. applying bold. If any part of the selection does not have the highlight, the highlight is applied to the whole selection instead of being cleared.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
