### PR TITLE
GN-4658: make pasting behaviour more in line with other editors

### DIFF
--- a/.changeset/olive-grapes-fix.md
+++ b/.changeset/olive-grapes-fix.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Close pasted slice if not surrounded by text

--- a/addon/core/say-editor.ts
+++ b/addon/core/say-editor.ts
@@ -1,6 +1,11 @@
 import { EditorState, Plugin } from 'prosemirror-state';
 import { NodeViewConstructor } from 'prosemirror-view';
-import { DOMParser as ProseParser, Schema } from 'prosemirror-model';
+import {
+  Fragment,
+  DOMParser as ProseParser,
+  Schema,
+  Slice,
+} from 'prosemirror-model';
 import {
   getPathFromRoot,
   isElement,
@@ -34,6 +39,8 @@ import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import SaySerializer from '@lblod/ember-rdfa-editor/core/say-serializer';
 import { gapCursor } from '../plugins/gap-cursor';
 import HTMLInputParser from '@lblod/ember-rdfa-editor/utils/_private/html-input-parser';
+import { unwrap } from '../utils/_private/option';
+import { closeSlice } from '../utils/node-utils';
 
 export type PluginConfig = Plugin[] | { plugins: Plugin[]; override?: boolean };
 interface SayEditorArgs {
@@ -128,6 +135,15 @@ export default class SayEditor {
         const htmlCleaner = new HTMLInputParser({ editorView });
 
         return htmlCleaner.prepareHTML(html);
+      },
+      transformPasted(slice, view) {
+        const { selection } = view.state;
+        const { nodeBefore } = selection.$from;
+        const { nodeAfter } = selection.$to;
+
+        const openStart = nodeBefore?.isInline ? slice.openStart : 0;
+        const openEnd = nodeAfter?.isInline ? slice.openEnd : 0;
+        return closeSlice(slice, openStart, openEnd);
       },
       clipboardSerializer: this.serializer,
     });

--- a/addon/utils/_private/node-utils.ts
+++ b/addon/utils/_private/node-utils.ts
@@ -1,4 +1,28 @@
-import { PNode } from '@lblod/ember-rdfa-editor';
+/**
+ * Contains code from the `prosemirror-view` package
+ *
+ * Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import { Fragment, PNode, Slice } from '@lblod/ember-rdfa-editor';
+import { unwrap } from './option';
 
 export function getGroups(node: PNode) {
   return node.type.spec.group?.split(' ') ?? [];
@@ -7,4 +31,66 @@ export function getGroups(node: PNode) {
 export function hasGroups(node: PNode, ...groups: string[]) {
   const nodeGroups = getGroups(node);
   return groups.every((group) => nodeGroups.includes(group));
+}
+
+/**
+ * Adapted from https://github.com/ProseMirror/prosemirror-view/blob/39fb7c2e71287d6ac2013f5a8c878873a074244e/src/clipboard.ts#L169
+ */
+function closeRange(
+  fragment: Fragment,
+  side: number,
+  from: number,
+  to: number,
+  depth: number,
+  openEnd: number,
+) {
+  const node =
+    side < 0 ? unwrap(fragment.firstChild) : unwrap(fragment.lastChild);
+  let inner = node.content;
+  if (fragment.childCount > 1) openEnd = 0;
+  if (depth < to - 1)
+    inner = closeRange(inner, side, from, to, depth + 1, openEnd);
+  if (depth >= from)
+    inner =
+      side < 0
+        ? unwrap(
+            node.contentMatchAt(0).fillBefore(inner, openEnd <= depth),
+          ).append(inner)
+        : inner.append(
+            unwrap(
+              node
+                .contentMatchAt(node.childCount)
+                .fillBefore(Fragment.empty, true),
+            ),
+          );
+  return fragment.replaceChild(
+    side < 0 ? 0 : fragment.childCount - 1,
+    node.copy(inner),
+  );
+}
+
+/**
+ * Adapted from https://github.com/ProseMirror/prosemirror-view/blob/39fb7c2e71287d6ac2013f5a8c878873a074244e/src/clipboard.ts#L179
+ */
+export function closeSlice(slice: Slice, openStart: number, openEnd: number) {
+  if (openStart < slice.openStart)
+    slice = new Slice(
+      closeRange(
+        slice.content,
+        -1,
+        openStart,
+        slice.openStart,
+        0,
+        slice.openEnd,
+      ),
+      openStart,
+      slice.openEnd,
+    );
+  if (openEnd < slice.openEnd)
+    slice = new Slice(
+      closeRange(slice.content, 1, openEnd, slice.openEnd, 0, 0),
+      slice.openStart,
+      openEnd,
+    );
+  return slice;
 }


### PR DESCRIPTION
### Overview
This PR is an attempt to change the pasting behaviour so it falls more in line with other editors.

Specifically, it adds a `transformPasted` hook to transform the slice to be pasted if necessary.
- If the node before the current selection is not inline, the slice will be closed at the start
- If the node after the current selection is not inline, the slice will be closed at the end

Examples of the pasting behaviour with the following clipboard content:

```
<p style="text-align: right" data-pm-slice="1 1 []">eee</p>
```

- Pasting into an empty document:
[Screencast from 2024-01-11 12-04-14.webm](https://github.com/lblod/ember-rdfa-editor/assets/24712836/a6e3a161-1fab-47e9-bef5-64b57b52df6f)

- Pasting after an inline node
  [Screencast from 2024-01-11 12-05-47.webm](https://github.com/lblod/ember-rdfa-editor/assets/24712836/ba4a826d-e0a2-4cbe-9592-0a51cacde333)

- Pasting before an inline node
[Screencast from 2024-01-11 13-28-01.webm](https://github.com/lblod/ember-rdfa-editor/assets/24712836/6817c953-1574-4c3a-8e95-7cb57f10de48)
  
- Pasting inbetween inline nodes
[Screencast from 2024-01-11 13-29-38.webm](https://github.com/lblod/ember-rdfa-editor/assets/24712836/747b7862-3a1a-4444-b8db-a5b2423ecf75)


##### connected issues and PRs:
[GN-4658](https://binnenland.atlassian.net/browse/GN-4658?atlOrigin=eyJpIjoiNGUxNDIwNjFiZTZkNGE5Y2JjOTJkZmM1ZWM1MWNmNmQiLCJwIjoiaiJ9)


### How to test/reproduce
- Open the dummy app
- Try out the different before-mentioned scenarios
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->
- Check if the behaviour works as expected with the following html (output from word)
  <details>
    <summary>Word output</summary>
      ```
      <html xmlns:o="urn:schemas-microsoft-com:office:office"
      xmlns:w="urn:schemas-microsoft-com:office:word"
      xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
      xmlns="http://www.w3.org/TR/REC-html40">
      
      <head>
      <meta http-equiv=Content-Type content="text/html; charset=utf-8">
      <meta name=ProgId content=Word.Document>
      <meta name=Generator content="Microsoft Word 15">
      <meta name=Originator content="Microsoft Word 15">
      </head>
      
      <body lang=en-BE style='tab-interval:36.0pt;word-wrap:break-word'>
      <!--StartFragment-->
      
      <p class=MsoNormal align=right style='text-align:right'><span lang=EN-US
      style='mso-ansi-language:EN-US'>Test rechts<o:p></o:p></span></p>
      
      <!--EndFragment-->
      </body>
      </html>
      ```
  </details>

### Challenges/uncertainties
- When pasting a paragraph with an `id` attribute (e.g. output from google docs), it does not get parsed as a `paragraph` node, but rather as a `block_rdfa` node. We should probably change this behaviour.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
