### PR TITLE
Consider all selection ranges when determining if mark is set

### DIFF
--- a/.changeset/lazy-jokes-sniff.md
+++ b/.changeset/lazy-jokes-sniff.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Fix behaviour of formatting marks for some selections, such as selecting multiple table cells. Now all cells are considered rather than just the last one to be selected.

--- a/addon/commands/toggle-mark-add-first.ts
+++ b/addon/commands/toggle-mark-add-first.ts
@@ -1,89 +1,11 @@
-import { PNode } from '@lblod/ember-rdfa-editor';
-import { Attrs, MarkType, ResolvedPos } from 'prosemirror-model';
-import { Command, SelectionRange, TextSelection } from 'prosemirror-state';
-import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
+import { Attrs, MarkType } from 'prosemirror-model';
+import { Command, TextSelection } from 'prosemirror-state';
 import { shallowEqual } from '@lblod/ember-rdfa-editor/utils/_private/object-utils';
-
-/**
- * Check that between 2 positions in a Node the same mark is set. Optionally only consider marks
- * equal if they have the same attributes.
- **/
-export function rangeHasMarkEverywhere(
-  root: PNode,
-  from: number,
-  to: number,
-  markType: MarkType,
-  markAttrs?: Attrs | null,
-) {
-  let found = false;
-  let keepSearching = true;
-  if (to > from) {
-    root.nodesBetween(from, to, (node) => {
-      if (node.isText && keepSearching) {
-        const mark = markType.isInSet(node.marks);
-        const hasMark =
-          !!mark && (!markAttrs || shallowEqual(markAttrs, mark.attrs));
-        found = hasMark;
-        if (!hasMark) {
-          keepSearching = false;
-        }
-      }
-      return keepSearching;
-    });
-  }
-  return found;
-}
-
-function markApplies(
-  doc: PNode,
-  ranges: readonly SelectionRange[],
-  type: MarkType,
-) {
-  for (let i = 0; i < ranges.length; i++) {
-    const { $from, $to } = ranges[i];
-    let can =
-      $from.depth == 0
-        ? doc.inlineContent && doc.type.allowsMarkType(type)
-        : false;
-    doc.nodesBetween($from.pos, $to.pos, (node) => {
-      if (can) {
-        return false;
-      }
-      can = node.inlineContent && node.type.allowsMarkType(type);
-      return true;
-    });
-    if (can) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * return { from, to } with the positions adjusted so any starting or ending spaces
- * are not part of the range anymore.
- **/
-function fromToWithoutEdgeSpaces(
-  $from: ResolvedPos,
-  $to: ResolvedPos,
-): { from: number; to: number } {
-  let from = $from.pos;
-  let to = $to.pos;
-  const start = $from.nodeAfter;
-  const end = $to.nodeBefore;
-
-  const spaceStart =
-    start && start.isText
-      ? unwrap(/^\s*/.exec(unwrap(start.text)))[0].length
-      : 0;
-  const spaceEnd =
-    end && end.isText ? unwrap(/\s*$/.exec(unwrap(end.text)))[0].length : 0;
-  if (from + spaceStart < to) {
-    from += spaceStart;
-    to -= spaceEnd;
-  }
-  return { from, to };
-}
+import {
+  fromToWithoutEdgeSpaces,
+  markApplies,
+  selectionHasMarkEverywhere,
+} from '@lblod/ember-rdfa-editor/utils/_private/mark-utils';
 
 /**
  * Adapted from https://github.com/ProseMirror/prosemirror-commands/blob/7635496296b2e561a5893b03154bd89c127a6972/src/commands.ts#L579
@@ -115,26 +37,18 @@ export function toggleMarkAddFirst(
           dispatch(state.tr.addStoredMark(markType.create(attrs)));
         }
       } else {
-        // 'has' will remain true only if all of the ranges have the mark everywhere
-        let has = true;
+        const hasEverywhere = selectionHasMarkEverywhere(
+          state.doc,
+          state.selection,
+          markType,
+          attrs ?? undefined,
+        );
         const tr = state.tr;
-        for (let i = 0; has && i < ranges.length; i++) {
-          const { $from, $to } = ranges[i];
-          // don't check the spaces before and after, as these might not contain the mark
-          // as expected because of the special `space logic` below.
-          const { from, to } = fromToWithoutEdgeSpaces($from, $to);
-          has = rangeHasMarkEverywhere(state.doc, from, to, markType, attrs);
-        }
         for (let i = 0; i < ranges.length; i++) {
           const { $from, $to } = ranges[i];
-          if (has) {
+          if (hasEverywhere) {
             tr.removeMark($from.pos, $to.pos, markType);
           } else {
-            // ### space logic ###
-            // if adding marks, do not add it the starting/final spaces,
-            // to avoid the mark still applying when typing behind this space.
-            // e.g. with text (between * highlighted)= `*ab *some text`, and setting bold
-            // we don't want to have the new typed text be bold if putting the cursor between `*s`.
             const { from, to } = fromToWithoutEdgeSpaces($from, $to);
             tr.addMark(from, to, markType.create(attrs));
           }

--- a/addon/core/say-controller.ts
+++ b/addon/core/say-controller.ts
@@ -3,7 +3,7 @@ import Owner from '@ember/owner';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import { shallowEqual } from '@lblod/ember-rdfa-editor/utils/_private/object-utils';
 import { datastoreKey } from '@lblod/ember-rdfa-editor/plugins/datastore';
-import { rangeHasMarkEverywhere } from '@lblod/ember-rdfa-editor/commands/toggle-mark-add-first';
+import { selectionHasMarkEverywhere } from '@lblod/ember-rdfa-editor/utils/_private/mark-utils';
 import SayView from '@lblod/ember-rdfa-editor/core/say-view';
 import SayEditor from '@lblod/ember-rdfa-editor/core/say-editor';
 import { tracked } from '@glimmer/tracking';
@@ -99,12 +99,17 @@ export default class SayController {
 
   isMarkActive(markType: MarkType, attrs?: Attrs) {
     const state = this.activeEditorState;
-    const { from, $from, to, empty } = state.selection;
+    const { $from, empty } = state.selection;
     if (empty) {
       const mark = markType.isInSet(state.storedMarks || $from.marks());
       return !!mark && (!attrs || shallowEqual(attrs, mark.attrs));
     } else {
-      return rangeHasMarkEverywhere(state.doc, from, to, markType, attrs);
+      return selectionHasMarkEverywhere(
+        state.doc,
+        state.selection,
+        markType,
+        attrs,
+      );
     }
   }
 

--- a/addon/utils/_private/mark-utils.ts
+++ b/addon/utils/_private/mark-utils.ts
@@ -1,0 +1,112 @@
+import { PNode } from '@lblod/ember-rdfa-editor';
+import { Attrs, MarkType, ResolvedPos } from 'prosemirror-model';
+import { SelectionRange, Selection } from 'prosemirror-state';
+import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
+import { shallowEqual } from '@lblod/ember-rdfa-editor/utils/_private/object-utils';
+
+/**
+ * Check that between 2 positions in a Node the same mark is set. Optionally only consider marks
+ * equal if they have the same attributes.
+ **/
+export function rangeHasMarkEverywhere(
+  root: PNode,
+  from: number,
+  to: number,
+  markType: MarkType,
+  markAttrs?: Attrs | null,
+) {
+  let found = false;
+  let keepSearching = true;
+  if (to > from) {
+    root.nodesBetween(from, to, (node) => {
+      if (node.isText && keepSearching) {
+        const mark = markType.isInSet(node.marks);
+        const hasMark =
+          !!mark && (!markAttrs || shallowEqual(markAttrs, mark.attrs));
+        found = hasMark;
+        if (!hasMark) {
+          keepSearching = false;
+        }
+      }
+      return keepSearching;
+    });
+  }
+  return found;
+}
+
+/**
+ * return { from, to } with the positions adjusted so any starting or ending spaces
+ * are not part of the range anymore.
+ * ### space logic ###
+ * if adding marks, do not add it the starting/final spaces,
+ * to avoid the mark still applying when typing behind this space.
+ * e.g. with text (between * highlighted)= `*ab *some text`, and setting bold
+ * we don't want to have the new typed text be bold if putting the cursor between `*s`.
+ **/
+export function fromToWithoutEdgeSpaces(
+  $from: ResolvedPos,
+  $to: ResolvedPos,
+): { from: number; to: number } {
+  let from = $from.pos;
+  let to = $to.pos;
+  const start = $from.nodeAfter;
+  const end = $to.nodeBefore;
+
+  const spaceStart =
+    start && start.isText
+      ? unwrap(/^\s*/.exec(unwrap(start.text)))[0].length
+      : 0;
+  const spaceEnd =
+    end && end.isText ? unwrap(/\s*$/.exec(unwrap(end.text)))[0].length : 0;
+  if (from + spaceStart < to) {
+    from += spaceStart;
+    to -= spaceEnd;
+  }
+  return { from, to };
+}
+
+/**
+ * Check whether a mark is set everywhere within a selection, including in all of the ranges within
+ * it. Optionally only consider marks equal if they have the same attributes. Don't check any spaces
+ * before and after, as the user can't see whether these contain the mark.
+ **/
+export function selectionHasMarkEverywhere(
+  doc: PNode,
+  { ranges }: Selection,
+  markType: MarkType,
+  attrs?: Attrs,
+) {
+  // 'has' will remain true only if all of the ranges have the mark everywhere
+  let has = true;
+  for (let i = 0; has && i < ranges.length; i++) {
+    const { $from, $to } = ranges[i];
+    const { from, to } = fromToWithoutEdgeSpaces($from, $to);
+    has = rangeHasMarkEverywhere(doc, from, to, markType, attrs);
+  }
+  return has;
+}
+
+export function markApplies(
+  doc: PNode,
+  ranges: readonly SelectionRange[],
+  type: MarkType,
+) {
+  for (let i = 0; i < ranges.length; i++) {
+    const { $from, $to } = ranges[i];
+    let can =
+      $from.depth == 0
+        ? doc.inlineContent && doc.type.allowsMarkType(type)
+        : false;
+    doc.nodesBetween($from.pos, $to.pos, (node) => {
+      if (can) {
+        return false;
+      }
+      can = node.inlineContent && node.type.allowsMarkType(type);
+      return true;
+    });
+    if (can) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
### Overview
Move the range looping logic from the toggle-mark command to a separate function, move these utils to a file, and use them in the `isMarkActive` check.

##### connected issues and PRs:
Related to the work done in #1084

### Setup
N/A

### How to test/reproduce
Create a table, apply a mark (e.g. bold) to some of the cells. The toolbar button will only appear 'active' if all the selected cells have that mark. Previously, only the last-selected cell was checked.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
