### PR TITLE
Add width to serialized table to mimic width from editor CSS

### DIFF
--- a/addon/plugins/table/nodes/table.ts
+++ b/addon/plugins/table/nodes/table.ts
@@ -135,7 +135,11 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
 
         return [
           'table',
-          { ...node.attrs, class: 'say-table' },
+          {
+            ...node.attrs,
+            class: 'say-table',
+            style: 'min-width: 100%',
+          },
           tableView.colgroupElement,
           ['tbody', 0],
         ];


### PR DESCRIPTION
### Overview
Table width is now dependent on the CSS which applies `min-width: 100%`, so this change mimics that when serializing.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor/pull/1138

### Setup
N/A

### How to test/reproduce
Copy-paste a table into another doc e.g. google docs. Before the table was only as wide as the content, now it is full width.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
