### PR TITLE
Small tweaks from ongoing backwards compatibility struggle in plugins

### DIFF
--- a/addon/components/toolbar/mark.ts
+++ b/addon/components/toolbar/mark.ts
@@ -1,5 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import type { MarkType } from 'prosemirror-model';
 import { toggleMarkAddFirst } from '@lblod/ember-rdfa-editor/commands';
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 
@@ -12,21 +13,30 @@ export default class MarkComponent extends Component<Args> {
     return this.args.controller;
   }
 
-  get mark() {
+  get mark(): MarkType | undefined {
+    if (this.controller && !this.controller.schema.marks[this.args.mark]) {
+      console.error(
+        `Can't find mark '${this.args.mark}', did you add it to your schema?`,
+      );
+    }
     return this.controller.schema.marks[this.args.mark];
   }
 
   get isActive() {
-    return this.controller.isMarkActive(this.mark);
+    return this.mark && this.controller.isMarkActive(this.mark);
   }
 
   get canToggle() {
-    return this.controller.checkCommand(toggleMarkAddFirst(this.mark));
+    return (
+      this.mark && this.controller.checkCommand(toggleMarkAddFirst(this.mark))
+    );
   }
 
   @action
   toggle() {
-    this.controller.focus();
-    this.controller.doCommand(toggleMarkAddFirst(this.mark));
+    if (this.mark) {
+      this.controller.focus();
+      this.controller.doCommand(toggleMarkAddFirst(this.mark));
+    }
   }
 }

--- a/addon/utils/_private/datastore/graphy-dataset.ts
+++ b/addon/utils/_private/datastore/graphy-dataset.ts
@@ -96,6 +96,11 @@ export class GraphyDataset implements QuadDataSet {
     return new GraphyDataset(this.fastDataset.difference(gds.fastDataset));
   }
 
+  minus(other: QuadDataSet): QuadDataSet {
+    const gds = new GraphyDataset(other);
+    return new GraphyDataset(this.fastDataset.minus(gds.fastDataset));
+  }
+
   equals(other: RDF.Dataset<RDF.Quad, RDF.Quad>): boolean {
     const gds = new GraphyDataset(other);
     return this.fastDataset.equals(gds.fastDataset);

--- a/tests/integration/rdfa/blackbox-test.ts
+++ b/tests/integration/rdfa/blackbox-test.ts
@@ -93,6 +93,10 @@ module('Integration | RDFa blackbox test ', function () {
         ${initialTurtle || '<empty>'}
         After:
         ${resultingTurtle || '<empty>'}
+        In 'before' but not in 'after':
+        ${await toTurtle(initialDataset.minus(resultingDataset))}
+        In 'after' but not in 'before':
+        ${await toTurtle(resultingDataset.minus(initialDataset))}
       `;
       assert.true(isEqual, message);
     });


### PR DESCRIPTION
### Overview
Don't crash if we use a toolbar button for a mark that isn't in the schema and give some more fine-grained output when blackbox tests fail.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Remove a mark (such as `redacted` from the schema but leave the corresponding toolbar button in place, you should get a nice console log telling you what's wrong and the button should just be disabled (it used to crash).
Enable one of the failing blackbox tests and see the slightly improved failure message.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
