### PR TITLE
Apply formatting to html and xml shown in codemirror debug-editor

### DIFF
--- a/.changeset/tricky-dogs-smell.md
+++ b/.changeset/tricky-dogs-smell.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Apply formatting to html/xml shown in codemirror debug editor

--- a/addon/components/debug-tools.ts
+++ b/addon/components/debug-tools.ts
@@ -2,7 +2,8 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import xmlFormat from 'xml-formatter';
-import { basicSetup, EditorView } from 'codemirror';
+import { basicSetup } from 'codemirror';
+import { EditorView, keymap } from '@codemirror/view';
 import { xml } from '@codemirror/lang-xml';
 import { html } from '@codemirror/lang-html';
 import sampleData from '../config/sample-data';
@@ -10,7 +11,6 @@ import { EditorState } from '@codemirror/state';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import ApplicationInstance from '@ember/application/instance';
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
-
 interface DebugToolArgs {
   controller?: SayController;
 }
@@ -59,7 +59,7 @@ export default class RdfaEditorDebugTools extends Component<DebugToolArgs> {
       parent: element,
     });
     this.xmlEditor.dispatch({
-      changes: { from: 0, insert: this.debuggerContent },
+      changes: { from: 0, insert: this.formattedDebuggerContent },
     });
   }
 
@@ -72,11 +72,11 @@ export default class RdfaEditorDebugTools extends Component<DebugToolArgs> {
       parent: element,
     });
     this.htmlEditor.dispatch({
-      changes: { from: 0, insert: this.debuggerContent },
+      changes: { from: 0, insert: this.formattedDebuggerContent },
     });
   }
 
-  get formattedXmlContent() {
+  get formattedDebuggerContent() {
     if (this.debuggerContent) {
       try {
         return xmlFormat(this.debuggerContent);

--- a/addon/components/debug-tools.ts
+++ b/addon/components/debug-tools.ts
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import xmlFormat from 'xml-formatter';
 import { basicSetup } from 'codemirror';
-import { EditorView, keymap } from '@codemirror/view';
+import { EditorView } from '@codemirror/view';
 import { xml } from '@codemirror/lang-xml';
 import { html } from '@codemirror/lang-html';
 import sampleData from '../config/sample-data';


### PR DESCRIPTION
### Overview
This PR ensures that the html/xml documents shown in the codemirror debug-editor are formatted using the `xml-formatter` package. This should make it easier to debug/inspect the output of the editor.

##### connected issues and PRs:
None

### How to test/reproduce
- Open the `CustomHTML` modal.
- Ensure that the html content shown is correctly formatted.

### Challenges/uncertainties
Using the standalone `prettier` package with the html plugin is another option, but I could not directly get this to work.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
