### PR TITLE
GN-4723: Addition of `table-tooltip` component allowing users quick access to table-editing features

### DIFF
--- a/.changeset/great-experts-scream.md
+++ b/.changeset/great-experts-scream.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Add custom `floating-ui` modifier with support for virtual elements, custom middleware options and transform-positioning

--- a/.changeset/quiet-llamas-shake.md
+++ b/.changeset/quiet-llamas-shake.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Addition of a `table-tooltip` component which allows users to quickly access table-editing features

--- a/addon/components/_private/selection-tooltip.hbs
+++ b/addon/components/_private/selection-tooltip.hbs
@@ -1,0 +1,14 @@
+{{#if this.visible}}
+  <div
+    {{this.floatingUI
+      referenceElement=this.referenceElement
+      placement="bottom"
+      middleware=this.tooltipMiddleWare
+      strategy="fixed"
+      useTransform=true
+    }}
+    class="say-editor-selection-tooltip"
+  >
+    {{yield}}
+  </div>
+{{/if}}

--- a/addon/components/_private/selection-tooltip.hbs
+++ b/addon/components/_private/selection-tooltip.hbs
@@ -8,6 +8,7 @@
       useTransform=true
     }}
     class="say-editor-selection-tooltip"
+    ...attributes
   >
     {{yield}}
   </div>

--- a/addon/components/_private/selection-tooltip.ts
+++ b/addon/components/_private/selection-tooltip.ts
@@ -1,0 +1,61 @@
+import { VirtualElement, flip, hide, offset, shift } from '@floating-ui/dom';
+import Component from '@glimmer/component';
+import { SayController } from '@lblod/ember-rdfa-editor';
+import floatingUI from '@lblod/ember-rdfa-editor/modifiers/_private/floating-ui';
+
+type Args = {
+  controller: SayController;
+  visible: boolean;
+};
+export default class SelectionTooltip extends Component<Args> {
+  floatingUI = floatingUI;
+
+  get controller() {
+    return this.args.controller;
+  }
+
+  get visible() {
+    return this.args.visible;
+  }
+
+  get referenceElement() {
+    const { selection } = this.controller.mainEditorState;
+    const virtualElement: VirtualElement = {
+      getBoundingClientRect: () => {
+        const coordsFrom = this.controller.mainEditorView.coordsAtPos(
+          selection.from,
+          -1,
+        );
+        const coordsTo = this.controller.mainEditorView.coordsAtPos(
+          selection.to,
+          -1,
+        );
+        const left = (coordsFrom.left + coordsTo.left) / 2;
+        const right = (coordsFrom.right + coordsTo.right) / 2;
+        const bottom = coordsTo.bottom;
+        const top = coordsFrom.top;
+        return {
+          left,
+          right,
+          bottom,
+          top,
+          x: left,
+          y: top,
+          width: 0,
+          height: bottom - top,
+        };
+      },
+      contextElement: this.controller.mainEditorView.dom,
+    };
+    return virtualElement;
+  }
+  get tooltipMiddleWare() {
+    return [
+      offset(10),
+      flip(),
+      shift({ padding: 5 }),
+      hide({ strategy: 'referenceHidden' }),
+      hide({ strategy: 'escaped' }),
+    ];
+  }
+}

--- a/addon/components/plugins/table/table-tooltip.hbs
+++ b/addon/components/plugins/table/table-tooltip.hbs
@@ -4,20 +4,24 @@
     @visible={{this.visible}}
     class="say-table-tooltip"
   >
-    {{#each this.tableActions as |action|}}
-      <button
-        type="button"
-        title={{action.title}}
-        disabled={{not (this.canExecuteAction action)}}
-        {{on "click" (fn this.executeAction action)}}
-      >
-        {{#if action.icon}}
-          <AuIcon @icon={{action.icon}} @size="large" />
-        {{/if}}
-        {{#if action.label}}
-          <span>{{action.label}}</span>
-        {{/if}}
-      </button>
+    {{#each this.tableActions as |row|}}
+      <div class="say-table-tooltip--actions">
+        {{#each row as |action|}}
+          <button
+            type="button"
+            title={{action.title}}
+            disabled={{not (this.canExecuteAction action)}}
+            {{on "click" (fn this.executeAction action)}}
+          >
+            {{#if action.icon}}
+              <AuIcon @icon={{action.icon}} @size="large" />
+            {{/if}}
+            {{#if action.label}}
+              <span>{{action.label}}</span>
+            {{/if}}
+          </button>
+        {{/each}}
+      </div>
     {{/each}}
   </this.SelectionTooltip>
 </div>

--- a/addon/components/plugins/table/table-tooltip.hbs
+++ b/addon/components/plugins/table/table-tooltip.hbs
@@ -2,14 +2,22 @@
   <this.SelectionTooltip
     @controller={{this.controller}}
     @visible={{this.visible}}
+    class="say-table-tooltip"
   >
     {{#each this.tableActions as |action|}}
-      <Toolbar::Button
-        @title={{action.title}}
-        @icon={{action.icon}}
-        @disabled={{not (this.canExecuteAction action)}}
+      <button
+        type="button"
+        title={{action.title}}
+        disabled={{not (this.canExecuteAction action)}}
         {{on "click" (fn this.executeAction action)}}
-      />
+      >
+        {{#if action.icon}}
+          <AuIcon @icon={{action.icon}} @size="large" />
+        {{/if}}
+        {{#if action.label}}
+          <span>{{action.label}}</span>
+        {{/if}}
+      </button>
     {{/each}}
   </this.SelectionTooltip>
 </div>

--- a/addon/components/plugins/table/table-tooltip.hbs
+++ b/addon/components/plugins/table/table-tooltip.hbs
@@ -1,0 +1,15 @@
+<div {{this.setUpListeners}}>
+  <this.SelectionTooltip
+    @controller={{this.controller}}
+    @visible={{this.visible}}
+  >
+    {{#each this.tableActions as |action|}}
+      <Toolbar::Button
+        @title={{action.title}}
+        @icon={{action.icon}}
+        @disabled={{not (this.canExecuteAction action)}}
+        {{on "click" (fn this.executeAction action)}}
+      />
+    {{/each}}
+  </this.SelectionTooltip>
+</div>

--- a/addon/components/plugins/table/table-tooltip.ts
+++ b/addon/components/plugins/table/table-tooltip.ts
@@ -9,6 +9,8 @@ import {
   deleteColumn,
   deleteRow,
   deleteTable,
+  toggleHeaderColumn,
+  toggleHeaderRow,
 } from 'prosemirror-tables';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
@@ -22,7 +24,8 @@ type Args = {
 
 type Action = {
   title: string;
-  icon: string;
+  icon?: string;
+  label?: string;
   command: Command;
 };
 export default class TableTooltip extends Component<Args> {
@@ -72,6 +75,16 @@ export default class TableTooltip extends Component<Args> {
         title: this.intl.t('ember-rdfa-editor.add-column-before'),
         icon: 'table-column-start-add',
         command: addColumnBefore,
+      },
+      {
+        title: this.intl.t('ember-rdfa-editor.toggle-header-row'),
+        label: this.intl.t('ember-rdfa-editor.toggle-header-row'),
+        command: toggleHeaderRow,
+      },
+      {
+        title: this.intl.t('ember-rdfa-editor.toggle-header-column'),
+        label: this.intl.t('ember-rdfa-editor.toggle-header-column'),
+        command: toggleHeaderColumn,
       },
       {
         title: this.intl.t('ember-rdfa-editor.delete-row'),

--- a/addon/components/plugins/table/table-tooltip.ts
+++ b/addon/components/plugins/table/table-tooltip.ts
@@ -87,7 +87,7 @@ export default class TableTooltip extends Component<Args> {
         title: this.intl.t('ember-rdfa-editor.delete-table'),
         icon: 'bin',
         command: deleteTable,
-      }
+      },
     ];
   }
 

--- a/addon/components/plugins/table/table-tooltip.ts
+++ b/addon/components/plugins/table/table-tooltip.ts
@@ -54,53 +54,59 @@ export default class TableTooltip extends Component<Args> {
     { eager: false },
   );
 
-  get tableActions(): Action[] {
+  get tableActions() {
     return [
-      {
-        title: this.intl.t('ember-rdfa-editor.add-row-below'),
-        icon: 'table-row-end-add',
-        command: addRowAfter,
-      },
-      {
-        title: this.intl.t('ember-rdfa-editor.add-row-above'),
-        icon: 'table-row-start-add',
-        command: addRowBefore,
-      },
-      {
-        title: this.intl.t('ember-rdfa-editor.add-column-after'),
-        icon: 'table-column-end-add',
-        command: addColumnAfter,
-      },
-      {
-        title: this.intl.t('ember-rdfa-editor.add-column-before'),
-        icon: 'table-column-start-add',
-        command: addColumnBefore,
-      },
-      {
-        title: this.intl.t('ember-rdfa-editor.toggle-header-row'),
-        label: this.intl.t('ember-rdfa-editor.toggle-header-row'),
-        command: toggleHeaderRow,
-      },
-      {
-        title: this.intl.t('ember-rdfa-editor.toggle-header-column'),
-        label: this.intl.t('ember-rdfa-editor.toggle-header-column'),
-        command: toggleHeaderColumn,
-      },
-      {
-        title: this.intl.t('ember-rdfa-editor.delete-row'),
-        icon: 'table-row-remove',
-        command: deleteRow,
-      },
-      {
-        title: this.intl.t('ember-rdfa-editor.delete-column'),
-        icon: 'table-column-remove',
-        command: deleteColumn,
-      },
-      {
-        title: this.intl.t('ember-rdfa-editor.delete-table'),
-        icon: 'bin',
-        command: deleteTable,
-      },
+      [
+        {
+          title: this.intl.t('ember-rdfa-editor.toggle-header-row'),
+          label: this.intl.t('ember-rdfa-editor.toggle-header-row'),
+          command: toggleHeaderRow,
+        },
+        {
+          title: this.intl.t('ember-rdfa-editor.toggle-header-column'),
+          label: this.intl.t('ember-rdfa-editor.toggle-header-column'),
+          command: toggleHeaderColumn,
+        },
+      ],
+      [
+        {
+          title: this.intl.t('ember-rdfa-editor.add-row-below'),
+          icon: 'table-row-end-add',
+          command: addRowAfter,
+        },
+        {
+          title: this.intl.t('ember-rdfa-editor.add-row-above'),
+          icon: 'table-row-start-add',
+          command: addRowBefore,
+        },
+        {
+          title: this.intl.t('ember-rdfa-editor.add-column-after'),
+          icon: 'table-column-end-add',
+          command: addColumnAfter,
+        },
+        {
+          title: this.intl.t('ember-rdfa-editor.add-column-before'),
+          icon: 'table-column-start-add',
+          command: addColumnBefore,
+        },
+      ],
+      [
+        {
+          title: this.intl.t('ember-rdfa-editor.delete-row'),
+          icon: 'table-row-remove',
+          command: deleteRow,
+        },
+        {
+          title: this.intl.t('ember-rdfa-editor.delete-column'),
+          icon: 'table-column-remove',
+          command: deleteColumn,
+        },
+        {
+          title: this.intl.t('ember-rdfa-editor.delete-table'),
+          icon: 'bin',
+          command: deleteTable,
+        },
+      ],
     ];
   }
 

--- a/addon/components/plugins/table/table-tooltip.ts
+++ b/addon/components/plugins/table/table-tooltip.ts
@@ -1,0 +1,115 @@
+import Component from '@glimmer/component';
+import { Command, SayController } from '@lblod/ember-rdfa-editor';
+import SelectionTooltip from '../../_private/selection-tooltip';
+import {
+  addColumnAfter,
+  addColumnBefore,
+  addRowAfter,
+  addRowBefore,
+  deleteColumn,
+  deleteRow,
+  deleteTable,
+} from 'prosemirror-tables';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+import { service } from '@ember/service';
+import IntlService from 'ember-intl/services/intl';
+
+type Args = {
+  controller: SayController;
+};
+
+type Action = {
+  title: string;
+  icon: string;
+  command: Command;
+};
+export default class TableTooltip extends Component<Args> {
+  @service declare intl: IntlService;
+
+  SelectionTooltip = SelectionTooltip;
+
+  @tracked _justClicked = false;
+
+  setUpListeners = modifier(
+    () => {
+      const handleMouseDown = () => {
+        this._justClicked = true;
+      };
+      const handleKeyDown = () => {
+        this._justClicked = false;
+      };
+      const viewDom = this.controller.mainEditorView.dom;
+      viewDom.addEventListener('mousedown', handleMouseDown);
+      viewDom.addEventListener('keydown', handleKeyDown);
+      return () => {
+        viewDom.removeEventListener('mousedown', handleMouseDown);
+        viewDom.removeEventListener('keydown', handleKeyDown);
+      };
+    },
+    { eager: false },
+  );
+
+  get tableActions(): Action[] {
+    return [
+      {
+        title: this.intl.t('ember-rdfa-editor.add-row-below'),
+        icon: 'table-row-end-add',
+        command: addRowAfter,
+      },
+      {
+        title: this.intl.t('ember-rdfa-editor.add-row-above'),
+        icon: 'table-row-start-add',
+        command: addRowBefore,
+      },
+      {
+        title: this.intl.t('ember-rdfa-editor.add-column-after'),
+        icon: 'table-column-end-add',
+        command: addColumnAfter,
+      },
+      {
+        title: this.intl.t('ember-rdfa-editor.add-column-before'),
+        icon: 'table-column-start-add',
+        command: addColumnBefore,
+      },
+      {
+        title: this.intl.t('ember-rdfa-editor.delete-row'),
+        icon: 'table-row-remove',
+        command: deleteRow,
+      },
+      {
+        title: this.intl.t('ember-rdfa-editor.delete-column'),
+        icon: 'table-column-remove',
+        command: deleteColumn,
+      },
+      {
+        title: this.intl.t('ember-rdfa-editor.delete-table'),
+        icon: 'bin',
+        command: deleteTable,
+      }
+    ];
+  }
+
+  get controller() {
+    return this.args.controller;
+  }
+
+  get visible() {
+    return this._justClicked && this.isInTable;
+  }
+
+  get isInTable() {
+    return this.controller.checkCommand(deleteTable);
+  }
+
+  canExecuteAction = (action: Action) => {
+    return this.controller.checkCommand(action.command);
+  };
+
+  @action
+  executeAction(action: Action) {
+    this.controller.focus();
+    this.controller.doCommand(action.command);
+  }
+}

--- a/addon/modifiers/_private/floating-ui.ts
+++ b/addon/modifiers/_private/floating-ui.ts
@@ -1,0 +1,105 @@
+/**
+ * Inspired by `floating-ui` (https://github.com/floating-ui/floating-ui) integrations of
+ * `ember-velcro` (https://github.com/CrowdStrike/ember-velcro) and
+ * `@appuniversum/ember-appuniversum` (https://github.com/appuniversum/ember-appuniversum) .
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2021
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { assert } from '@ember/debug';
+import {
+  Middleware,
+  Placement,
+  ReferenceElement,
+  Strategy,
+  autoUpdate,
+  computePosition,
+} from '@floating-ui/dom';
+import { modifier } from 'ember-modifier';
+
+export type FloatingUISignature = {
+  Element: HTMLElement;
+  Args: {
+    Named: {
+      referenceElement: ReferenceElement | string;
+      placement?: Placement;
+      strategy?: Strategy;
+      useTransform?: boolean;
+      middleware?: Middleware[];
+    };
+  };
+};
+
+const floatingUI = modifier<FloatingUISignature>(
+  (
+    floatingElement,
+    _positional,
+    {
+      strategy = 'absolute',
+      referenceElement,
+      placement,
+      useTransform = true,
+      middleware,
+    },
+  ) => {
+    if (typeof referenceElement === 'string') {
+      const refElement = document.querySelector(referenceElement);
+      assert(
+        `Reference element ${referenceElement} is undefined`,
+        refElement instanceof HTMLElement,
+      );
+      referenceElement = refElement;
+    }
+
+    Object.assign(floatingElement.style, {
+      position: strategy,
+      top: '0',
+      left: '0',
+    });
+
+    const update = () => {
+      computePosition(referenceElement as ReferenceElement, floatingElement, {
+        placement,
+        strategy: strategy,
+        middleware,
+      })
+        .then(({ x, y, middlewareData }) => {
+          const visibility = middlewareData.hide?.referenceHidden
+            ? 'hidden'
+            : 'visible';
+          const xVal = Math.round(x);
+          const yVal = Math.round(y);
+          if (useTransform) {
+            Object.assign(floatingElement.style, {
+              transform: `translate(${xVal}px, ${yVal}px)`,
+              visibility,
+            });
+          } else {
+            Object.assign(floatingElement.style, {
+              top: `${y}px`,
+              left: `${x}px`,
+              visibility,
+            });
+          }
+        })
+        .catch((e) => {
+          console.error(e);
+        });
+    };
+
+    const cleanup = autoUpdate(referenceElement, floatingElement, update);
+    return () => {
+      cleanup();
+    };
+  },
+  {
+    eager: false,
+  },
+);
+
+export default floatingUI;

--- a/app/components/plugins/table/table-tooltip.js
+++ b/app/components/plugins/table/table-tooltip.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/components/plugins/table/table-tooltip';

--- a/app/styles/ember-rdfa-editor/_a-custom-components.scss
+++ b/app/styles/ember-rdfa-editor/_a-custom-components.scss
@@ -13,6 +13,7 @@
 @import 'c-placeholder';
 @import 'c-toast';
 @import 'c-toolbar';
+@import 'c-selection-tooltip';
 @import 'c-table';
 @import 'c-ember-node';
 @import 'c-color-selector';

--- a/app/styles/ember-rdfa-editor/_c-selection-tooltip.scss
+++ b/app/styles/ember-rdfa-editor/_c-selection-tooltip.scss
@@ -1,0 +1,8 @@
+$say-selection-tooltip-background: var(--au-gray-200) !default;
+
+.say-editor-selection-tooltip {
+  background: $say-selection-tooltip-background;
+  border: 0.1rem solid var(--au-gray-300);
+  border-radius: 0.5rem;
+  padding: $au-unit-tiny;
+}

--- a/app/styles/ember-rdfa-editor/_c-selection-tooltip.scss
+++ b/app/styles/ember-rdfa-editor/_c-selection-tooltip.scss
@@ -4,5 +4,4 @@ $say-selection-tooltip-background: var(--au-gray-200) !default;
   background: $say-selection-tooltip-background;
   border: 0.1rem solid var(--au-gray-300);
   border-radius: 0.5rem;
-  padding: $au-unit-tiny;
 }

--- a/app/styles/ember-rdfa-editor/_c-table.scss
+++ b/app/styles/ember-rdfa-editor/_c-table.scss
@@ -83,8 +83,12 @@ table.ProseMirror-selectednode,
 }
 
 .say-table-tooltip {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  display: flex;
+  flex-direction: column;
+}
+.say-table-tooltip--actions {
+  display: flex;
+  flex-direction: row;
   button {
     outline: none;
     border: 0;

--- a/app/styles/ember-rdfa-editor/_c-table.scss
+++ b/app/styles/ember-rdfa-editor/_c-table.scss
@@ -65,7 +65,6 @@
   }
 }
 
-
 .tableWrapper {
   overflow-y: hidden;
 }
@@ -81,4 +80,19 @@ table.ProseMirror-selectednode,
 // Class that columnResizing plugin adds
 .resize-cursor {
   cursor: col-resize;
+}
+
+.say-table-tooltip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  button {
+    outline: none;
+    border: 0;
+    color: var(--au-gray-600);
+    padding: $au-unit-small;
+    &:hover,
+    &:focus {
+      color: var(--au-gray-700);
+    }
+  }
 }

--- a/app/styles/ember-rdfa-editor/_c-table.scss
+++ b/app/styles/ember-rdfa-editor/_c-table.scss
@@ -58,7 +58,6 @@
     top: 0;
     bottom: 0;
     width: 4px;
-    z-index: 20;
     background-color: #adf;
     pointer-events: none;
     margin-top: 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.5",
         "@embroider/macros": "^1.13.1",
+        "@floating-ui/dom": "^1.6.3",
         "@glimmer/tracking": "^1.1.2",
         "@graphy/memory.dataset.fast": "4.3.3",
         "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",
@@ -3108,11 +3109,11 @@
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.4.tgz",
-      "integrity": "sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
       "dependencies": {
-        "@floating-ui/core": "^1.5.3",
+        "@floating-ui/core": "^1.0.0",
         "@floating-ui/utils": "^0.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.5",
     "@embroider/macros": "^1.13.1",
+    "@floating-ui/dom": "^1.6.3",
     "@glimmer/tracking": "^1.1.2",
     "@graphy/memory.dataset.fast": "4.3.3",
     "@guardian/prosemirror-invisibles": "git+https://git@github.com/lblod/prosemirror-invisibles",

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,6 +1,6 @@
 <DummyContainer>
   <:header>
-    <DebugTools @controller={{this.rdfaEditor}}/>
+    <DebugTools @controller={{this.rdfaEditor}} />
   </:header>
   <:content>
     <EditorContainer
@@ -21,7 +21,11 @@
           @plugins={{this.plugins}}
           @schema={{this.schema}}
           @nodeViews={{this.nodeViews}}
-          @rdfaEditorInit={{this.rdfaEditorInit}}/>
+          @rdfaEditorInit={{this.rdfaEditorInit}}
+        />
+        {{#if this.rdfaEditor}}
+          <Plugins::Table::TableTooltip @controller={{this.rdfaEditor}} />
+        {{/if}}
       </:default>
       <:aside>
         <Sidebar>


### PR DESCRIPTION
### Overview
This PR includes several changes leading into the implementation of a `table-tooltip` component. This component allows users quick access to table-editing features.
Specifically, this PR includes the following changes/features:
- Addition of the `floating-ui` package and implementation of a custom (for now private) `floating-ui` modifier. Compared to the modifier provided by the `ember-velcro` package, it includes the following features:
   * Support for virtual elements (https://floating-ui.com/docs/virtual-elements)
   * Support for transform positioning (similar to the `vue` and `react` implementations of `floating-ui`: https://floating-ui.com/docs/usefloating#transform). By default the modifier uses `transform` positioning, but this can be disabled.
   * Support for fully customizable middleware-pipelines
- Addition of a (private) `selection-tooltip` component. This is a simple tooltip which displays under the current editor selection. It does so by leveraging the `floating-ui` modifier in combination with usage of virtual elements. A virtual element is used here, as the editor selection does not (always) correspond to a specific element, but rather to a position/series of positions. https://floating-ui.com/docs/virtual-elements contains more information on how to use virtual elements
- Addition of a (public) `table-tooltip` component. A simple tooltip which displays only when inside a table. It provides several table-actions including:
  * Add row after
  * Add row before
  * Add column after
  * Add column before
  * Delete row
  * Delete column
  * Delete table
  This tooltip is implemented to be as non-intrusive as possible: it only displays when clicking; and disappears when typing.

##### connected issues and PRs:
[GN-4723](https://binnenland.atlassian.net/browse/GN-4723?atlOrigin=eyJpIjoiMmVjNzhmNTc2ZDZhNGI2M2FkNGZmNWVkZDU2MjM1NDgiLCJwIjoiaiJ9)


### How to test/reproduce
- Open the dummy app on the `home` page
- Insert a table with some content inside
- Clicking inside any cell, the table-tooltip should appear
- The different actions provided by the table-tooltip should work
- When scrolling the viewport, the tooltip should correctly move along with the selection
- The tooltip should correctly disappear when the selection is out-of-view. (This is why the `contextElement` of the virtual-element is needed)
- When starting to type in the cell, the tooltip should disappear
- Observe that the tooltip element uses `transform` based positioning and the `position: fixed` approach.

### Challenges/uncertainties
- I did not opt into using the `ember-velcro` package for the implementation of this tooltip as it is missing several needed features. We might be able to upstream some features (such as virtual-element support and transform-based position) in the future.

### TODOs/Future work
- [x] Add `toggle header row` and `toggle header column` actions to tooltip
- [x] (Optional) Look into using a grid layout for the table-tooltip
- [ ] Look into supporting the `arrow` middleware (https://floating-ui.com/docs/arrow) (not crucial for this PR)
- [ ] Look into supporting a 'headless' version of the `floating-ui` modifier, in which the user itself has more control over how the styling is set/computed. (see the https://floating-ui.com/docs/vue and https://floating-ui.com/docs/react packages) (not crucial for this PR)
- [ ] Replace usages of `ember-velcro` with our custom `floating-ui` modifier (not crucial for this PR)
- [ ] Apply `size` modifier to dropdown components => allows for displaying a scrollbar when viewport is too short.


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
