### PR TITLE
Remove custom `transformPasted` hook and add `defining` attribute to `paragraph` node-spec

### DIFF
--- a/.changeset/three-lamps-ring.md
+++ b/.changeset/three-lamps-ring.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Mark paragraphs as `defining`, as they may contain important attributes (such as alignment and indentation) that should not be lost when pasting

--- a/.changeset/wild-eggs-tap.md
+++ b/.changeset/wild-eggs-tap.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Remove custom `transformPasted` hook as it conflicts with the `defining` node-spec attribute

--- a/addon/core/say-editor.ts
+++ b/addon/core/say-editor.ts
@@ -130,15 +130,6 @@ export default class SayEditor {
 
         return htmlCleaner.prepareHTML(html);
       },
-      transformPasted(slice, view) {
-        const { selection } = view.state;
-        const { nodeBefore } = selection.$from;
-        const { nodeAfter } = selection.$to;
-
-        const openStart = nodeBefore?.isInline ? slice.openStart : 0;
-        const openEnd = nodeAfter?.isInline ? slice.openEnd : 0;
-        return SliceUtils.closeSlice(slice, openStart, openEnd);
-      },
       clipboardSerializer: this.serializer,
     });
     this.activeView = this.mainView;

--- a/addon/core/say-editor.ts
+++ b/addon/core/say-editor.ts
@@ -34,7 +34,6 @@ import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import SaySerializer from '@lblod/ember-rdfa-editor/core/say-serializer';
 import { gapCursor } from '../plugins/gap-cursor';
 import HTMLInputParser from '@lblod/ember-rdfa-editor/utils/_private/html-input-parser';
-import SliceUtils from '../utils/_private/slice-utils';
 
 export type PluginConfig = Plugin[] | { plugins: Plugin[]; override?: boolean };
 interface SayEditorArgs {

--- a/addon/nodes/paragraphWithConfig.ts
+++ b/addon/nodes/paragraphWithConfig.ts
@@ -39,6 +39,7 @@ export const paragraphWithConfig: (
     content: config?.content || 'inline*',
     group: config?.group || 'block paragraphGroup',
     subType: config.subType,
+    defining: true,
     attrs: {
       alignment: {
         default: DEFAULT_ALIGNMENT,


### PR DESCRIPTION
### Overview
This PR contains the following modifications:
- The custom `transformPasted` hook introduced in https://github.com/lblod/ember-rdfa-editor/pull/1108 conflicted heavily with the `defining` node-spec attribute. Even non-defining nodes were copied over due to this hook when this was not at all desired. This PR removes the custom hook.
- Addition of the `defining` attribute on the `paragraph` node-spec. This ensures that the paragraph surrouned copied content is correctly preserved. This also solves issues with the loss of paragraph alignment/indentation. The `heading` node-spec already had the `defining` attribute enabled.

Examples of the pasting behaviour with the following clipboard content:

```
<p style="text-align: right" data-pm-slice="1 1 []">eee</p>
```

- Pasting into an empty document:
[Screencast from 2024-01-11 12-04-14.webm](https://github.com/lblod/ember-rdfa-editor/assets/24712836/a6e3a161-1fab-47e9-bef5-64b57b52df6f)

- Pasting after an inline node
  [Screencast from 2024-01-11 12-05-47.webm](https://github.com/lblod/ember-rdfa-editor/assets/24712836/ba4a826d-e0a2-4cbe-9592-0a51cacde333)

- Pasting inbetween inline nodes
[Screencast from 2024-01-11 13-29-38.webm](https://github.com/lblod/ember-rdfa-editor/assets/24712836/747b7862-3a1a-4444-b8db-a5b2423ecf75)

##### connected issues and PRs:
- https://github.com/lblod/ember-rdfa-editor/pull/1108
- [GN-4658](https://binnenland.atlassian.net/browse/GN-4658?atlOrigin=eyJpIjoiNGUxNDIwNjFiZTZkNGE5Y2JjOTJkZmM1ZWM1MWNmNmQiLCJwIjoiaiJ9)


### How to test/reproduce
- Open the dummy app
- Try out the different before-mentioned scenarios
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->
- Check if the behaviour works as expected with the following html (output from word)
  <details>
    <summary>Word output</summary>
      
        <html xmlns:o="urn:schemas-microsoft-com:office:office"
        xmlns:w="urn:schemas-microsoft-com:office:word"
        xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
        xmlns="http://www.w3.org/TR/REC-html40">
        
        <head>
        <meta http-equiv=Content-Type content="text/html; charset=utf-8">
        <meta name=ProgId content=Word.Document>
        <meta name=Generator content="Microsoft Word 15">
        <meta name=Originator content="Microsoft Word 15">
        </head>
        
        <body lang=en-BE style='tab-interval:36.0pt;word-wrap:break-word'>
        <!--StartFragment-->
        
        <p class=MsoNormal align=right style='text-align:right'><span lang=EN-US
        style='mso-ansi-language:EN-US'>Test rechts<o:p></o:p></span></p>
        
        <!--EndFragment-->
        </body>
        </html>
      
  </details>

### Challenges/uncertainties
- The `block_rdfa` still has the `defining` attribute, this is probably not desired.
- We should probably go over all nodes and determine if it is useful/sensible if they are defining or not.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
