### PR TITLE
Remove `id` attribute from block_rdfa spec

### DIFF
--- a/.changeset/weak-students-applaud.md
+++ b/.changeset/weak-students-applaud.md
@@ -1,0 +1,7 @@
+---
+"@lblod/ember-rdfa-editor": major
+---
+
+Removal of the id attribute from the block_rdfa spec. It is currently not used by the block_rdfa node and is not part of the RDFa spec.
+
+Additionally, this solves the issue where paragraphs with an id attribute were parsed as block_rdfa.

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -15,7 +15,6 @@ export const rdfaAttrs = {
   lang: { default: undefined },
   xmlns: { default: undefined },
   src: { default: undefined },
-  id: { default: undefined },
   role: { default: undefined },
   inlist: { default: undefined },
   datetime: { default: undefined },

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -79,7 +79,6 @@ export const paragraphWithConfig: (
           }
 
           if (!matchingSubType(node, config.subType)) return false;
-
           return {
             indentationLevel: optionMapOr(
               DEFAULT_INDENTATION,


### PR DESCRIPTION
### Overview
This PR removes the `id` attribute from the `block_rdfa` spec. It is currently not used by the `block_rdfa` node and is not part of the RDFa spec.

Additionally, this solves the issue where paragraphs with an `id` attribute were parsed as `block_rdfa`.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor/pull/1108

### How to test/reproduce
- Open the dummy app
- Copy content from google docs (the first paragraph in the google docs output should contain the `id` attribute)
- Ensure that the first copied paragraph from google docs is not parsed as `block_rdfa`

### Challenges/uncertainties
It is possible that some of our users make use of the `block_rdfa` `id` attribute. This is why this PR is marked as breaking.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
