### PR TITLE
Replace postpack script with `clean` as this breaks linking

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+declarations
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepack": "tsc --project tsconfig.declarations.json",
-    "postpack": "rimraf declarations",
+    "clean": "rimraf declarations",
     "start": "concurrently -c \"auto\" -P \"npm:serve -- {@}\" \"npm:typecheck\" --",
     "typecheck": "tsc --noEmit --watch",
     "serve": "ember serve",


### PR DESCRIPTION
### Overview
`npm link` is broken by the files being removed (it uses a symlink). `yalc publish --push` works but `yalc push` seems to clear the declarations directory. Make it a manual step and add declarations to a dockerignore file.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
`npm link` or `yalc publish && yalc push` into another TS project and no longer see the types fail to import.

### Challenges/uncertainties
`npm link` still seems to see type problems as it is treating the types from different locations as different, e.g.:
```
Type 'import("<...>/ember-rdfa-editor-lblod-plugins/node_modules/prosemirror-model/dist/index").MarkSpec' is not assignable to type 'import("<...>/ember-rdfa-editor/node_modules/prosemirror-model/dist/index").MarkSpec
```

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
