### PR TITLE
Fix `looseMatches is undefined` error

### DIFF
--- a/.changeset/poor-socks-pay.md
+++ b/.changeset/poor-socks-pay.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Fix `looseMatches` is undefined error

--- a/addon/utils/intl-utils.ts
+++ b/addon/utils/intl-utils.ts
@@ -24,12 +24,11 @@ export function decentLocaleMatch(
     languageMap[lang] = [...(languageMap[lang] || []), locale];
   });
   userLocs.forEach((locale) => {
-    const looseMatches = languageMap[locale.split('-')[0]];
+    const looseMatches = languageMap[locale.split('-')[0]] ?? [];
     looseMatches.forEach((match) => matches.add(match));
   });
 
   // Add the default so we always have something
   matches.add(defaultLocale.toLowerCase());
-
   return [...matches];
 }

--- a/addon/utils/intl-utils.ts
+++ b/addon/utils/intl-utils.ts
@@ -18,7 +18,7 @@ export function decentLocaleMatch(
 
   // Then look for locales that just match based on language,
   // e.g. match en or en-US if looking for en-GB
-  const languageMap: Record<string, string[]> = {};
+  const languageMap: Record<string, string[] | undefined> = {};
   supportedLocs.forEach((locale) => {
     const lang = locale.split('-')[0];
     languageMap[lang] = [...(languageMap[lang] || []), locale];


### PR DESCRIPTION
### Overview
This PR adds an empty array fallback when initializing the variable `looseMatches` in the `decentLocaleMatch` function, to prevent it from having the `undefined` value.

### How to test/reproduce
Before this fix:
- Open the dummy app
- Set the browser locale to an unsupported language (e.g. french)
- Observe the `looseMatches` is undefined error

After this fix:
- Open the dummy app
- Set the browser locale to an unsupported language
- The error should no longer show up, the language shown is the default language (english)
