### PR TITLE
Keep paragraph config e.g. indent when including soft breaks

### DIFF
--- a/.changeset/nervous-poets-laugh.md
+++ b/.changeset/nervous-poets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Maintain formatting (such as indentation) of paragraphs which include 'soft breaks' (new lines created with shift-enter) on reloading the editor

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -66,6 +66,9 @@ export const paragraphWithConfig: (
           }
           return false;
         },
+        // If this rule matches (a paragraph with block node content),
+        // the paragraph itself is skipped (but it's content is still parsed).
+        // Paragraphs with block content are not allowed in the HTML spec.
         skip: true,
       },
       {

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -11,14 +11,7 @@ export type ParagraphDataAttributes = {
 
 export type ParagraphNodeSpec = NodeSpec & { subType: string };
 
-let BLOCK_SELECTOR = '';
-NON_BLOCK_NODES.forEach(
-  (tag) => (BLOCK_SELECTOR = `${BLOCK_SELECTOR}${tag}, `),
-);
-// Also include br tag as while it's normally handled as a block by the editor, it's also used for
-// 'soft breaks' (when adding a newline with shift-enter), so we need to include it here.
-BLOCK_SELECTOR = `:not(${BLOCK_SELECTOR} br)`;
-
+const BLOCK_SELECTOR = `:not(${NON_BLOCK_NODES.join(', ')})`;
 const BASE_PARAGRAPH_TYPE = 'paragraph';
 const matchingSubType = (node: HTMLElement, subType: string) => {
   // basic paragraph has no subtype in its dataset and an empty subType
@@ -56,23 +49,23 @@ export const paragraphWithConfig: (
       {
         tag: 'p',
         getAttrs(node: HTMLElement) {
-          const nonBlockNode = node.querySelector(BLOCK_SELECTOR);
-          if (nonBlockNode && matchingSubType(node, config.subType)) {
+          const blockNode = node.querySelector(BLOCK_SELECTOR);
+          if (blockNode && matchingSubType(node, config.subType)) {
             // NOTE This parse rule is used to avoid parsing `<p>` tags which contain block tags,
             // hence the `skip: true` option. It's therefore not necessary to actually return
             // anything but an empty object.
-            // It's unclear whether skipping these is still relevant - Rich
             return {};
           }
           return false;
         },
         // If this rule matches (a paragraph with block node content),
-        // the paragraph itself is skipped (but it's content is still parsed).
+        // the paragraph element itself is skipped (but it's content is still parsed).
         // Paragraphs with block content are not allowed in the HTML spec.
         //
         // This rule is mainly added in order to support older document which might contain
         // important block-node information inside `p` tags.
-        // If this rule is not present, the block content of these paragraphs may not be parsed correctly (it would just be parsed as flat text).
+        // If this rule is not present, the block content of these paragraphs may not be parsed
+        // correctly (it would just be parsed as flat text).
         skip: true,
       },
       {

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -15,10 +15,9 @@ let BLOCK_SELECTOR = '';
 NON_BLOCK_NODES.forEach(
   (tag) => (BLOCK_SELECTOR = `${BLOCK_SELECTOR}${tag}, `),
 );
-BLOCK_SELECTOR = `:not(${BLOCK_SELECTOR.substring(
-  0,
-  BLOCK_SELECTOR.length - 2,
-)})`;
+// Also include br tag as while it's normally handled as a block by the editor, it's also used for
+// 'soft breaks' (when adding a newline with shift-enter), so we need to include it here.
+BLOCK_SELECTOR = `:not(${BLOCK_SELECTOR} br)`;
 
 const BASE_PARAGRAPH_TYPE = 'paragraph';
 const matchingSubType = (node: HTMLElement, subType: string) => {
@@ -59,14 +58,11 @@ export const paragraphWithConfig: (
         getAttrs(node: HTMLElement) {
           const nonBlockNode = node.querySelector(BLOCK_SELECTOR);
           if (nonBlockNode && matchingSubType(node, config.subType)) {
-            return {
-              indentationLevel: optionMapOr(
-                0,
-                parseInt,
-                node.dataset.indentationLevel,
-              ),
-              alignment: getAlignment(node),
-            };
+            // NOTE This parse rule is used to avoid parsing `<p>` tags which contain block tags,
+            // hence the `skip: true` option. It's therefore not necessary to actually return
+            // anything but an empty object.
+            // It's unclear whether skipping these is still relevant - Rich
+            return {};
           }
           return false;
         },

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -69,6 +69,10 @@ export const paragraphWithConfig: (
         // If this rule matches (a paragraph with block node content),
         // the paragraph itself is skipped (but it's content is still parsed).
         // Paragraphs with block content are not allowed in the HTML spec.
+        //
+        // This rule is mainly added in order to support older document which might contain
+        // important block-node information inside `p` tags.
+        // If this rule is not present, the block content of these paragraphs may not be parsed correctly (it would just be parsed as flat text).
         skip: true,
       },
       {

--- a/addon/utils/_private/constants.ts
+++ b/addon/utils/_private/constants.ts
@@ -1,6 +1,8 @@
-// based on https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content
-// we've added a, del, ins to the list since we assume they only contain phrasing content in the editor
-// we've removed br from the list to be inline with editor behaviour, which treats it as a block
+/**
+ * based on https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content
+ * we've added a, del, ins to the list since we assume they only contain phrasing content in the editor
+ * we've removed br from the list to be inline with editor behaviour, which treats it as a block
+ **/
 export const PHRASING_CONTENT = [
   'a',
   'abbr',
@@ -52,7 +54,13 @@ export const PHRASING_CONTENT = [
   'video',
   'wbr',
 ];
-export const NON_BLOCK_NODES = new Set(PHRASING_CONTENT);
+/**
+ * List of element types which can be used in non-block (phrasing) context.
+ * Unlike PHRASING_CONTENT also includes br tag as while it's normally handled as a block by the
+ * editor, it's also used for 'soft breaks' (when adding a newline with shift-enter), so we include
+ * it here.
+ **/
+export const NON_BLOCK_NODES = [...PHRASING_CONTENT, 'br'];
 export const LIST_TYPES = new Set(['li', 'ul', 'ol']);
 export const LIST_CONTAINERS = new Set(['ul', 'ol']);
 export const TABLE_TYPES = new Set([


### PR DESCRIPTION
### Overview
As reported in #1076 we were losing information from `paragraphWithConfig` nodes when they contain `<br>` tags. This is due to a parse rule which skips any `<p>` tags which contain block content (or rather non-phrasing content), but which was treating `<br>` incorrectly. This now correctly treats `<br>` as phrasing content. I also added some comments to clarify what this code is doing.

##### connected issues and PRs:
Fixes #1076

### Setup
N/A

### How to test/reproduce
As indicated in #1076 :

- Open the dummy application.
- Input some text and indent it using the indentation tool within the toolbar.
- Add a soft break to the indented text using shift + enter and add some more text.
- Reload the dummy application.
- The indentation (and thus the data-indentation-level value) gets removed.

### Challenges/uncertainties
It's unclear the reason why `<p>` elements with block content are being ignored as `paragraphWithConfig` nodes. Ideally this would be in a comment in the code.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
