### PR TITLE
Do not clean self-closing hr elements from paste

### DIFF
--- a/.changeset/grumpy-chicken-march.md
+++ b/.changeset/grumpy-chicken-march.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Do not clean <hr /> tags from pasted input

--- a/addon/utils/_private/ce/paste-handler-helper-functions/cleanEmptyElements.ts
+++ b/addon/utils/_private/ce/paste-handler-helper-functions/cleanEmptyElements.ts
@@ -1,6 +1,6 @@
 import { traverseElements } from './traverseElements';
 
-const ALLOWED_EMPTY_ELEMENTS = ['BR', 'IMG', 'TR', 'TD'];
+const ALLOWED_EMPTY_ELEMENTS = ['BR', 'IMG', 'TR', 'TD', 'HR'];
 const NOTRIM_ELEMENTS = ['SPAN'];
 
 function isEmpty(element: Element): boolean {


### PR DESCRIPTION
### Overview
As noticed by @abeforgit.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
In the dummy app, add a custom html sample data containing a `<hr />` tag.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
