### PR TITLE
Add locale helper function to handle falling back to a matching language

### DIFF
--- a/.changeset/nasty-rice-change.md
+++ b/.changeset/nasty-rice-change.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Add helper function to help with locale selection and add translation note to readme

--- a/README.md
+++ b/README.md
@@ -339,6 +339,14 @@ To use `@lblod/ember-rdfa-editor` with Embroider some extra Webpack configuratio
 
 If you already provide some Webpack configuration, you can deep merge that with the config object we provide.
 
+## Translation
+
+Translations are provided for UI elements using ember-intl.
+Currently the only languages supported are English (en-US) and Dutch (nl-BE).
+Other languages can be added by copying the contents of the file `translations/en-us.yaml` into the relevant language file in your `translations` folder and translating all of the strings.
+
+A helper function is provided to assist with finding a reasonable fallback locale, for example providing `en-US` translations if `en` is requested.
+See [the test app](tests/dummy/app/routes/application.ts) for example of it's usage.
 
 ## Compatibility
 

--- a/addon/utils/intl-utils.ts
+++ b/addon/utils/intl-utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Helper function to help pick supported locales for ember-intl.
+ * Returns exact matches first, then language matches, then the default.
+ **/
+export function decentLocaleMatch(
+  userLocales: string[] | readonly string[],
+  supportedLocales: string[],
+  defaultLocale: string,
+) {
+  // Ember-intl lowercases locales so we can make comparisons easier by doing the same
+  const userLocs = userLocales.map((locale) => locale.toLowerCase());
+  const supportedLocs = supportedLocales.map((locale) => locale.toLowerCase());
+
+  // First find exact matches. Use a set to avoid duplicates while preserving insert order.
+  const matches = new Set(
+    userLocs.filter((locale) => supportedLocs.includes(locale)),
+  );
+
+  // Then look for locales that just match based on language,
+  // e.g. match en or en-US if looking for en-GB
+  const languageMap: Record<string, string[]> = {};
+  supportedLocs.forEach((locale) => {
+    const lang = locale.split('-')[0];
+    languageMap[lang] = [...(languageMap[lang] || []), locale];
+  });
+  userLocs.forEach((locale) => {
+    const looseMatches = languageMap[locale.split('-')[0]];
+    looseMatches.forEach((match) => matches.add(match));
+  });
+
+  // Add the default so we always have something
+  matches.add(defaultLocale.toLowerCase());
+
+  return [...matches];
+}

--- a/tests/dummy/app/routes/application.ts
+++ b/tests/dummy/app/routes/application.ts
@@ -2,13 +2,18 @@ import sampleData from '../config/sample-data';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type { IntlService as Intl } from 'ember-intl';
+import { decentLocaleMatch } from '@lblod/ember-rdfa-editor/utils/intl-utils';
 
 export default class ApplicationRoute extends Route {
   @service declare intl: Intl;
 
   beforeModel() {
-    const userLocale = navigator.language || navigator.languages[0];
-    this.intl.setLocale([userLocale, 'nl-BE']);
+    const userLocales = decentLocaleMatch(
+      navigator.languages,
+      this.intl.locales,
+      'en-US',
+    );
+    this.intl.setLocale(userLocales);
   }
 
   model() {


### PR DESCRIPTION
### Overview
Also switch the default dummy app language to en-US.

Ember-intl [doesn't seem](https://github.com/ember-intl/ember-intl/issues/1667) to [support](https://github.com/ember-intl/ember-intl/issues/1533) matching different locales well, it just matches against an ([inconsistently lowercased](https://github.com/ember-intl/ember-intl/issues/1707)) exact match.

A proper improvement would be inside ember-intl but this helper function should make it more natural for a user. The first matches will always be exact, e.g. if we ask for `en-GB, nl-BE`, and we support `en-US` and `nl-BE`, we get `['nl-BE', 'en-US']` as our list of locales to use for translations. It will then fall back to matches by language, starting with the user's first, e.g. asking for `en-GB, nl-BE` and we have `en-US` and `nl-NL`, then the preference order is `['en-US', 'nl-NL']`.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Use [a locale switcher](https://addons.mozilla.org/en-US/firefox/addon/locale-switcher/) to try different combinations of locales and that it always translates the UI as expected. In that add-on you can select multiple locales by clicking the switch at the top:
![image](https://github.com/lblod/ember-rdfa-editor/assets/1323250/aa09386d-a735-4432-b130-fa4d93f28bbf)

### Challenges/uncertainties
There seems to be no general consensus on how to do this, so TC-39 is unwilling to implement this in the language.

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
