### PR TITLE
Add toggle to enable hiding of editor sidebar

### DIFF
--- a/.changeset/selfish-badgers-lay.md
+++ b/.changeset/selfish-badgers-lay.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Add a more flexible way to programatically hide the editor sidebar

--- a/addon/components/editor-container.hbs
+++ b/addon/components/editor-container.hbs
@@ -2,7 +2,7 @@
   class='say-container
     {{if @editorOptions.showRdfaHover "say-container--sidebar-left"}}
     {{if @editorOptions.showPaper "say-container--paper"}}
-    {{if (has-block "aside") "say-container--sidebar-right"}}
+    {{if (and (has-block "aside") (not @hideSidebar)) "say-container--sidebar-right"}}
     {{if @editorOptions.showToolbarBottom "say-container--toolbar-bottom"}}'
 >
   {{yield to='top'}}


### PR DESCRIPTION
### Overview
Allow manually hiding the sidebar, if for example, the contents of the 'aside' block is conditional and so is empty. Ember still considers an empty block as 'has-block'.

##### connected issues and PRs:
Embeddable PR https://github.com/lblod/frontend-embeddable-notule-editor/pull/208

### Setup
N/A

### How to test/reproduce
Pass `@hideSidebar={{true}}` to `<EditorContainer>` in one of the dummy app routes. Confirm that the sidebar is gone and there is no empty space left for it.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
