### PR TITLE
Increase peerdependency requirement of `@appuniversum/ember-appuniversum` package to `^2.15.0`

### DIFF
--- a/.changeset/strong-lemons-try.md
+++ b/.changeset/strong-lemons-try.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": major
+---
+
+Increase `@appuniversum/ember-appuniversum` peerdependency requirement to `^2.15.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "xml-formatter": "^3.2.1"
       },
       "devDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.16.0",
+        "@appuniversum/ember-appuniversum": "2.15.0",
         "@babel/eslint-parser": "^7.21.3",
         "@babel/plugin-proposal-decorators": "^7.21.0",
         "@changesets/changelog-github": "^0.5.0",
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@appuniversum/ember-appuniversum": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.18.0.tgz",
-      "integrity": "sha512-W67tWC3racq9Eq9ziV4heFhAPeoRG0ILPtjKmYwM0BeIQ8k+L6Fp3Vrnh741yQBERNkdAr6F8XQu4G8mNbkBow==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.15.0.tgz",
+      "integrity": "sha512-Z77MTwJM7gWVt4rj6pckADETE+UxMtQD0vWSf+1aEedWqnDMWp853APlhJYz1VPq8xtfJL9g809XFQUmyHUN6A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.22.10",
@@ -198,14 +198,12 @@
         "ember-concurrency": "2.x || ^3.1.0",
         "ember-data-table": "^2.1.0",
         "ember-file-upload": "^7.0.3",
-        "ember-focus-trap": "^1.1.0",
+        "ember-focus-trap": "^1.0.2",
         "ember-modifier": "^3.2.7",
-        "ember-template-imports": "^3.4.2",
         "ember-test-selectors": "^6.0.0",
-        "ember-truth-helpers": "^3.1.1",
         "inputmask": "^5.0.7",
         "merge-anything": "^5.1.3",
-        "tracked-toolbox": "^2.0.0"
+        "tracked-toolbox": "^1.2.3"
       },
       "engines": {
         "node": "14.* || 16.* || >= 18"
@@ -32501,24 +32499,16 @@
       }
     },
     "node_modules/tracked-toolbox": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-2.0.0.tgz",
-      "integrity": "sha512-adZtX+RGN6F+pWs/5JqVuDxLhuia4uhqmQp+UlUaxpykWjDFETtAdQR+LdDJiFPXFAXnS6FBqn/tnSLJQCm3Yw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-1.3.0.tgz",
+      "integrity": "sha512-KHfYLvNyRr0qQeXQPnmb6Z4JYZ0/47R7LjVwzUrsKc539eQi3Sz2z3mb7FJN9KgaJXVuM3GQ8zcwUFTf0hrOsQ==",
       "dev": true,
       "dependencies": {
-        "@embroider/addon-shim": "^1.6.0",
-        "ember-cache-primitive-polyfill": "^1.0.0"
+        "ember-cache-primitive-polyfill": "^1.0.0",
+        "ember-cli-babel": "^7.26.6"
       },
       "engines": {
-        "node": "14.* || 16.* || >= 18"
-      },
-      "peerDependencies": {
-        "ember-source": "*"
-      },
-      "peerDependenciesMeta": {
-        "ember-source": {
-          "optional": true
-        }
+        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/tree-kill": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-qunit": "^8.0.0",
         "loader.js": "^4.7.0",
-        "prettier": "^3.0.0",
+        "prettier": "^3.2.0",
         "prosemirror-dev-tools": "^4.0.0",
         "qunit": "^2.19.4",
         "qunit-dom": "^2.0.0",
@@ -147,7 +147,7 @@
         "node": "16.* || 18.* || >= 20"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.4.2",
+        "@appuniversum/ember-appuniversum": "^2.15.0",
         "@glint/template": "^1.1.0",
         "ember-cli-sass": "^11.0.1",
         "ember-intl": "^5.7.2 || ^6.1.0",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "webpack": "^5.78.0"
   },
   "peerDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.4.2",
+    "@appuniversum/ember-appuniversum": "^2.15.0",
     "@glint/template": "^1.1.0",
     "ember-cli-sass": "^11.0.1",
     "ember-intl": "^5.7.2 || ^6.1.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "xml-formatter": "^3.2.1"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.16.0",
+    "@appuniversum/ember-appuniversum": "2.15.0",
     "@babel/eslint-parser": "^7.21.3",
     "@babel/plugin-proposal-decorators": "^7.21.0",
     "@changesets/changelog-github": "^0.5.0",


### PR DESCRIPTION
### Overview
This PR includes an increase of the peerdependency requirement of `@appuniversum/ember-appuniversum` package to `^2.15.0`.

The main reason for this stricter requirement is to be able to use features of the more recent versions of the package.

Additionally, this PR also pins the `@appuniversum/ember-appuniversum` to the lowest supported version (2.15.0).

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
