### PR TITLE
GN-4660: Percentage resize for tables instead of absolute pixels

### DIFF
--- a/.changeset/sharp-hornets-love.md
+++ b/.changeset/sharp-hornets-love.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+GN-4660: Percentage resize for tables instead of absolute pixels

--- a/addon/plugins/table/commands/insertTable.ts
+++ b/addon/plugins/table/commands/insertTable.ts
@@ -2,10 +2,9 @@ import { Command } from 'prosemirror-state';
 
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import { PNode } from '@lblod/ember-rdfa-editor';
-import { getEditorViewWidth } from '@lblod/ember-rdfa-editor/utils/_private/editor-view';
 
 export function insertTable(rows: number, columns: number): Command {
-  return (state, dispatch, view) => {
+  return (state, dispatch) => {
     const {
       schema,
       selection: { $from },
@@ -24,7 +23,7 @@ export function insertTable(rows: number, columns: number): Command {
 
     for (let r = 0; r < rows; r++) {
       const cells = [];
-      const proportionalWidth = view ? getEditorViewWidth(view) / columns : 0;
+      const proportionalWidth = 100 / columns;
 
       for (let c = 0; c < columns; c++) {
         cells.push(

--- a/addon/plugins/table/nodes/table.ts
+++ b/addon/plugins/table/nodes/table.ts
@@ -19,16 +19,31 @@ type CellAttributes = {
   colwidth?: number[] | null;
 } & Record<string, unknown>;
 
+// A naive way to fix the colwidths attribute, from pixels to percentage
+const fixupColWidth = (number: string) => {
+  const numberWidth = Number(number);
+
+  if (numberWidth > 100) {
+    // return 0 to reset the width
+    return 0;
+  }
+
+  return numberWidth;
+};
+
 function getCellAttrs(
   dom: Element,
   extraAttrs: Record<string, ExtraAttribute>,
 ): CellAttributes {
   const widthAttr = dom.getAttribute('data-colwidth');
+
   const widths =
-    widthAttr && /^\d+(,\d+)*$/.test(widthAttr)
-      ? widthAttr.split(',').map((s) => Number(s))
+    widthAttr && /^\d+(\.\d+)*(,\d+(\.\d+)*)*$/.test(widthAttr)
+      ? widthAttr.split(',').map(fixupColWidth)
       : null;
+
   const colspan = Number(dom.getAttribute('colspan') || 1);
+
   const result: CellAttributes = {
     colspan,
     rowspan: Number(dom.getAttribute('rowspan') || 1),

--- a/app/styles/ember-rdfa-editor/_c-table.scss
+++ b/app/styles/ember-rdfa-editor/_c-table.scss
@@ -1,11 +1,9 @@
 .say-table {
   @include au-font-size($au-h6);
   display: table;
-  table-layout: fixed;
+  table-layout: auto;
   position: relative;
-  // important because we're overriding `width` that is being set by columnResizing plugin
-  // TODO: do not set `table` width inside `columnResizing` plugin
-  width: 100% !important;
+  min-width: 100%;
   border-collapse: collapse;
   border: 0.1rem solid var(--au-gray-300);
 
@@ -64,12 +62,6 @@
     background-color: #adf;
     pointer-events: none;
     margin-top: 0;
-  }
-
-  colgroup col:last-child {
-    // last column should always be `auto` so it takes up the remaining space
-    // that accommodates editor width changes
-    width: auto !important;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "prosemirror-schema-basic": "^1.2.1",
         "prosemirror-schema-list": "^1.2.2",
         "prosemirror-state": "^1.4.2",
-        "prosemirror-tables": "git://github.com/lblod/prosemirror-tables",
+        "prosemirror-tables": "lblod/prosemirror-tables#289fb59ede8c605767af9ef3a106a62aae223220",
         "prosemirror-transform": "^1.8.0",
         "prosemirror-view": "^1.32.4",
         "rdf-data-factory": "^1.1.0",
@@ -29744,7 +29744,8 @@
     },
     "node_modules/prosemirror-tables": {
       "version": "1.3.5",
-      "resolved": "git+ssh://git@github.com/lblod/prosemirror-tables.git#6d76d7209d8f4f2600aba679585208e2b0ac3f54",
+      "resolved": "git+ssh://git@github.com/lblod/prosemirror-tables.git#289fb59ede8c605767af9ef3a106a62aae223220",
+      "integrity": "sha512-mCe/ITjsWdDO1rm4OS/ge4S7K+IAICxWBAVl1T4RRTryAn27f/7JJpHzMOmCCrmDpEDvIu2Fptm5HXRbFSvYIg==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-keymap": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prosemirror-schema-basic": "^1.2.1",
     "prosemirror-schema-list": "^1.2.2",
     "prosemirror-state": "^1.4.2",
-    "prosemirror-tables": "git://github.com/lblod/prosemirror-tables",
+    "prosemirror-tables": "lblod/prosemirror-tables#289fb59ede8c605767af9ef3a106a62aae223220",
     "prosemirror-transform": "^1.8.0",
     "prosemirror-view": "^1.32.4",
     "rdf-data-factory": "^1.1.0",


### PR DESCRIPTION
### Overview

Percentage resize for tables instead of absolute pixels

Changes to our fork of `prosemirror-tables` here - https://github.com/lblod/prosemirror-tables/pull/2

##### connected issues and PRs:

Fixes

* https://binnenland.atlassian.net/browse/GN-4660
* https://binnenland.atlassian.net/browse/GN-4657 (will need a change in [GN](https://github.com/lblod/frontend-gelinkt-notuleren/pull/627))


### Setup

1. Checkout
2. `npm i`

### How to test/reproduce

1. `npm run start`
2. Insert table, resize column, see if that still works 😅 

### Challenges/uncertainties

Inserting a lot of extra column and resizing them might yield strange results, as they don't have "real width", the browser just makes the best effort to render them, so they might seem unresizeable initially, but resizing them actually works.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
