### PR TITLE
GN-4657: Serialize table column width to exported HTML

### DIFF
--- a/addon/components/plugins/list/ordered.hbs
+++ b/addon/components/plugins/list/ordered.hbs
@@ -7,6 +7,7 @@
     {{on "click" (fn this.toggle 'decimal')}}
     @controller={{@controller}}
     @disabled={{not this.canToggle}}
+    @onToggleDropdown={{fn this.toggleDropdown}}
   >
     <:options as |Menu|>
       {{#each this.styles as |style|}}
@@ -17,6 +18,22 @@
           {{style.description}}
         </Menu.Item>
       {{/each}}
+      <div role='group'>
+        <div role='menuitem' class='say-dropdown__menu-with-inputs'>
+          List start
+          <AuLabel for='editor-table-columns' class='au-u-hidden-visually'>
+            List start
+          </AuLabel>
+          <Input
+            class='say-input say-input--small'
+            size='2'
+            @value={{this.listStart}}
+          />
+        </div>
+      </div>
+      <Menu.Item @menuAction={{(fn this.setOrder)}}>
+        Set start
+      </Menu.Item>
     </:options>
   </Toolbar::Button>
 {{/if}}

--- a/addon/components/plugins/list/ordered.ts
+++ b/addon/components/plugins/list/ordered.ts
@@ -12,6 +12,7 @@ import { sinkListItem, wrapInList } from 'prosemirror-schema-list';
 import { Command } from 'prosemirror-state';
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import { tracked } from '@glimmer/tracking';
+import { PNode } from '@lblod/ember-rdfa-editor';
 
 type Args = {
   controller: SayController;
@@ -98,9 +99,7 @@ export default class ListOrdered extends Component<Args> {
   @action
   setStyle(style: OrderListStyle) {
     const firstListParent = this.firstListParent;
-    if (
-      firstListParent?.node.type === this.controller.schema.nodes.ordered_list
-    ) {
+    if (firstListParent && this.isNodeOrderedListType(firstListParent.node)) {
       const pos = firstListParent.pos;
       this.controller.withTransaction((tr) => {
         return tr.setNodeAttribute(pos, 'style', style);
@@ -114,9 +113,7 @@ export default class ListOrdered extends Component<Args> {
   setOrder() {
     const firstListParent = this.firstListParent;
 
-    if (
-      firstListParent?.node.type === this.controller.schema.nodes.ordered_list
-    ) {
+    if (firstListParent && this.isNodeOrderedListType(firstListParent.node)) {
       const pos = firstListParent.pos;
       this.controller.withTransaction((tr) => {
         return tr.setNodeAttribute(pos, 'order', this.listStart);
@@ -127,21 +124,21 @@ export default class ListOrdered extends Component<Args> {
   @action
   toggleDropdown() {
     const firstListParent = this.firstListParent;
-    if (
-      firstListParent?.node.type === this.controller.schema.nodes.ordered_list
-    ) {
+    if (firstListParent && this.isNodeOrderedListType(firstListParent.node)) {
       this.listStart = parseInt(firstListParent.node.attrs.order, 10);
     }
   }
 
   styleIsActive = (style: string) => {
     const firstListParent = this.firstListParent;
-    if (
-      firstListParent?.node.type === this.controller.schema.nodes.ordered_list
-    ) {
+    if (firstListParent && this.isNodeOrderedListType(firstListParent.node)) {
       return firstListParent.node.attrs.style === style;
     } else {
       return false;
     }
+  };
+
+  isNodeOrderedListType = (node: PNode) => {
+    return node?.type === this.controller.schema.nodes.ordered_list;
   };
 }

--- a/addon/components/plugins/list/ordered.ts
+++ b/addon/components/plugins/list/ordered.ts
@@ -11,12 +11,15 @@ import { autoJoin, chainCommands } from 'prosemirror-commands';
 import { sinkListItem, wrapInList } from 'prosemirror-schema-list';
 import { Command } from 'prosemirror-state';
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
+import { tracked } from '@glimmer/tracking';
 
 type Args = {
   controller: SayController;
 };
+
 export default class ListOrdered extends Component<Args> {
   @service declare intl: IntlService;
+  @tracked listStart = 1;
 
   get styles() {
     return [
@@ -104,6 +107,30 @@ export default class ListOrdered extends Component<Args> {
       });
     } else {
       this.toggle(style);
+    }
+  }
+
+  @action
+  setOrder() {
+    const firstListParent = this.firstListParent;
+
+    if (
+      firstListParent?.node.type === this.controller.schema.nodes.ordered_list
+    ) {
+      const pos = firstListParent.pos;
+      this.controller.withTransaction((tr) => {
+        return tr.setNodeAttribute(pos, 'order', this.listStart);
+      });
+    }
+  }
+
+  @action
+  toggleDropdown() {
+    const firstListParent = this.firstListParent;
+    if (
+      firstListParent?.node.type === this.controller.schema.nodes.ordered_list
+    ) {
+      this.listStart = parseInt(firstListParent.node.attrs.order, 10);
     }
   }
 

--- a/addon/components/toolbar/button.hbs
+++ b/addon/components/toolbar/button.hbs
@@ -14,7 +14,8 @@
   </button>
   {{#if (has-block "options")}}
     <Toolbar::Dropdown @disabled={{@disabled}} @icon={{this.optionsIcon}} @iconSize="" @controller={{@controller}} class="options"
-                       title={{@optionsLabel}} as |Menu|>
+                       title={{@optionsLabel}}
+                       @onToggleDropdown={{@onToggleDropdown}} as |Menu|>
       {{yield Menu to="options"}}
     </Toolbar::Dropdown>
   {{/if}}

--- a/addon/components/toolbar/dropdown.ts
+++ b/addon/components/toolbar/dropdown.ts
@@ -8,7 +8,9 @@ import { Velcro } from 'ember-velcro';
 
 type Args = {
   controller: SayController;
+  onToggleDropdown?: (newState: boolean) => void;
 };
+
 export default class ToolbarDropdown extends Component<Args> {
   @tracked referenceElement?: Element = undefined;
   @tracked dropdownOpen = false;
@@ -35,7 +37,10 @@ export default class ToolbarDropdown extends Component<Args> {
 
   @action
   toggleDropdown() {
-    this.dropdownOpen = !this.dropdownOpen;
+    const nextDropdownOpenState = !this.dropdownOpen;
+
+    this.dropdownOpen = nextDropdownOpenState;
+    this.args.onToggleDropdown?.(nextDropdownOpenState);
   }
 
   @action


### PR DESCRIPTION
### Overview

GN-4657: Serialize table column width to exported HTML

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4657


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
