### PR TITLE
Add option for inlining styles for table borders

### DIFF
--- a/.changeset/pretty-trains-peel.md
+++ b/.changeset/pretty-trains-peel.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Add option for table plugin to enable developers to specify the styling of table borders, which are maintained when exporting tables, such as when copying to the clipboard.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ export default class EditorComponent extends Component {
           defaultLanguage: 'nl-BE',
         }),
         paragraph,
-        ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+        ...tableNodes({
+          tableGroup: 'block',
+          cellContent: 'block+',
+          inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
+        }),
         heading,
         blockquote,
         horizontal_rule,

--- a/addon/core/say-node-spec.ts
+++ b/addon/core/say-node-spec.ts
@@ -6,5 +6,14 @@ import { DOMOutputSpec, NodeSpec } from 'prosemirror-model';
  * It allows to create a serialized version of a node based on the node itself and the current editor-state.
  */
 export default interface SayNodeSpec extends NodeSpec {
+  /**
+   * `serialize` method which is used by an instance of a `SaySerializer`.
+   * When defined, this method takes precedence over `toDOM` when serializing using a `SaySerializer`.
+   *
+   * Note: this method is not a replacement to `toDOM`, `toDOM` is still used by Prosemirror to construct the node-view for this node,
+   * `serialize` is only used when `SaySerializer` is explicitly used in our code to serialize something.
+   * e.g. copying a part of the editor (see `clipboardSerializer`) or extracting the document html using the 'SayController.htmlContent` method.
+   *
+   */
   serialize?: (node: PNode, state: EditorState) => DOMOutputSpec;
 }

--- a/addon/plugins/table/index.ts
+++ b/addon/plugins/table/index.ts
@@ -33,22 +33,12 @@ export class TableView extends PluginTableView {
   }
 
   private addAttrs(node: Node): void {
-    const {
-      class: nodeClasses,
-      style,
-      ...attrs
-    } = node.attrs as Record<string, unknown>;
+    const { class: nodeClasses, style } = node.attrs as Record<string, unknown>;
     if (typeof nodeClasses === 'string') {
       this.table.classList.add(...nodeClasses.split(' '));
     }
     if (typeof style === 'string') {
       this.table.style.cssText = `${this.table.style.cssText} ${style}`;
-    }
-    for (const attrName in attrs) {
-      const attr = attrs[attrName];
-      if (typeof attr === 'string') {
-        this.table.setAttribute(attrName, attr);
-      }
     }
   }
 

--- a/addon/plugins/table/index.ts
+++ b/addon/plugins/table/index.ts
@@ -29,13 +29,26 @@ export class TableView extends PluginTableView {
     public cellMinWidth: number,
   ) {
     super(node, cellMinWidth);
-    this.addClasses(node);
+    this.addAttrs(node);
   }
 
-  private addClasses(node: Node): void {
-    const nodeClasses = node.attrs.class as string | undefined;
+  private addAttrs(node: Node): void {
+    const {
+      class: nodeClasses,
+      style,
+      ...attrs
+    } = node.attrs as Record<string, unknown>;
     if (typeof nodeClasses === 'string') {
       this.table.classList.add(...nodeClasses.split(' '));
+    }
+    if (typeof style === 'string') {
+      this.table.style.cssText = `${this.table.style.cssText} ${style}`;
+    }
+    for (const attrName in attrs) {
+      const attr = attrs[attrName];
+      if (typeof attr === 'string') {
+        this.table.setAttribute(attrName, attr);
+      }
     }
   }
 

--- a/addon/plugins/table/nodes/table.ts
+++ b/addon/plugins/table/nodes/table.ts
@@ -86,6 +86,17 @@ interface TableNodeOptions {
   tableGroup?: string;
   cellContent: string;
   cellAttributes?: Record<string, ExtraAttribute>;
+  /**
+   * Style to be applied inline to elements in order to mark the rows and columns of the table.
+   * If not supplied, the default stylesheets apply a border to ensure that it is visible.
+   * This is not maintained when exporting the markup (e.g. when copy-pasting a table).
+   * Style defaults to 'solid'.
+   */
+  inlineBorderStyle?: {
+    width: string;
+    style?: string;
+    color: string;
+  };
 }
 
 interface TableNodes extends Record<string, NodeSpec> {
@@ -105,13 +116,25 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
   for (const [key, attr] of Object.entries(extraAttrs)) {
     cellAttrs[key] = { default: attr.default };
   }
+  const inlineBorderStyle =
+    options.inlineBorderStyle &&
+    `${options.inlineBorderStyle.width} ${options.inlineBorderStyle.style || 'solid'} ${options.inlineBorderStyle.color}`;
+  const tableStyle =
+    inlineBorderStyle &&
+    `border: ${inlineBorderStyle}; border-collapse: collapse;`;
+  const rowStyle = inlineBorderStyle && `border-bottom: ${inlineBorderStyle};`;
+  const cellStyle = inlineBorderStyle && `border-left: ${inlineBorderStyle};`;
 
   return {
     table: {
       content: 'table_row+',
       tableRole: 'table',
       isolating: true,
-      attrs: { ...rdfaAttrs, class: { default: 'say-table' } },
+      attrs: {
+        ...rdfaAttrs,
+        class: { default: 'say-table' },
+        style: { default: tableStyle },
+      },
       group: options.tableGroup,
       allowGapCursor: false,
       parseDOM: [
@@ -128,7 +151,15 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
         },
       ],
       toDOM(node: PNode) {
-        return ['table', { ...node.attrs, class: 'say-table' }, ['tbody', 0]];
+        return [
+          'table',
+          {
+            ...node.attrs,
+            class: 'say-table',
+            style: tableStyle,
+          },
+          ['tbody', 0],
+        ];
       },
       serialize(node: PNode) {
         const tableView = new TableView(node, 25);
@@ -138,7 +169,7 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
           {
             ...node.attrs,
             class: 'say-table',
-            style: 'min-width: 100%',
+            style: `width: 100%; ${tableStyle || ''}`,
           },
           tableView.colgroupElement,
           ['tbody', 0],
@@ -164,7 +195,7 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
         },
       ],
       toDOM(node: PNode) {
-        return ['tr', node.attrs, 0];
+        return ['tr', { ...node.attrs, style: rowStyle }, 0];
       },
     },
     table_cell: {
@@ -180,7 +211,11 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
         },
       ],
       toDOM(node) {
-        return ['td', setCellAttrs(node, extraAttrs), 0];
+        return [
+          'td',
+          { ...setCellAttrs(node, extraAttrs), style: cellStyle },
+          0,
+        ];
       },
     },
     table_header: {
@@ -195,7 +230,11 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
         },
       ],
       toDOM(node) {
-        return ['th', setCellAttrs(node, extraAttrs), 0];
+        return [
+          'th',
+          { ...setCellAttrs(node, extraAttrs), style: cellStyle },
+          0,
+        ];
       },
     },
   };

--- a/addon/plugins/table/nodes/table.ts
+++ b/addon/plugins/table/nodes/table.ts
@@ -122,7 +122,7 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
   const tableStyle =
     inlineBorderStyle &&
     `border: ${inlineBorderStyle}; border-collapse: collapse;`;
-  const rowStyle = inlineBorderStyle && `border-bottom: ${inlineBorderStyle};`;
+  const rowStyle = inlineBorderStyle && `border-top: ${inlineBorderStyle};`;
   const cellStyle = inlineBorderStyle && `border-left: ${inlineBorderStyle};`;
 
   return {

--- a/tests/dummy/app/controllers/backspace.ts
+++ b/tests/dummy/app/controllers/backspace.ts
@@ -88,7 +88,11 @@ export default class BackspaceController extends Controller {
       ordered_list,
       bullet_list,
       placeholder,
-      ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+      ...tableNodes({
+        tableGroup: 'block',
+        cellContent: 'block+',
+        inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
+      }),
       heading,
       blockquote,
 

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -82,7 +82,11 @@ export default class IndexController extends Controller {
       ordered_list,
       bullet_list,
       placeholder,
-      ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+      ...tableNodes({
+        tableGroup: 'block',
+        cellContent: 'block+',
+        inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
+      }),
       heading,
       blockquote,
 

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -87,7 +87,11 @@ export default class IndexController extends Controller {
       ordered_list,
       bullet_list,
       placeholder,
-      ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+      ...tableNodes({
+        tableGroup: 'block',
+        cellContent: 'block+',
+        inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
+      }),
       heading,
       blockquote,
 

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -83,7 +83,11 @@ export default class SpaceInvisibleController extends Controller {
       ordered_list,
       bullet_list,
       placeholder,
-      ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+      ...tableNodes({
+        tableGroup: 'block',
+        cellContent: 'block+',
+        inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
+      }),
       heading,
       blockquote,
 


### PR DESCRIPTION
### Overview
Allows control of table border styles by (dev) users of the editor. When no style is passed, it defaults to the current behaviour, which is the CSS applies a border in the editor but this is not serialized/exported. If a style is passed, it's serialized.

##### connected issues and PRs:
[PR to embeddable to expose this](https://github.com/lblod/frontend-embeddable-notule-editor/pull/226)
https://binnenland.atlassian.net/browse/GN-4697

### Setup
Inlined styles can be tweaked in the schema for test pages of the dummy app.

### How to test/reproduce
Create a table and see the border styles are applied correctly and then click 'show export preview' or copy-paste it into e.g. google docs. With no style passed, behaviour should be unchanged, i.e. thin border in the editor, nothing in the copy-pasted content.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
