### PR TITLE
GN-4719: extend html insertion capabilities

### DIFF
--- a/.changeset/fuzzy-seals-remain.md
+++ b/.changeset/fuzzy-seals-remain.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Add option to provide `EditorRange` object to `setHtmlContent` method in order to only replace a part of the document

--- a/.changeset/lucky-glasses-obey.md
+++ b/.changeset/lucky-glasses-obey.md
@@ -1,0 +1,10 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Add `domParser` getter to `SayController` class.
+
+The `domParser` getter provides access to an instance of the `ProseMirror` parser.
+This parser allows you to parse html nodes into prosemirror nodes/fragments.
+
+To get more information on the `DomParser` class, visit https://prosemirror.net/docs/ref/#model.DOMParser

--- a/addon/core/say-controller.ts
+++ b/addon/core/say-controller.ts
@@ -5,7 +5,7 @@ import { shallowEqual } from '@lblod/ember-rdfa-editor/utils/_private/object-uti
 import { datastoreKey } from '@lblod/ember-rdfa-editor/plugins/datastore';
 import { selectionHasMarkEverywhere } from '@lblod/ember-rdfa-editor/utils/_private/mark-utils';
 import SayView, {
-  type EditorRange,
+  type DocumentRange,
 } from '@lblod/ember-rdfa-editor/core/say-view';
 import SayEditor from '@lblod/ember-rdfa-editor/core/say-editor';
 import { tracked } from '@glimmer/tracking';
@@ -103,7 +103,7 @@ export default class SayController {
    */
   setHtmlContent(
     content: string,
-    options: { shouldFocus?: boolean; range?: EditorRange } = {},
+    options: { shouldFocus?: boolean; range?: DocumentRange } = {},
   ) {
     this.mainEditorView.setHtmlContent(content, options);
   }

--- a/addon/core/say-controller.ts
+++ b/addon/core/say-controller.ts
@@ -4,7 +4,9 @@ import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import { shallowEqual } from '@lblod/ember-rdfa-editor/utils/_private/object-utils';
 import { datastoreKey } from '@lblod/ember-rdfa-editor/plugins/datastore';
 import { selectionHasMarkEverywhere } from '@lblod/ember-rdfa-editor/utils/_private/mark-utils';
-import SayView from '@lblod/ember-rdfa-editor/core/say-view';
+import SayView, {
+  type EditorRange,
+} from '@lblod/ember-rdfa-editor/core/say-view';
 import SayEditor from '@lblod/ember-rdfa-editor/core/say-editor';
 import { tracked } from '@glimmer/tracking';
 import { type Attrs, MarkType, Schema } from 'prosemirror-model';
@@ -99,7 +101,10 @@ export default class SayController {
    * Note: it does not create a new `doc` node and does not update the `doc` node based on the provided html
    * (e.g. `lang` attributes on the `doc` node are not parsed)
    */
-  setHtmlContent(content: string, options: { shouldFocus?: boolean } = {}) {
+  setHtmlContent(
+    content: string,
+    options: { shouldFocus?: boolean; range?: EditorRange } = {},
+  ) {
     this.mainEditorView.setHtmlContent(content, options);
   }
 

--- a/addon/core/say-controller.ts
+++ b/addon/core/say-controller.ts
@@ -59,6 +59,10 @@ export default class SayController {
     return !!this.activeEditorView.parent;
   }
 
+  get domParser() {
+    return this.mainEditorView.domParser;
+  }
+
   clone() {
     return new SayController(this.editor);
   }

--- a/addon/core/say-view.ts
+++ b/addon/core/say-view.ts
@@ -13,7 +13,7 @@ export default class SayView extends EditorView {
   isSayView = true;
   @tracked declare state: EditorState;
   @tracked parent?: SayView;
-  domParser?: ProseParser;
+  domParser: ProseParser;
 
   constructor(
     place:
@@ -27,7 +27,8 @@ export default class SayView extends EditorView {
     parent?: SayView,
   ) {
     super(place, props);
-    this.domParser = props.domParser;
+    this.domParser =
+      props.domParser ?? ProseParser.fromSchema(this.state.schema);
     this.parent = parent;
   }
 
@@ -40,8 +41,6 @@ export default class SayView extends EditorView {
     content: string,
     options: { shouldFocus?: boolean; range?: DocumentRange } = {},
   ) {
-    const parser =
-      this.props.domParser ?? ProseParser.fromSchema(this.state.schema);
     const { shouldFocus = true } = options;
     if (shouldFocus) {
       this.focus();
@@ -50,14 +49,14 @@ export default class SayView extends EditorView {
     const tr = this.state.tr;
     if (range) {
       const fragment = htmlToFragment(content, {
-        parser: parser,
+        parser: this.domParser,
         editorView: this,
       });
       tr.replaceRange(range.from, range.to, fragment);
     } else {
       const doc = htmlToDoc(content, {
         schema: this.state.schema,
-        parser: parser,
+        parser: this.domParser,
         editorView: this,
       });
       tr.step(new SetDocAttributesStep(doc.attrs));

--- a/addon/core/say-view.ts
+++ b/addon/core/say-view.ts
@@ -5,7 +5,7 @@ import { htmlToDoc, htmlToFragment } from '../utils/_private/html-utils';
 import { DOMSerializer, ProseParser } from '..';
 import { SetDocAttributesStep } from '../utils/steps';
 
-export type EditorRange = {
+export type DocumentRange = {
   from: number;
   to: number;
 };
@@ -38,7 +38,7 @@ export default class SayView extends EditorView {
    */
   setHtmlContent(
     content: string,
-    options: { shouldFocus?: boolean; range?: EditorRange } = {},
+    options: { shouldFocus?: boolean; range?: DocumentRange } = {},
   ) {
     const parser =
       this.props.domParser ?? ProseParser.fromSchema(this.state.schema);

--- a/addon/utils/_private/html-utils.ts
+++ b/addon/utils/_private/html-utils.ts
@@ -29,6 +29,19 @@ export function htmlToDoc(
   return doc;
 }
 
+export function htmlToFragment(
+  html: string,
+  options: { parser: ProseParser; editorView: EditorView },
+) {
+  const { parser, editorView } = options;
+  const htmlCleaner = new HTMLInputParser({ editorView: editorView });
+  const cleanedHTML = htmlCleaner.prepareHTML(html);
+  const domParser = new DOMParser();
+  const parsed = domParser.parseFromString(cleanedHTML, 'text/html').body;
+  preprocessRDFa(parsed);
+  return parser.parseSlice(parsed, { preserveWhitespace: true });
+}
+
 function matchTopNode(
   node: HTMLElement,
   options: { schema: Schema },

--- a/tests/unit/prosemirror/view-test.ts
+++ b/tests/unit/prosemirror/view-test.ts
@@ -1,0 +1,100 @@
+import { module, test } from 'qunit';
+import TEST_SCHEMA from 'dummy/tests/test-utils';
+import { EditorState, SayView } from '@lblod/ember-rdfa-editor';
+import { oneLineTrim } from 'common-tags';
+
+module('ProseMirror | view', function () {
+  test('setHtmlContent without a supplied range should replace the whole content of the document', function (assert) {
+    const schema = TEST_SCHEMA;
+
+    const view = new SayView(null, {
+      state: EditorState.create({ schema }),
+    });
+    const htmlToInsert = oneLineTrim`
+    <div lang="en-US" data-say-document="true">
+      <div style="display: none" data-rdfa-container="true"></div>
+      <div data-content-container="true">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+           Fusce euismod mauris in lacus mollis, eu laoreet risus sollicitudin.
+           Donec tincidunt dolor quis dignissim tincidunt.
+        </p>
+        <p>
+           Suspendisse molestie ipsum odio, ac dignissim odio vestibulum ut.
+           Ut facilisis purus et blandit posuere.
+           Mauris vitae neque bibendum, rutrum leo ac, euismod magna.
+        </p>
+        <p>
+           Maecenas non eros et sem sodales ultricies.
+           Cras a tortor nec ante accumsan imperdiet ut eu nisi.
+           Morbi placerat leo vitae quam tincidunt venenatis.
+           Pellentesque neque magna, dignissim vitae faucibus eu, dignissim vitae urna.
+           Aenean dolor ipsum, rutrum at gravida sit amet, fringilla et erat.
+        </p>
+      </div>
+    </div>
+    `;
+    view.setHtmlContent(htmlToInsert);
+    assert.strictEqual(view.htmlContent, htmlToInsert);
+  });
+  test('setHtmlContent should be able to replace a specific range when specified', function (assert) {
+    const schema = TEST_SCHEMA;
+
+    const view = new SayView(null, {
+      state: EditorState.create({ schema }),
+    });
+    const htmlToInsert = oneLineTrim`
+    <div lang="en-US" data-say-document="true">
+      <div style="display: none" data-rdfa-container="true"></div>
+      <div data-content-container="true">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+           Fusce euismod mauris in lacus mollis, eu laoreet risus sollicitudin.
+           Donec tincidunt dolor quis dignissim tincidunt.
+        </p>
+        <p>
+           Suspendisse molestie ipsum odio, ac dignissim odio vestibulum ut.
+           Ut facilisis purus et blandit posuere.
+           Mauris vitae neque bibendum, rutrum leo ac, euismod magna.
+        </p>
+        <p>
+           Maecenas non eros et sem sodales ultricies.
+           Cras a tortor nec ante accumsan imperdiet ut eu nisi.
+           Morbi placerat leo vitae quam tincidunt venenatis.
+           Pellentesque neque magna, dignissim vitae faucibus eu, dignissim vitae urna.
+           Aenean dolor ipsum, rutrum at gravida sit amet, fringilla et erat.
+        </p>
+      </div>
+    </div>
+    `;
+    const expectedHtml = oneLineTrim`
+    <div lang="en-US" data-say-document="true">
+      <div style="display: none" data-rdfa-container="true"></div>
+      <div data-content-container="true">
+        <p>Lorem ips<strong>um dolor s</strong>
+        </p>
+        <p>new paragraph it amet, consectetur adipiscing elit.
+           Fusce euismod mauris in lacus mollis, eu laoreet risus sollicitudin.
+           Donec tincidunt dolor quis dignissim tincidunt.
+        </p>
+        <p>
+           Suspendisse molestie ipsum odio, ac dignissim odio vestibulum ut.
+           Ut facilisis purus et blandit posuere.
+           Mauris vitae neque bibendum, rutrum leo ac, euismod magna.
+        </p>
+        <p>
+           Maecenas non eros et sem sodales ultricies.
+           Cras a tortor nec ante accumsan imperdiet ut eu nisi.
+           Morbi placerat leo vitae quam tincidunt venenatis.
+           Pellentesque neque magna, dignissim vitae faucibus eu, dignissim vitae urna.
+           Aenean dolor ipsum, rutrum at gravida sit amet, fringilla et erat.
+        </p>
+      </div>
+    </div>
+    `;
+    view.setHtmlContent(htmlToInsert);
+
+    view.setHtmlContent('<strong>um dolor s</strong><p>new paragraph </p>', {
+      range: { from: 10, to: 20 },
+    });
+    assert.strictEqual(view.htmlContent, expectedHtml);
+  });
+});


### PR DESCRIPTION
### Overview
This PR extends the functionality of the `setHtmlContent` method found on `SayView` and `SayController` objects. It allows users of the method to provide an range which should be replaced by the provided html string.
- If no range is passed: the whole document is replaced, include the `doc` node
- If a range is passed, only a specific part of the document is replaced.
Two simple tests have been added to test the functionality of `setHtmlContent`.

This PR also exposes an instance of the [DOMParser](https://prosemirror.net/docs/ref/#model.DOMParser) class through the `SayController` `domParser` getter.

Additionally, this PR also adds a `htmlToFragment` utility function.

##### connected issues and PRs:
[GN-4719](https://binnenland.atlassian.net/browse/GN-4719?atlOrigin=eyJpIjoiODlkMzk2MDAyNWYzNGNhN2E0ODcxMTc2NWNkZGRlMmMiLCJwIjoiaiJ9)

### How to test/reproduce
This PR does not really include a user-facing change. Two tests have been added to check the functionality of  `setHtmlContent`.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
