### PR TITLE
Drop support for `ember-intl` `5.x`

### DIFF
--- a/.changeset/thirty-carrots-deny.md
+++ b/.changeset/thirty-carrots-deny.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": major
+---
+
+Drop support for `ember-intl` `5.x`

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "ember-cli-sri": "^2.1.1",
         "ember-cli-terser": "^4.0.2",
         "ember-cli-typescript-blueprints": "^3.0.0",
-        "ember-intl": "^6.4.0",
+        "ember-intl": "6.1.0",
         "ember-load-initializers": "^2.1.2",
         "ember-modifier": "^3.2.7",
         "ember-page-title": "^8.0.0",
@@ -150,7 +150,7 @@
         "@appuniversum/ember-appuniversum": "^2.15.0",
         "@glint/template": "^1.1.0",
         "ember-cli-sass": "^11.0.1",
-        "ember-intl": "^5.7.2 || ^6.1.0",
+        "ember-intl": "^6.1.0",
         "ember-modifier": "^3.2.7",
         "ember-source": "^3.28.0 || ^4.0.0"
       }
@@ -10003,9 +10003,9 @@
       }
     },
     "node_modules/cldr-core": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-44.1.0.tgz",
-      "integrity": "sha512-ssbJaXu3pCkc4YqNC6xHhgleZG7YqnOFZ9laMlJfHOfnspoA9waI4AH54gKB3Fe/+wI4i3cVxKFdCTVGTRw+UA==",
+      "version": "43.1.0",
+      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-43.1.0.tgz",
+      "integrity": "sha512-8Q/Zh/eCzV4SxggzZhPnw5WDWH9OnhbPfwzthfG8uXsCn7F5UeBCiAOTxsstxuxtXPKlvPJqqMSQjiYcqJPJsA==",
       "dev": true
     },
     "node_modules/clean-base-url": {
@@ -16207,30 +16207,35 @@
       }
     },
     "node_modules/ember-intl": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-6.4.0.tgz",
-      "integrity": "sha512-BXxscjgoqzXQ6tUSV8aJsQcUAIcfqLJnNjegarFWdBBHLEOffQ8xARhvQC0hW40zGi/RHFEyTTx7vbiCPGtP1A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-6.1.0.tgz",
+      "integrity": "sha512-aLxRwjlk3KmQ40YMjeu/OJ1iAdXbtGGuBHimCrtiPZmwj41cV++VZENv+wF9inK0IdMWeIyKNklQraNmpwTixg==",
       "dev": true,
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": "^2.7.3",
-        "@formatjs/intl": "^2.9.9",
+        "@formatjs/icu-messageformat-parser": "^2.6.2",
+        "@formatjs/intl": "^2.9.3",
         "broccoli-caching-writer": "^3.0.3",
-        "broccoli-funnel": "^3.0.8",
+        "broccoli-funnel": "^3.0.3",
         "broccoli-merge-files": "^0.8.0",
         "broccoli-merge-trees": "^4.2.0",
-        "broccoli-source": "^3.0.1",
+        "broccoli-source": "^3.0.0",
         "broccoli-stew": "^3.0.0",
         "calculate-cache-key-for-tree": "^2.0.0",
-        "cldr-core": "^44.0.1",
-        "ember-auto-import": "^2.7.0",
-        "ember-cli-babel": "^8.2.0",
+        "cldr-core": "^43.1.0",
+        "ember-auto-import": "^2.6.3",
+        "ember-cli-babel": "^8.0.0",
         "ember-cli-typescript": "^5.2.1",
         "eventemitter3": "^5.0.1",
         "extend": "^3.0.2",
         "fast-memoize": "^2.5.2",
-        "intl-messageformat": "^10.5.8",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "intl-messageformat": "^10.5.3",
+        "js-yaml": "4",
+        "json-stable-stringify": "^1.0.2",
+        "locale-emoji": "^0.3.0",
+        "lodash.castarray": "^4.4.0",
+        "lodash.last": "^3.0.0",
+        "lodash.omit": "^4.5.0",
         "silent-error": "^1.1.1"
       },
       "engines": {
@@ -23967,6 +23972,12 @@
       "integrity": "sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==",
       "dev": true
     },
+    "node_modules/locale-emoji": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/locale-emoji/-/locale-emoji-0.3.0.tgz",
+      "integrity": "sha512-JGm8+naU49CBDnH1jksS3LecPdfWQLxFgkLN6ZhYONKa850pJ0Xt8DPGJnYK0ZuJI8jTuiDDPCDtSL3nyacXwg==",
+      "dev": true
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -24179,6 +24190,12 @@
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
+    },
+    "node_modules/lodash.last": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+      "integrity": "sha512-14mq7rSkCxG4XMy9lF2FbIOqqgF0aH0NfPuQ3LPR3vIh0kHnUvIYP70dqa1Hf47zyXfQ8FzAg0MYOQeSuE1R7A==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-cli-typescript-blueprints": "^3.0.0",
-    "ember-intl": "^6.4.0",
+    "ember-intl": "6.1.0",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^3.2.7",
     "ember-page-title": "^8.0.0",
@@ -173,14 +173,9 @@
     "@appuniversum/ember-appuniversum": "^2.15.0",
     "@glint/template": "^1.1.0",
     "ember-cli-sass": "^11.0.1",
-    "ember-intl": "^5.7.2 || ^6.1.0",
+    "ember-intl": "^6.1.0",
     "ember-modifier": "^3.2.7",
     "ember-source": "^3.28.0 || ^4.0.0"
-  },
-  "overrides": {
-    "ember-intl@^5.7.2": {
-      "typescript": "$typescript"
-    }
   },
   "engines": {
     "node": "16.* || 18.* || >= 20"


### PR DESCRIPTION
### Overview
This PR drops support for `ember-intl` `5.x`.
The minimum supported version is now `6.1.0`.
Additionally, this PR pins the devdependency of `ember-intl` to version `6.1.0`.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
