### PR TITLE
Absolutely position toolbar dropdowns to avoid unreachable items

### DIFF
--- a/.changeset/healthy-papayas-check.md
+++ b/.changeset/healthy-papayas-check.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Allow dropbown menus to extend beyond editor container when embedded as a very small window

--- a/addon/components/toolbar/dropdown.hbs
+++ b/addon/components/toolbar/dropdown.hbs
@@ -1,6 +1,6 @@
 
 <div class="say-dropdown" ...attributes>
-  <this.Velcro @placement="bottom" @offsetOptions={{hash mainAxis=6}} as |velcro|>
+  <this.Velcro @placement="bottom" @offsetOptions={{hash mainAxis=6}} @strategy="absolute" as |velcro|>
     <button
       {{this.reference}}
       class='say-dropdown__button {{if this.dropdownOpen "is-active" ""}}'


### PR DESCRIPTION
### Overview
Based on a ticket which was from Loket, which was including the editor by importing the `ember-rdfa-editor` package and giving it a very small box to render in, but is no longer using the editor.

Only relevant in embedded scenarios with very short editor windows.

This uses the floating UI option to use the absolute positioning strategy rather than the velcro default of fixed. This means the browser handles the case that the dropdown extends past the extent of the editor div in a way that at least means all the controls are accessible.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4014

### Setup
Modify `app/styles/ember-rdfa-editor/_c-dummy.scss` to remove `overflow: hidden` from the `.c-dummy` class (L10) and set `height: 200px` instead of 100% for `.c-dummy__content` (L81).

### How to test/reproduce
When opening the text style dropdown, the menu should now extend beyond the editor display.

### Challenges/uncertainties
It's unclear where this will be useful as it's no longer used in Loket any more.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
