### PR TITLE
Another couple of backwards compatibility changes

### DIFF
--- a/addon/components/editor-container.hbs
+++ b/addon/components/editor-container.hbs
@@ -14,6 +14,7 @@
     <div
       class='say-editor
         {{if @editorOptions.showRdfa "rdfa-annotations"}}
+        {{if @editorOptions.editRdfa "rdfa-editing"}}
         {{if @editorOptions.showRdfaHighlight "rdfa-annotations-highlight"}}
         {{if @editorOptions.showRdfaHover "rdfa-annotations-hover"}}
         {{if @loading "au-u-hidden-visually"}}

--- a/addon/plugins/link/nodes/link.ts
+++ b/addon/plugins/link/nodes/link.ts
@@ -1,4 +1,8 @@
-import { getRdfaAttrs, rdfaAttrSpec } from '../../../core/schema';
+import {
+  getRdfaAttrs,
+  rdfaAttrSpec,
+  renderRdfaAware,
+} from '../../../core/schema';
 import {
   createEmberNodeSpec,
   createEmberNodeView,
@@ -11,6 +15,9 @@ type LinkOptions = {
   interactive: boolean;
 };
 
+// TODO this spec doesn't play well with RDFa editing tools. It has been modified so that any
+// additional RDFa annotations are not striped. This is for example, used by the citation plugin in
+// lblod-plugins
 const emberNodeConfig: (options: LinkOptions) => EmberNodeConfig = (
   options,
 ) => {
@@ -48,7 +55,14 @@ const emberNodeConfig: (options: LinkOptions) => EmberNodeConfig = (
     ],
     toDOM(node) {
       const { interactive, placeholder, ...attrs } = node.attrs;
-      return ['a', attrs, 0];
+      return renderRdfaAware({
+        renderable: node,
+        tag: 'a',
+        attrs,
+        rdfaContainerTag: 'span',
+        contentContainerTag: 'span',
+        content: 0,
+      });
     },
   };
 };

--- a/app/styles/ember-rdfa-editor/_c-editable-node.scss
+++ b/app/styles/ember-rdfa-editor/_c-editable-node.scss
@@ -1,11 +1,13 @@
-.say-editable {
-  outline: 0.1rem solid var(--au-gray-300);
-  padding: $au-unit;
-  border-radius: $au-radius;
-  &.say-active {
-    outline: 0.2rem solid var(--au-blue-500);
-  }
-  &.ProseMirror-selectednode {
-    background-color: var(--au-blue-200);
+.rdfa-editing {
+  .say-editable {
+    outline: 0.1rem solid var(--au-gray-300);
+    padding: $au-unit;
+    border-radius: $au-radius;
+    &.say-active {
+      outline: 0.2rem solid var(--au-blue-500);
+    }
+    &.ProseMirror-selectednode {
+      background-color: var(--au-blue-200);
+    }
   }
 }

--- a/app/styles/ember-rdfa-editor/_c-inline-rdfa.scss
+++ b/app/styles/ember-rdfa-editor/_c-inline-rdfa.scss
@@ -1,13 +1,15 @@
-.say-inline-rdfa {
-
-  display: inline-block;
-  border-color: green;
-  border-style: dashed;
-  border-width: 1px;
-  &.say-active {
-    outline: 0.2rem solid var(--au-blue-500);
+.rdfa-editing {
+  .say-inline-rdfa {
+    display: inline-block;
+    border-color: green;
+    border-style: dashed;
+    border-width: 1px;
+    &.say-active {
+      outline: 0.2rem solid var(--au-blue-500);
+    }
   }
 }
+
 .ember-node {
   white-space: normal !important;
   &.say-active {

--- a/tests/dummy/app/templates/editable-node.hbs
+++ b/tests/dummy/app/templates/editable-node.hbs
@@ -5,6 +5,7 @@
   <:content>
     <EditorContainer
       @editorOptions={{hash
+        editRdfa="true"
         showRdfaHighlight="true"
         showRdfaHover="true"
         showPaper="true"


### PR DESCRIPTION
### Overview
Another couple of small things that I missed from making GN work with this branch.
- Render links as RdfaAware, as otherwise their RDFa attributes get stripped, which breaks citation links, for example
- Add a toggle for the CSS of RDFa aware nodes so we can switch it off when not enabled

##### connected issues and PRs:
Needed for https://github.com/lblod/frontend-gelinkt-notuleren/pull/622

### Setup
N/A

### How to test/reproduce
- Check that links still work as expected, and if you add an rdfa annotation to the customHTML input it will be maintained
- In the editable nodes POC page, open a document containing RDFa, then switch to another one of the dummy app pages and see that the boxes in the editor are gone and the old annotations are back.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
