### PR TITLE
Add a new helper for rdfa and some small improvements

### DIFF
--- a/addon/components/_private/rdfa-editor/property-editor/modal.hbs
+++ b/addon/components/_private/rdfa-editor/property-editor/modal.hbs
@@ -14,7 +14,7 @@
             </AuLabel>
             <AuInput
               id={{id}}
-              @value={{this.newPredicate}}
+              value={{this.newPredicate}}
               @width="block"
               {{on "input" this.updatePredicate}}
             />
@@ -28,7 +28,7 @@
             <AuInput
               id={{id}}
               required={{true}}
-              @value={{this.newObject}}
+              value={{this.newObject}}
               @width="block"
               {{on "input" this.updateObject}}
             />

--- a/addon/components/_private/rdfa-editor/relationship-editor/content-predicate-list.hbs
+++ b/addon/components/_private/rdfa-editor/relationship-editor/content-predicate-list.hbs
@@ -28,8 +28,9 @@
         <AuInput
           aria-label="New predicate input"
           id="new-predicate-input"
-          @value={{this.newPredicate}}
+          value={{this.newPredicate}}
           placeholder="Add new predicate"
+          {{on "change" this.setNewPredicate}}
         />
 
       </AuFormRow>

--- a/addon/components/_private/rdfa-editor/relationship-editor/content-predicate-list.ts
+++ b/addon/components/_private/rdfa-editor/relationship-editor/content-predicate-list.ts
@@ -17,6 +17,10 @@ export default class ContentPredicateListComponent extends Component<Args> {
       .filter((entry) => entry.prop.type === 'content');
   }
   @action
+  setNewPredicate(event: InputEvent) {
+    this.newPredicate = (event.target as HTMLInputElement).value;
+  }
+  @action
   addContentProperty() {
     this.args.addProperty({ type: 'content', predicate: this.newPredicate });
     this.newPredicate = '';

--- a/addon/components/_private/rdfa-editor/relationship-editor/index.ts
+++ b/addon/components/_private/rdfa-editor/relationship-editor/index.ts
@@ -67,11 +67,9 @@ export default class RdfaRelationshipEditor extends Component<Args> {
   }
 
   get currentResource() {
-    return (
-      this.node.attrs.subject ||
+    return (this.node.attrs.subject ||
       this.node.attrs.about ||
-      (this.node.attrs.resource as string | undefined)
-    );
+      this.node.attrs.resource) as string | undefined;
   }
   get type() {
     return this.node.attrs.rdfaNodeType as 'resource' | 'literal';
@@ -105,8 +103,13 @@ export default class RdfaRelationshipEditor extends Component<Args> {
   goToOutgoing = (outgoing: ExternalProperty) => {
     this.closeStatusMessage();
     const { object } = outgoing;
-    if (object.type === 'literal') {
-      const result = this.controller?.doCommand(
+    if (!this.controller) {
+      this.statusMessage = {
+        message: 'No editor controller found. This is probably a bug.',
+        type: 'error',
+      };
+    } else if (object.type === 'literal') {
+      const result = this.controller.doCommand(
         selectNodeByRdfaId({ rdfaId: object.rdfaId }),
         { view: this.controller.mainEditorView },
       );
@@ -117,7 +120,7 @@ export default class RdfaRelationshipEditor extends Component<Args> {
         };
       }
     } else {
-      const result = this.controller?.doCommand(
+      const result = this.controller.doCommand(
         selectNodeByResource({ resource: object.resource }),
         { view: this.controller.mainEditorView },
       );
@@ -139,7 +142,12 @@ export default class RdfaRelationshipEditor extends Component<Args> {
         view: this.controller.mainEditorView,
       },
     );
-    if (!result) {
+    if (!this.controller) {
+      this.statusMessage = {
+        message: 'No editor controller found. This is probably a bug.',
+        type: 'error',
+      };
+    } else if (!result) {
       this.statusMessage = {
         message: `No resource node found for ${backlink.subject}.`,
         type: 'info',

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -236,7 +236,7 @@ export function renderRdfaAware({
   ];
 }
 
-export const getRdfaContentElement = (node: Node) => {
+const findRdfaContentElement = (node: Node) => {
   if (!isElement(node)) {
     throw new Error('node is not an element');
   }
@@ -245,5 +245,16 @@ export const getRdfaContentElement = (node: Node) => {
       return child as HTMLElement;
     }
   }
-  return node;
+  return null;
+};
+
+export const hasRdfaContentChild = (node: Node) =>
+  !!findRdfaContentElement(node);
+
+/**
+ * Returns a direct child element with 'data-content-container' attribute. If not found, returns the
+ * node itself (to satisfy prosemirror api)
+ **/
+export const getRdfaContentElement = (node: Node) => {
+  return findRdfaContentElement(node) ?? (node as HTMLElement);
 };


### PR DESCRIPTION
### Overview
Also added a doc to clarify the behaviour.

##### connected issues and PRs:
Part of GN compatibility work, PRs will be added if this isn't merged by that time...

### Setup
N/A

### How to test/reproduce
- Test property editor modal inputs still work
- Test content predicate input still works
- Test that clicking relationships still works
- Modify the RdfaEditor template and pass `undefined` to `@controller` on the `RelationshipEditor` component and verify that the specific error is shown when trying to go to relationships

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
