### PR TITLE
Pin devdependencies which are included as peerdependencies to the lowest supported version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
         "ember-cli-autoprefixer": "^2.0.0",
         "ember-cli-dependency-checker": "^3.3.1",
         "ember-cli-inject-live-reload": "^2.1.0",
-        "ember-cli-sass": "^11.0.1",
+        "ember-cli-sass": "11.0.1",
         "ember-cli-sri": "^2.1.1",
         "ember-cli-terser": "^4.0.2",
         "ember-cli-typescript-blueprints": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "ember-cli-typescript-blueprints": "^3.0.0",
         "ember-intl": "6.1.0",
         "ember-load-initializers": "^2.1.2",
-        "ember-modifier": "^3.2.7",
+        "ember-modifier": "3.2.7",
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^6.2.0",
         "ember-resolver": "^11.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "@ember/test-helpers": "^2.9.3",
         "@embroider/test-setup": "^3.0.1",
         "@glimmer/component": "^1.1.2",
-        "@glint/template": "^1.2.2",
+        "@glint/template": "1.1.0",
         "@rdfjs/types": "^1.1.0",
         "@release-it/keep-a-changelog": "^4.0.0",
         "@types/common-tags": "^1.8.4",
@@ -3516,9 +3516,9 @@
       }
     },
     "node_modules/@glint/template": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@glint/template/-/template-1.2.2.tgz",
-      "integrity": "sha512-T9XxJiFicAou1KbdgDaQdypYmRAVQZlnb0EEdCsG3pu/i2rzlMBZKzkqygKwIF5ZWB8xyzvdVHyQLrmrPRCbiQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@glint/template/-/template-1.1.0.tgz",
+      "integrity": "sha512-gK4tifrw7mIMYECzGeG5jrez2lY0TlwE584cnoYOFhzxXKrsuungdiebd7LDwjvfQpImQd1JUSQr3u/uF/XYJg==",
       "devOptional": true
     },
     "node_modules/@graphy/core.data.factory": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "ember-cli-autoprefixer": "^2.0.0",
     "ember-cli-dependency-checker": "^3.3.1",
     "ember-cli-inject-live-reload": "^2.1.0",
-    "ember-cli-sass": "^11.0.1",
+    "ember-cli-sass": "11.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-cli-typescript-blueprints": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@ember/test-helpers": "^2.9.3",
     "@embroider/test-setup": "^3.0.1",
     "@glimmer/component": "^1.1.2",
-    "@glint/template": "^1.2.2",
+    "@glint/template": "1.1.0",
     "@rdfjs/types": "^1.1.0",
     "@release-it/keep-a-changelog": "^4.0.0",
     "@types/common-tags": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-intl": "6.1.0",
     "ember-load-initializers": "^2.1.2",
-    "ember-modifier": "^3.2.7",
+    "ember-modifier": "3.2.7",
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^6.2.0",
     "ember-resolver": "^11.0.1",


### PR DESCRIPTION
### Overview
This PR pins the remaining devdependencies which are included as peerdependencies to the lowest supported version.
- `ember-modifier` to 3.2.7
- `ember-cli-sass` to 11.0.1
- `@glint/template` to 1.2.2

This PR is part of a change of strategy to test this addon with the lowest supported peerdependency versions. This way, we can't accidentally include features of these packages which are not supported by their whole peerdependency range.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
