### PR TITLE
Only set attributes on paragraphWithConfig node when non-default

### DIFF
--- a/.changeset/eight-moons-pump.md
+++ b/.changeset/eight-moons-pump.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+When creating paragraph elements, do not set a style attribute if there is no style, instead of setting an empty attribute.

--- a/.changeset/gold-pumpkins-kneel.md
+++ b/.changeset/gold-pumpkins-kneel.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+When creating paragraph elements, only set an indentation level data attribute if the indentation level is non-zero.

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -12,6 +12,7 @@ export type ParagraphDataAttributes = {
 
 export type ParagraphNodeSpec = NodeSpec & { subType: string };
 
+const DEFAULT_INDENTATION = 0;
 const BLOCK_SELECTOR = `:not(${NON_BLOCK_NODES.join(', ')})`;
 const BASE_PARAGRAPH_TYPE = 'paragraph';
 const matchingSubType = (node: HTMLElement, subType: string) => {
@@ -43,7 +44,7 @@ export const paragraphWithConfig: (
         default: DEFAULT_ALIGNMENT,
       },
       indentationLevel: {
-        default: null,
+        default: DEFAULT_INDENTATION,
       },
     },
     parseDOM: [
@@ -81,7 +82,7 @@ export const paragraphWithConfig: (
 
           return {
             indentationLevel: optionMapOr(
-              null,
+              DEFAULT_INDENTATION,
               parseInt,
               node.dataset.indentationLevel,
             ),
@@ -97,7 +98,10 @@ export const paragraphWithConfig: (
       if (alignment && alignment !== DEFAULT_ALIGNMENT) {
         attrs.style = `text-align: ${alignment}`;
       }
-      if (Number.isInteger(indentationLevel)) {
+      if (
+        Number.isInteger(indentationLevel) &&
+        indentationLevel !== DEFAULT_INDENTATION
+      ) {
         attrs['data-indentation-level'] = indentationLevel as number;
       }
       const subType = (node.type.spec as ParagraphNodeSpec).subType;

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -5,8 +5,9 @@ import { optionMapOr } from '../utils/_private/option';
 import { DEFAULT_ALIGNMENT, getAlignment } from '../plugins/alignment';
 
 export type ParagraphDataAttributes = {
-  'data-indentation-level': number;
+  'data-indentation-level'?: number;
   'data-sub-type'?: string;
+  style?: string;
 };
 
 export type ParagraphNodeSpec = NodeSpec & { subType: string };
@@ -50,7 +51,7 @@ export const paragraphWithConfig: (
         default: DEFAULT_ALIGNMENT,
       },
       indentationLevel: {
-        default: 0,
+        default: null,
       },
     },
     parseDOM: [
@@ -61,7 +62,7 @@ export const paragraphWithConfig: (
           if (nonBlockNode && matchingSubType(node, config.subType)) {
             return {
               indentationLevel: optionMapOr(
-                0,
+                null,
                 parseInt,
                 node.dataset.indentationLevel,
               ),
@@ -84,7 +85,7 @@ export const paragraphWithConfig: (
 
           return {
             indentationLevel: optionMapOr(
-              0,
+              null,
               parseInt,
               node.dataset.indentationLevel,
             ),
@@ -96,18 +97,18 @@ export const paragraphWithConfig: (
     ],
     toDOM(node) {
       const { alignment, indentationLevel } = node.attrs;
-      let style = '';
+      const attrs: ParagraphDataAttributes = {};
       if (alignment && alignment !== DEFAULT_ALIGNMENT) {
-        style += `text-align: ${alignment}`;
+        attrs.style = `text-align: ${alignment}`;
       }
-      const attrs: ParagraphDataAttributes = {
-        'data-indentation-level': indentationLevel as number,
-      };
+      if (Number.isInteger(indentationLevel)) {
+        attrs['data-indentation-level'] = indentationLevel as number;
+      }
       const subType = (node.type.spec as ParagraphNodeSpec).subType;
       if (subType) {
         attrs['data-sub-type'] = subType;
       }
-      return ['p', { ...attrs, style }, 0];
+      return ['p', attrs, 0];
     },
   };
 };


### PR DESCRIPTION
### Overview
Was originally part of #1079 but separated as it does not rely on RDFa work.

Prevent empty style attributes and data attributes with indentationLevel = 0 by default for paragraph nodes.

##### connected issues and PRs:
Cherry-picked from #1079.

### Setup
N/A

### How to test/reproduce
In the editor, press enter to insert a new paragraph and inspect the html. The paragraph should just be a `<p>` element rather than `<p data-indentation-level=0 style="">`.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
