### PR TITLE
Add 2 small RDFa helpers 

### DIFF
--- a/addon/commands/insert-html-command.ts
+++ b/addon/commands/insert-html-command.ts
@@ -2,17 +2,20 @@ import { Command } from 'prosemirror-state';
 import { isTextNode } from '@lblod/ember-rdfa-editor/utils/_private/dom-helpers';
 import { DOMParser as ProseParser, Fragment, Mark } from 'prosemirror-model';
 import { normalToPreWrapWhiteSpace } from '@lblod/ember-rdfa-editor/utils/_private/whitespace-collapsing';
+import { preprocessRDFa } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import { PNode } from '..';
+
 export function insertHtml(
   html: Node | string,
   from: number,
   to: number,
   marks?: Mark[],
   preserveWhitespace = false,
+  shouldPreprocessRdfa = false,
 ): Command {
   return function (state, dispatch, view) {
     if (dispatch) {
-      let htmlNode: Node;
+      let htmlNode: Node | Document;
       if (typeof html === 'string') {
         const domParser = new DOMParser();
         htmlNode = domParser.parseFromString(html, 'text/html');
@@ -21,6 +24,9 @@ export function insertHtml(
       }
       if (!preserveWhitespace) {
         cleanUpNode(htmlNode);
+      }
+      if (shouldPreprocessRdfa) {
+        preprocessRDFa('body' in htmlNode ? htmlNode.body : htmlNode);
       }
       let fragment = ProseParser.fromSchema(state.schema).parseSlice(htmlNode, {
         preserveWhitespace,

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { DOMOutputSpec, Mark } from 'prosemirror-model';
+import { Attrs, DOMOutputSpec, Mark } from 'prosemirror-model';
 import { PNode } from '@lblod/ember-rdfa-editor/index';
 import { isSome } from '../utils/_private/option';
 import { Backlink, Property } from './rdfa-processor';
@@ -45,6 +45,14 @@ export interface RdfaResourceAttrs extends RdfaAwareAttrs {
 }
 export type RdfaAttrs = (RdfaLiteralAttrs | RdfaResourceAttrs) &
   Record<string, string | number | Property[] | Backlink[]>;
+
+export function isRdfaAttrs(attrs: Attrs): attrs is RdfaAttrs {
+  return (
+    '__rdfaId' in attrs &&
+    'backlinks' in attrs &&
+    rdfaNodeTypes.includes(attrs.rdfaNodeType)
+  );
+}
 
 export const sharedRdfaNodeSpec = {
   isolating: true,


### PR DESCRIPTION
### Overview
Add option to preprocess RDFa to insertHtml command, needed for plugins that insert HTML templates that contain RDFa aware nodes, such as standard-template-plugin.
Add a typeguard function for RdfaAttrs from Attrs to avoid constant typecasting.

##### connected issues and PRs:
Needed for https://github.com/lblod/frontend-gelinkt-notuleren/pull/622

### Setup
N/A

### How to test/reproduce
Easiest test is to link it into [the branch of GN](https://github.com/lblod/frontend-gelinkt-notuleren/pull/622), which also needs an RDFa branch of the plugins repo.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
