### PR TITLE
Improved RDFa backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ export default class EditorComponent extends Component {
         block_rdfa: block_rdfa(),
       },
       marks: {
-        inline_rdfa,
+        inline_rdfa: inline_rdfa(),
         em,
         strikethrough,
         strong,

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ export default class EditorComponent extends Component {
           cellContent: 'block+',
           inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
         }),
-        heading,
+        heading: heading(),
         blockquote,
         horizontal_rule,
         code_block,

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ export default class EditorComponent extends Component {
     // A prosemirror schema which determines how documents are parsed and written to the DOM.
     return new Schema({
       nodes: {
-        doc: docWithConfig({
+        doc: doc({
           defaultLanguage: 'nl-BE',
         }),
         paragraph,
@@ -102,7 +102,7 @@ export default class EditorComponent extends Component {
         code_block,
         text,
         hard_break,
-        block_rdfa,
+        block_rdfa: block_rdfa(),
       },
       marks: {
         inline_rdfa,

--- a/addon/commands/select-block-rdfa.ts
+++ b/addon/commands/select-block-rdfa.ts
@@ -1,8 +1,6 @@
 import { type Command, TextSelection } from 'prosemirror-state';
 import { selectNodeBackward } from 'prosemirror-commands';
 
-import { block_rdfa } from '../nodes';
-
 export const selectBlockRdfaNode: Command = (state, dispatch, view) => {
   if (!(state.selection instanceof TextSelection)) {
     return false;
@@ -20,7 +18,7 @@ export const selectBlockRdfaNode: Command = (state, dispatch, view) => {
         state.doc.resolve($cursor.before($cursor.depth)).nodeBefore
       : $cursor.nodeBefore;
 
-  const isBlockRdfaNode = nodeBefore && nodeBefore.type.spec === block_rdfa;
+  const isBlockRdfaNode = nodeBefore && nodeBefore.type.name === 'block_rdfa';
 
   if (isBlockRdfaNode) {
     return selectNodeBackward(state, dispatch, view);

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Mark, type Attrs, type DOMOutputSpec } from 'prosemirror-model';
 import { PNode } from '@lblod/ember-rdfa-editor/index';
-import { unwrap } from '../utils/_private/option';
+import { isSome, unwrap } from '../utils/_private/option';
 import type {
   ContentTriple,
   IncomingLiteralNodeTriple,
@@ -11,6 +11,44 @@ import type {
 import { isElement } from '@lblod/ember-rdfa-editor/utils/_private/dom-helpers';
 
 // const logger = createLogger('core/schema');
+
+export const classicRdfaAttrSpec = {
+  vocab: { default: undefined },
+  typeof: { default: undefined },
+  prefix: { default: undefined },
+  property: { default: undefined },
+  rel: { default: undefined },
+  rev: { default: undefined },
+  href: { default: undefined },
+  about: { default: undefined },
+  resource: { default: undefined },
+  content: { default: undefined },
+  datatype: { default: undefined },
+  lang: { default: undefined },
+  xmlns: { default: undefined },
+  src: { default: undefined },
+  role: { default: undefined },
+  inlist: { default: undefined },
+  datetime: { default: undefined },
+};
+
+export function getClassicRdfaAttrs(
+  node: Element,
+): Record<string, string> | false {
+  const attrs: Record<string, string> = {};
+  let hasAnyRdfaAttributes = false;
+  for (const key of Object.keys(classicRdfaAttrSpec)) {
+    const value = node.attributes.getNamedItem(key)?.value;
+    if (isSome(value)) {
+      attrs[key] = value;
+      hasAnyRdfaAttributes = true;
+    }
+  }
+  if (hasAnyRdfaAttributes) {
+    return attrs;
+  }
+  return false;
+}
 
 export const rdfaAttrSpec = {
   properties: { default: [] },

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import type { Attrs, DOMOutputSpec, Mark } from 'prosemirror-model';
+import { Mark, type Attrs, type DOMOutputSpec } from 'prosemirror-model';
 import { PNode } from '@lblod/ember-rdfa-editor/index';
 import { unwrap } from '../utils/_private/option';
 import type {
@@ -233,13 +233,20 @@ export type RdfaRenderArgs = {
   contentContainerAttrs?: Record<string, unknown>;
 } & ({ content: DOMOutputSpec | 0 } | { contentArray: unknown[] });
 
+function determineChildTag(renderable: Mark | PNode) {
+  if (renderable instanceof Mark) {
+    return 'span';
+  } else {
+    return renderable.inlineContent || renderable.isInline ? 'span' : 'div';
+  }
+}
 export function renderRdfaAware({
   renderable,
   tag,
   attrs = {},
-  rdfaContainerTag = tag,
+  rdfaContainerTag = determineChildTag(renderable),
   rdfaContainerAttrs,
-  contentContainerTag = tag,
+  contentContainerTag = determineChildTag(renderable),
   contentContainerAttrs = {},
   ...rest
 }: RdfaRenderArgs): DOMOutputSpec {

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -94,6 +94,7 @@ export function isRdfaAttrs(attrs: Attrs): attrs is RdfaAttrs {
 export const sharedRdfaNodeSpec = {
   isolating: true,
   selectable: true,
+  editable: true,
 };
 
 export function getRdfaAttrs(node: HTMLElement): RdfaAttrs | false {

--- a/addon/nodes/block-rdfa.ts
+++ b/addon/nodes/block-rdfa.ts
@@ -1,48 +1,65 @@
 import { Node as PNode } from 'prosemirror-model';
 import {
+  classicRdfaAttrSpec,
+  getClassicRdfaAttrs,
   getRdfaAttrs,
   getRdfaContentElement,
   rdfaAttrSpec,
   renderRdfaAware,
-  sharedRdfaNodeSpec,
 } from '@lblod/ember-rdfa-editor/core/schema';
 import type SayNodeSpec from '../core/say-node-spec';
 
-export const block_rdfa: SayNodeSpec = {
-  content: 'block+',
-  editable: true,
-  group: 'block',
-  attrs: {
-    ...rdfaAttrSpec,
-  },
-  defining: true,
-  ...sharedRdfaNodeSpec,
-  parseDOM: [
-    {
-      tag: `p, div, address, article, aside, blockquote, details, dialog, dd, dt, fieldset, figcaption, figure, footer, form, header, hgroup, hr, main, nav, pre, section`,
-      // Default priority is 50, so this means a more specific definition matches before this one
-      priority: 40,
-      getAttrs(node: string | HTMLElement) {
-        if (typeof node === 'string') {
-          return false;
-        }
-        const attrs = getRdfaAttrs(node);
-        if (attrs) {
-          return attrs;
-        }
-        return false;
-      },
-      contentElement: getRdfaContentElement,
+type Config = {
+  rdfaAware?: boolean;
+};
+
+export const block_rdfa: (config?: Config) => SayNodeSpec = ({
+  rdfaAware = false,
+} = {}) => {
+  return {
+    content: 'block+',
+    group: 'block',
+    get attrs() {
+      if (rdfaAware) {
+        return rdfaAttrSpec;
+      } else {
+        return classicRdfaAttrSpec;
+      }
     },
-  ],
-  toDOM(node: PNode) {
-    return renderRdfaAware({
-      renderable: node,
-      tag: 'div',
-      attrs: {
-        class: 'say-editable',
+    defining: true,
+    parseDOM: [
+      {
+        tag: `p, div, address, article, aside, blockquote, details, dialog, dd, dt, fieldset, figcaption, figure, footer, form, header, hgroup, hr, main, nav, pre, section`,
+        // Default priority is 50, so this means a more specific definition matches before this one
+        priority: 40,
+        getAttrs(node: string | HTMLElement) {
+          if (typeof node === 'string') {
+            return false;
+          }
+          const attrs = rdfaAware
+            ? getRdfaAttrs(node)
+            : getClassicRdfaAttrs(node);
+          if (attrs) {
+            return attrs;
+          }
+          return false;
+        },
+        contentElement: getRdfaContentElement,
       },
-      content: 0,
-    });
-  },
+    ],
+    toDOM(node: PNode) {
+      if (rdfaAware) {
+        return renderRdfaAware({
+          renderable: node,
+          tag: 'div',
+          attrs: {
+            class: 'say-editable',
+          },
+          content: 0,
+        });
+      } else {
+        return ['div', node.attrs, 0];
+      }
+    },
+  };
 };

--- a/addon/nodes/doc.ts
+++ b/addon/nodes/doc.ts
@@ -33,7 +33,6 @@ export const doc = ({
         return baseAttrs;
       }
     },
-    editable: true,
     parseDOM: [
       {
         tag: 'div',

--- a/addon/nodes/index.ts
+++ b/addon/nodes/index.ts
@@ -1,5 +1,5 @@
 export { block_rdfa } from './block-rdfa';
-export { doc, docWithConfig } from './doc';
+export { doc } from './doc';
 export { hard_break } from './hard-break';
 export { horizontal_rule } from './horizontal-rule';
 export { invisible_rdfa } from './invisible-rdfa';

--- a/addon/nodes/inline-rdfa.ts
+++ b/addon/nodes/inline-rdfa.ts
@@ -1,5 +1,7 @@
 import { Node as PNode } from 'prosemirror-model';
 import {
+  classicRdfaAttrSpec,
+  getClassicRdfaAttrs,
   getRdfaAttrs,
   getRdfaContentElement,
   rdfaAttrSpec,
@@ -13,49 +15,66 @@ import {
 import InlineRdfaComponent from '../components/ember-node/inline-rdfa';
 import type { ComponentLike } from '@glint/template';
 
-const parseDOM = [
-  {
-    tag: 'span',
-    // default prio is 50, highest prio comes first, and this parserule should at least come after all other nodes
-    priority: 10,
-    getAttrs(node: string | HTMLElement) {
-      if (typeof node === 'string') {
-        return false;
-      }
-      const attrs = getRdfaAttrs(node);
-      if (attrs) {
-        return attrs;
-      }
-      return false;
-    },
-    contentElement: getRdfaContentElement,
-  },
-];
-const toDOM = (node: PNode) => {
-  return renderRdfaAware({
-    renderable: node,
-    tag: 'span',
-    attrs: { class: 'say-inline-rdfa', ...node.attrs },
-    content: 0,
-  });
+type Options = {
+  rdfaAware?: boolean;
 };
 
-const emberNodeConfig: EmberNodeConfig = {
-  name: 'inline-rdfa',
-  inline: true,
-  component: InlineRdfaComponent as unknown as ComponentLike,
-  group: 'inline',
-  content: 'inline*',
-  atom: true,
-  editable: true,
-  draggable: false,
-  selectable: true,
-  // isolating: true,
-  toDOM,
-  parseDOM,
-  attrs: {
-    ...rdfaAttrSpec,
-  },
+const emberNodeConfig: (options?: Options) => EmberNodeConfig = ({
+  rdfaAware = false,
+} = {}) => {
+  return {
+    name: 'inline-rdfa',
+    inline: true,
+    component: InlineRdfaComponent as unknown as ComponentLike,
+    group: 'inline',
+    content: 'inline*',
+    atom: true,
+    draggable: false,
+    selectable: true,
+    toDOM(node: PNode) {
+      if (rdfaAware) {
+        return renderRdfaAware({
+          renderable: node,
+          tag: 'span',
+          attrs: { class: 'say-inline-rdfa' },
+          content: 0,
+        });
+      } else {
+        return ['span', { ...node.attrs, class: 'say-inline-rdfa' }, 0];
+      }
+    },
+    parseDOM: [
+      {
+        tag: 'span',
+        // default prio is 50, highest prio comes first, and this parserule should at least come after all other nodes
+        priority: 10,
+        getAttrs(node: string | HTMLElement) {
+          if (typeof node === 'string') {
+            return false;
+          }
+          const attrs = rdfaAware
+            ? getRdfaAttrs(node)
+            : getClassicRdfaAttrs(node);
+          if (attrs) {
+            return attrs;
+          }
+          return false;
+        },
+        contentElement: getRdfaContentElement,
+      },
+    ],
+    get attrs() {
+      if (rdfaAware) {
+        return rdfaAttrSpec;
+      } else {
+        return classicRdfaAttrSpec;
+      }
+    },
+  };
 };
-export const inline_rdfa = createEmberNodeSpec(emberNodeConfig);
-export const inlineRdfaView = createEmberNodeView(emberNodeConfig);
+
+export const inline_rdfa = (options?: Options) =>
+  createEmberNodeSpec(emberNodeConfig(options));
+
+export const inlineRdfaView = (options?: Options) =>
+  createEmberNodeView(emberNodeConfig(options));

--- a/addon/nodes/invisible-rdfa.ts
+++ b/addon/nodes/invisible-rdfa.ts
@@ -1,43 +1,73 @@
-import {
-  getRdfaAttrs,
-  type NodeSpec,
-  PNode,
-  rdfaAttrSpec,
-} from '@lblod/ember-rdfa-editor';
+import { getRdfaAttrs, PNode, rdfaAttrSpec } from '@lblod/ember-rdfa-editor';
 import { tagName } from '@lblod/ember-rdfa-editor/utils/_private/dom-helpers';
+import type SayNodeSpec from '../core/say-node-spec';
+import {
+  classicRdfaAttrSpec,
+  type RdfaAttrs,
+  renderInvisibleRdfa,
+  renderRdfaAttrs,
+  getClassicRdfaAttrs,
+} from '../core/schema';
 
-export const invisible_rdfa: NodeSpec = {
-  inline: true,
-  group: 'inline',
-  atom: true,
-  defining: true,
-  isolating: true,
-  attrs: {
-    ...rdfaAttrSpec,
-    __tag: { default: 'span' },
-  },
-  parseDOM: [
-    {
-      tag: 'span, link',
-      getAttrs(node: string | HTMLElement) {
-        if (typeof node === 'string') {
-          return false;
-        }
-        if (!node.hasChildNodes()) {
-          const attrs = getRdfaAttrs(node);
-          if (attrs) {
-            return {
-              ...attrs,
-              __tag: tagName(node),
-            };
-          }
-        }
-        return false;
-      },
+type Options = {
+  rdfaAware?: boolean;
+};
+
+export const invisible_rdfa: (options?: Options) => SayNodeSpec = ({
+  rdfaAware = false,
+} = {}) => {
+  return {
+    inline: true,
+    group: 'inline',
+    atom: true,
+    defining: true,
+    isolating: true,
+    get attrs() {
+      if (rdfaAware) {
+        return {
+          ...rdfaAttrSpec,
+          __tag: { default: 'span' },
+        };
+      } else {
+        return {
+          ...classicRdfaAttrSpec,
+          __tag: { default: 'span' },
+        };
+      }
     },
-  ],
-  toDOM(node: PNode) {
-    const { __tag, ...attrs } = node.attrs;
-    return [__tag, attrs];
-  },
+    parseDOM: [
+      {
+        tag: 'span, link',
+        getAttrs(node: string | HTMLElement) {
+          if (typeof node === 'string') {
+            return false;
+          }
+          if (!node.hasChildNodes()) {
+            const attrs = rdfaAware
+              ? getRdfaAttrs(node)
+              : getClassicRdfaAttrs(node);
+            if (attrs) {
+              return {
+                ...attrs,
+                __tag: tagName(node),
+              };
+            }
+          }
+          return false;
+        },
+      },
+    ],
+    toDOM(node: PNode) {
+      const { __tag, ...attrs } = node.attrs;
+      if (rdfaAware) {
+        return [
+          __tag,
+          renderRdfaAttrs(attrs as RdfaAttrs),
+          renderInvisibleRdfa(node, 'span'),
+        ];
+      } else {
+        return [__tag, attrs];
+      }
+    },
+  };
 };

--- a/addon/nodes/repaired-block.ts
+++ b/addon/nodes/repaired-block.ts
@@ -1,29 +1,59 @@
-import type { DOMOutputSpec, Node as PNode, NodeSpec } from 'prosemirror-model';
+import type { DOMOutputSpec, Node as PNode } from 'prosemirror-model';
 import { getRdfaAttrs, rdfaAttrSpec } from '@lblod/ember-rdfa-editor';
+import type SayNodeSpec from '../core/say-node-spec';
+import {
+  classicRdfaAttrSpec,
+  getClassicRdfaAttrs,
+  getRdfaContentElement,
+  renderRdfaAware,
+} from '../core/schema';
 
-export const repaired_block: NodeSpec = {
-  inline: true,
-  content: 'inline*',
-  group: 'inline',
-  attrs: { ...rdfaAttrSpec },
-  // defining: true,
-  parseDOM: [
-    {
-      tag: 'p, div, h1, h2, h3, h4, h5, h6, address, article, aside, blockquote, details, dialog, dd, dt, fieldset, figcaption, figure, footer, form, header, hgroup, hr, main, nav, pre, section',
-      getAttrs(node: string | HTMLElement) {
-        if (typeof node === 'string') {
-          return false;
-        }
-        const myAttrs = getRdfaAttrs(node);
-        if (myAttrs) {
-          return myAttrs;
-        }
-        return null;
-      },
-      context: 'inline/',
+type Options = {
+  rdfaAware?: boolean;
+};
+
+export const repaired_block: (options?: Options) => SayNodeSpec = ({
+  rdfaAware = false,
+} = {}) => {
+  return {
+    inline: true,
+    content: 'inline*',
+    group: 'inline',
+    get attrs() {
+      if (rdfaAware) {
+        return rdfaAttrSpec;
+      } else {
+        return classicRdfaAttrSpec;
+      }
     },
-  ],
-  toDOM(node: PNode): DOMOutputSpec {
-    return ['span', { ...node.attrs }, 0];
-  },
+    // defining: true,
+    parseDOM: [
+      {
+        tag: 'p, div, h1, h2, h3, h4, h5, h6, address, article, aside, blockquote, details, dialog, dd, dt, fieldset, figcaption, figure, footer, form, header, hgroup, hr, main, nav, pre, section',
+        getAttrs(node: string | HTMLElement) {
+          if (typeof node === 'string') {
+            return false;
+          }
+          if (rdfaAware) {
+            return {
+              ...getRdfaAttrs(node),
+            };
+          } else {
+            return {
+              ...getClassicRdfaAttrs(node),
+            };
+          }
+        },
+        contentElement: getRdfaContentElement,
+        context: 'inline/',
+      },
+    ],
+    toDOM(node: PNode): DOMOutputSpec {
+      if (rdfaAware) {
+        return renderRdfaAware({ renderable: node, tag: 'span', content: 0 });
+      } else {
+        return ['span', { ...node.attrs }, 0];
+      }
+    },
+  };
 };

--- a/addon/plugins/heading/nodes/heading.ts
+++ b/addon/plugins/heading/nodes/heading.ts
@@ -1,8 +1,10 @@
 import { Node as PNode } from 'prosemirror-model';
 import {
+  classicRdfaAttrSpec,
+  getClassicRdfaAttrs,
   getRdfaAttrs,
+  getRdfaContentElement,
   renderRdfaAware,
-  sharedRdfaNodeSpec,
 } from '@lblod/ember-rdfa-editor/core/schema';
 import { rdfaAttrSpec } from '@lblod/ember-rdfa-editor';
 import { optionMapOr } from '@lblod/ember-rdfa-editor/utils/_private/option';
@@ -10,139 +12,93 @@ import type SayNodeSpec from '@lblod/ember-rdfa-editor/core/say-node-spec';
 import NumberEditor from '@lblod/ember-rdfa-editor/components/_private/number-editor';
 import type { ComponentLike } from '@glint/template';
 import { DEFAULT_ALIGNMENT, getAlignment } from '../../alignment';
+import { HEADING_ELEMENTS } from '@lblod/ember-rdfa-editor/utils/_private/constants';
+import { getHeadingLevel } from '@lblod/ember-rdfa-editor/utils/_private/html-utils';
 
-export const heading: SayNodeSpec = {
-  attrs: {
-    level: {
-      default: 1,
-      editable: true,
-      editor: NumberEditor as unknown as ComponentLike,
+type Config = {
+  rdfaAware?: boolean;
+};
+
+export const heading: (config?: Config) => SayNodeSpec = ({
+  rdfaAware = false,
+} = {}) => {
+  return {
+    get attrs() {
+      const commonAttrs = {
+        level: {
+          default: 1,
+          editable: true,
+          editor: NumberEditor as unknown as ComponentLike,
+        },
+        indentationLevel: {
+          default: 0,
+          editable: true,
+          editor: NumberEditor as unknown as ComponentLike,
+        },
+        alignment: { default: DEFAULT_ALIGNMENT },
+      };
+      if (rdfaAware) {
+        return { ...commonAttrs, ...rdfaAttrSpec };
+      } else {
+        return { ...commonAttrs, ...classicRdfaAttrSpec };
+      }
     },
-    indentationLevel: {
-      default: 0,
-      editable: true,
-      editor: NumberEditor as unknown as ComponentLike,
-    },
-    alignment: { default: DEFAULT_ALIGNMENT },
-    ...rdfaAttrSpec,
-  },
-  content: 'inline*',
-  group: 'block',
-  editable: true,
-  defining: true,
-  ...sharedRdfaNodeSpec,
-  parseDOM: [
-    {
-      tag: 'h1',
-      getAttrs(node: string | HTMLElement) {
-        if (typeof node === 'string') {
-          return false;
-        }
-        return {
-          level: 1,
-          indentationLevel: optionMapOr(
-            0,
-            parseInt,
-            node.dataset['indentationLevel'],
-          ),
-          ...getRdfaAttrs(node),
-          alignment: getAlignment(node),
-        };
+    content: 'inline*',
+    group: 'block',
+    defining: true,
+    parseDOM: [
+      {
+        tag: HEADING_ELEMENTS.join(','),
+        getAttrs(node: string | HTMLElement) {
+          if (!(node instanceof HTMLHeadingElement)) {
+            return false;
+          }
+          const level = getHeadingLevel(node);
+          const baseAttrs = {
+            level,
+            indentationLevel: optionMapOr(
+              0,
+              parseInt,
+              node.dataset['indentationLevel'],
+            ),
+            alignment: getAlignment(node),
+          };
+          if (rdfaAware) {
+            return { ...baseAttrs, ...getRdfaAttrs(node) };
+          } else {
+            return { ...baseAttrs, ...getClassicRdfaAttrs(node) };
+          }
+        },
+        contentElement: getRdfaContentElement,
       },
-    },
-    {
-      tag: 'h2',
-      getAttrs(node: HTMLElement) {
-        return {
-          level: 2,
-          indentationLevel: optionMapOr(
-            0,
-            parseInt,
-            node.dataset['indentationLevel'],
-          ),
-          ...getRdfaAttrs(node),
-          alignment: getAlignment(node),
-        };
-      },
-    },
-    {
-      tag: 'h3',
-      getAttrs(node: HTMLElement) {
-        return {
-          level: 3,
-          indentationLevel: optionMapOr(
-            0,
-            parseInt,
-            node.dataset['indentationLevel'],
-          ),
-          ...getRdfaAttrs(node),
-          alignment: getAlignment(node),
-        };
-      },
-    },
-    {
-      tag: 'h4',
-      getAttrs(node: HTMLElement) {
-        return {
-          level: 4,
-          indentationLevel: optionMapOr(
-            0,
-            parseInt,
-            node.dataset['indentationLevel'],
-          ),
-          ...getRdfaAttrs(node),
-          alignment: getAlignment(node),
-        };
-      },
-    },
-    {
-      tag: 'h5',
-      getAttrs(node: HTMLElement) {
-        return {
-          level: 5,
-          indentationLevel: optionMapOr(
-            0,
-            parseInt,
-            node.dataset['indentationLevel'],
-          ),
-          ...getRdfaAttrs(node),
-          alignment: getAlignment(node),
-        };
-      },
-    },
-    {
-      tag: 'h6',
-      getAttrs(node: HTMLElement) {
-        return {
-          level: 6,
-          indentationLevel: optionMapOr(
-            0,
-            parseInt,
-            node.dataset['indentationLevel'],
-          ),
-          ...getRdfaAttrs(node),
-          alignment: getAlignment(node),
-        };
-      },
-    },
-  ],
-  toDOM(node: PNode) {
-    const { level, indentationLevel, alignment } = node.attrs;
-    let style = '';
-    if (alignment && alignment !== DEFAULT_ALIGNMENT) {
-      style += `text-align: ${alignment}`;
-    }
-    return renderRdfaAware({
-      tag: `h${(level as number).toString()}`,
-      renderable: node,
-      attrs: {
+    ],
+    toDOM(node: PNode) {
+      const { level, indentationLevel, alignment } = node.attrs;
+      let style = '';
+      if (alignment && alignment !== DEFAULT_ALIGNMENT) {
+        style += `text-align: ${alignment}`;
+      }
+      const baseAttrs = {
         'data-indentation-level': indentationLevel as number,
-        class: 'say-editable',
         style,
-      },
-      rdfaContainerTag: 'span',
-      contentContainerTag: 'span',
-      content: 0,
-    });
-  },
+      };
+      if (rdfaAware) {
+        return renderRdfaAware({
+          tag: `h${(level as number).toString()}`,
+          renderable: node,
+          attrs: {
+            ...baseAttrs,
+            class: 'say-editable',
+          },
+          content: 0,
+        });
+      } else {
+        return [
+          `h${(level as number).toString()}`,
+          { ...baseAttrs, ...node.attrs },
+          0,
+        ];
+      }
+    },
+  };
 };

--- a/addon/plugins/list/nodes/list-nodes.ts
+++ b/addon/plugins/list/nodes/list-nodes.ts
@@ -4,6 +4,7 @@ import {
   rdfaAttrSpec,
   renderRdfaAttrs,
   renderInvisibleRdfa,
+  type RdfaAttrs,
 } from '@lblod/ember-rdfa-editor/core/schema';
 import { optionMapOr } from '@lblod/ember-rdfa-editor/utils/_private/option';
 
@@ -50,7 +51,7 @@ export const ordered_list: NodeSpec = {
     return [
       'ol',
       {
-        ...renderRdfaAttrs(node),
+        ...renderRdfaAttrs(node.attrs as RdfaAttrs),
         ...(order !== 1 && { start: order }),
         ...(style && {
           style: `list-style-type: ${style};`,
@@ -96,7 +97,7 @@ export const list_item: NodeSpec = {
   toDOM(node: PNode) {
     return [
       'li',
-      { ...renderRdfaAttrs(node), ...node.attrs },
+      { ...renderRdfaAttrs(node.attrs as RdfaAttrs), ...node.attrs },
       renderInvisibleRdfa(node, 'div'),
       ['div', {}, 0],
     ];

--- a/addon/plugins/table/nodes/table.ts
+++ b/addon/plugins/table/nodes/table.ts
@@ -183,6 +183,30 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
           contentElement: getRdfaContentElement,
         },
       ],
+      toDOM(node: PNode) {
+        if (rdfaAware) {
+          return [
+            'table',
+            {
+              ...renderRdfaAttrs(node.attrs as RdfaAttrs),
+              class: 'say-table',
+              style: `width: 100%; ${tableStyle || ''}`,
+            },
+            renderInvisibleRdfa(node, 'div'),
+            ['tbody', { 'data-content-container': true }, 0],
+          ];
+        } else {
+          return [
+            'table',
+            {
+              ...node.attrs,
+              class: 'say-table',
+              style: `width: 100%; ${tableStyle || ''}`,
+            },
+            ['tbody', 0],
+          ];
+        }
+      },
       serialize(node: PNode) {
         const tableView = new TableView(node, 25);
         if (rdfaAware) {

--- a/addon/utils/_private/constants.ts
+++ b/addon/utils/_private/constants.ts
@@ -3,6 +3,8 @@
  * we've added a, del, ins to the list since we assume they only contain phrasing content in the editor
  * we've removed br from the list to be inline with editor behaviour, which treats it as a block
  **/
+
+export const HEADING_ELEMENTS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
 export const PHRASING_CONTENT = [
   'a',
   'abbr',

--- a/addon/utils/_private/html-utils.ts
+++ b/addon/utils/_private/html-utils.ts
@@ -4,6 +4,7 @@ import type { Attrs, Schema } from 'prosemirror-model';
 import HTMLInputParser from './html-input-parser';
 import { tagName } from './dom-helpers';
 import { EditorView } from 'prosemirror-view';
+import type { HEADING_ELEMENTS } from './constants';
 
 export function htmlToDoc(
   html: string,
@@ -101,4 +102,9 @@ function matchTopNode(
     }
   }
   return;
+}
+
+export function getHeadingLevel(headingElement: HTMLHeadingElement) {
+  const tagName = headingElement.tagName as (typeof HEADING_ELEMENTS)[number];
+  return Number(tagName.substring(1));
 }

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -110,7 +110,7 @@ export default class EditableBlockController extends Controller {
       image,
 
       hard_break,
-      block_rdfa,
+      block_rdfa: block_rdfa({ rdfaAware: true }),
       inline_rdfa,
       link: link(this.linkOptions),
     },

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -89,7 +89,7 @@ export default class EditableBlockController extends Controller {
       }),
       paragraph,
 
-      repaired_block,
+      repaired_block: repaired_block({ rdfaAware: true }),
 
       list_item: list_item({ rdfaAware: true }),
       ordered_list: ordered_list({ rdfaAware: true }),

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -100,7 +100,7 @@ export default class EditableBlockController extends Controller {
         cellContent: 'block+',
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
       }),
-      heading,
+      heading: heading({ rdfaAware: true }),
       blockquote,
 
       horizontal_rule,

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -73,6 +73,7 @@ import {
   inlineRdfaView,
   inline_rdfa,
 } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
+import { sharedRdfaNodeSpec } from '@lblod/ember-rdfa-editor/core/schema';
 
 export default class EditableBlockController extends Controller {
   DebugInfo = DebugInfo;
@@ -83,10 +84,13 @@ export default class EditableBlockController extends Controller {
   @service declare intl: IntlService;
   schema = new Schema({
     nodes: {
-      doc: doc({
-        defaultLanguage: 'nl-BE',
-        rdfaAware: true,
-      }),
+      doc: {
+        ...doc({
+          defaultLanguage: 'nl-BE',
+          rdfaAware: true,
+        }),
+        ...sharedRdfaNodeSpec,
+      },
       paragraph,
 
       repaired_block: repaired_block({ rdfaAware: true }),
@@ -101,7 +105,7 @@ export default class EditableBlockController extends Controller {
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
         rdfaAware: true,
       }),
-      heading: heading({ rdfaAware: true }),
+      heading: { ...heading({ rdfaAware: true }), ...sharedRdfaNodeSpec },
       blockquote,
 
       horizontal_rule,
@@ -112,8 +116,11 @@ export default class EditableBlockController extends Controller {
       image,
 
       hard_break,
-      block_rdfa: block_rdfa({ rdfaAware: true }),
-      inline_rdfa: inline_rdfa({ rdfaAware: true }),
+      block_rdfa: { ...block_rdfa({ rdfaAware: true }), ...sharedRdfaNodeSpec },
+      inline_rdfa: {
+        ...inline_rdfa({ rdfaAware: true }),
+        ...sharedRdfaNodeSpec,
+      },
       link: link(this.linkOptions),
     },
     marks: {

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -12,7 +12,7 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/text-style';
 import {
   block_rdfa,
-  docWithConfig,
+  doc,
   hard_break,
   horizontal_rule,
   paragraph,
@@ -83,8 +83,9 @@ export default class EditableBlockController extends Controller {
   @service declare intl: IntlService;
   schema = new Schema({
     nodes: {
-      doc: docWithConfig({
+      doc: doc({
         defaultLanguage: 'nl-BE',
+        rdfaAware: true,
       }),
       paragraph,
 

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -91,9 +91,9 @@ export default class EditableBlockController extends Controller {
 
       repaired_block,
 
-      list_item,
-      ordered_list,
-      bullet_list,
+      list_item: list_item({ rdfaAware: true }),
+      ordered_list: ordered_list({ rdfaAware: true }),
+      bullet_list: bullet_list({ rdfaAware: true }),
       placeholder,
       ...tableNodes({
         tableGroup: 'block',

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -131,6 +131,7 @@ export default class EditableBlockController extends Controller {
   get linkOptions() {
     return {
       interactive: true,
+      rdfaAware: true,
     };
   }
 

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -113,7 +113,7 @@ export default class EditableBlockController extends Controller {
 
       hard_break,
       block_rdfa: block_rdfa({ rdfaAware: true }),
-      inline_rdfa,
+      inline_rdfa: inline_rdfa({ rdfaAware: true }),
       link: link(this.linkOptions),
     },
     marks: {
@@ -160,7 +160,7 @@ export default class EditableBlockController extends Controller {
     return {
       link: linkView(this.linkOptions)(controller),
       image: imageView(controller),
-      inline_rdfa: inlineRdfaView(controller),
+      inline_rdfa: inlineRdfaView({ rdfaAware: true })(controller),
     };
   };
 

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -99,6 +99,7 @@ export default class EditableBlockController extends Controller {
         tableGroup: 'block',
         cellContent: 'block+',
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
+        rdfaAware: true,
       }),
       heading: heading({ rdfaAware: true }),
       blockquote,

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -99,7 +99,7 @@ export default class IndexController extends Controller {
 
       hard_break,
       invisible_rdfa,
-      block_rdfa,
+      block_rdfa: block_rdfa(),
       link: link(this.linkOptions),
     },
     marks: {

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -76,7 +76,7 @@ export default class IndexController extends Controller {
       }),
       paragraph,
 
-      repaired_block,
+      repaired_block: repaired_block(),
 
       list_item: list_item(),
       ordered_list: ordered_list(),

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -12,7 +12,7 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/text-style';
 import {
   block_rdfa,
-  docWithConfig,
+  doc,
   hard_break,
   horizontal_rule,
   paragraph,
@@ -71,7 +71,7 @@ export default class IndexController extends Controller {
   @service declare intl: IntlService;
   schema = new Schema({
     nodes: {
-      doc: docWithConfig({
+      doc: doc({
         defaultLanguage: 'nl-BE',
       }),
       paragraph,

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -103,7 +103,7 @@ export default class IndexController extends Controller {
       link: link(this.linkOptions),
     },
     marks: {
-      inline_rdfa,
+      inline_rdfa: inline_rdfa(),
       code,
       em,
       strong,

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -98,7 +98,7 @@ export default class IndexController extends Controller {
       image,
 
       hard_break,
-      invisible_rdfa,
+      invisible_rdfa: invisible_rdfa(),
       block_rdfa: block_rdfa(),
       link: link(this.linkOptions),
     },

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -87,7 +87,7 @@ export default class IndexController extends Controller {
         cellContent: 'block+',
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
       }),
-      heading,
+      heading: heading(),
       blockquote,
 
       horizontal_rule,

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -78,9 +78,9 @@ export default class IndexController extends Controller {
 
       repaired_block,
 
-      list_item,
-      ordered_list,
-      bullet_list,
+      list_item: list_item(),
+      ordered_list: ordered_list(),
+      bullet_list: bullet_list(),
       placeholder,
       ...tableNodes({
         tableGroup: 'block',

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -104,7 +104,7 @@ export default class IndexController extends Controller {
 
       hard_break,
       invisible_rdfa,
-      block_rdfa,
+      block_rdfa: block_rdfa(),
       card,
       counter,
       dropdown,

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -81,7 +81,7 @@ export default class IndexController extends Controller {
       }),
       paragraph,
 
-      repaired_block,
+      repaired_block: repaired_block(),
 
       list_item: list_item(),
       ordered_list: ordered_list(),

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -103,7 +103,7 @@ export default class IndexController extends Controller {
       image,
 
       hard_break,
-      invisible_rdfa,
+      invisible_rdfa: invisible_rdfa(),
       block_rdfa: block_rdfa(),
       card,
       counter,

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -92,7 +92,7 @@ export default class IndexController extends Controller {
         cellContent: 'block+',
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
       }),
-      heading,
+      heading: heading(),
       blockquote,
 
       horizontal_rule,

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -111,7 +111,7 @@ export default class IndexController extends Controller {
       link: link(this.linkOptions),
     },
     marks: {
-      inline_rdfa,
+      inline_rdfa: inline_rdfa(),
       code,
       em,
       strong,

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -83,9 +83,9 @@ export default class IndexController extends Controller {
 
       repaired_block,
 
-      list_item,
-      ordered_list,
-      bullet_list,
+      list_item: list_item(),
+      ordered_list: ordered_list(),
+      bullet_list: bullet_list(),
       placeholder,
       ...tableNodes({
         tableGroup: 'block',

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -6,7 +6,7 @@ import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import { inline_rdfa } from '@lblod/ember-rdfa-editor/marks';
 import {
   block_rdfa,
-  docWithConfig,
+  doc,
   hard_break,
   horizontal_rule,
   invisible_rdfa,
@@ -76,7 +76,7 @@ export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
   schema = new Schema({
     nodes: {
-      doc: docWithConfig({
+      doc: doc({
         defaultLanguage: 'nl-BE',
       }),
       paragraph,

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -77,7 +77,7 @@ export default class SpaceInvisibleController extends Controller {
       }),
       paragraph,
 
-      repaired_block,
+      repaired_block: repaired_block(),
 
       list_item: list_item(),
       ordered_list: ordered_list(),

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -100,7 +100,7 @@ export default class SpaceInvisibleController extends Controller {
 
       hard_break,
       invisible_rdfa,
-      block_rdfa,
+      block_rdfa: block_rdfa(),
       link: link(this.linkOptions),
     },
     marks: {

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -12,7 +12,7 @@ import {
 } from '@lblod/ember-rdfa-editor/plugins/text-style';
 import {
   block_rdfa,
-  docWithConfig,
+  doc,
   hard_break,
   horizontal_rule,
   paragraph,
@@ -72,7 +72,7 @@ export default class SpaceInvisibleController extends Controller {
   @service declare intl: IntlService;
   schema = new Schema({
     nodes: {
-      doc: docWithConfig({
+      doc: doc({
         defaultLanguage: 'nl-BE',
       }),
       paragraph,

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -104,7 +104,7 @@ export default class SpaceInvisibleController extends Controller {
       link: link(this.linkOptions),
     },
     marks: {
-      inline_rdfa,
+      inline_rdfa: inline_rdfa(),
       code,
       em,
       strong,

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -99,7 +99,7 @@ export default class SpaceInvisibleController extends Controller {
       image,
 
       hard_break,
-      invisible_rdfa,
+      invisible_rdfa: invisible_rdfa(),
       block_rdfa: block_rdfa(),
       link: link(this.linkOptions),
     },

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -88,7 +88,7 @@ export default class SpaceInvisibleController extends Controller {
         cellContent: 'block+',
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
       }),
-      heading,
+      heading: heading(),
       blockquote,
 
       horizontal_rule,

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -79,9 +79,9 @@ export default class SpaceInvisibleController extends Controller {
 
       repaired_block,
 
-      list_item,
-      ordered_list,
-      bullet_list,
+      list_item: list_item(),
+      ordered_list: ordered_list(),
+      bullet_list: bullet_list(),
       placeholder,
       ...tableNodes({
         tableGroup: 'block',

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -91,7 +91,7 @@ const nodes = {
 
   hard_break,
   invisible_rdfa,
-  block_rdfa,
+  block_rdfa: block_rdfa({ rdfaAware: true }),
 };
 const marks = {
   inline_rdfa,

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -72,7 +72,7 @@ const nodes = {
   doc: doc({ rdfaAware: true }),
   paragraph,
 
-  repaired_block,
+  repaired_block: repaired_block({ rdfaAware: true }),
 
   list_item: list_item({ rdfaAware: true }),
   ordered_list: ordered_list({ rdfaAware: true }),

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -10,7 +10,7 @@ import {
 import { link } from '@lblod/ember-rdfa-editor/plugins/link';
 import {
   block_rdfa,
-  docWithConfig,
+  doc,
   hard_break,
   horizontal_rule,
   paragraph,
@@ -70,7 +70,7 @@ export async function renderEditor() {
 }
 
 const nodes = {
-  doc: docWithConfig(),
+  doc: doc({ rdfaAware: true }),
   paragraph,
 
   repaired_block,

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -74,9 +74,9 @@ const nodes = {
 
   repaired_block,
 
-  list_item,
-  ordered_list,
-  bullet_list,
+  list_item: list_item({ rdfaAware: true }),
+  ordered_list: ordered_list({ rdfaAware: true }),
+  bullet_list: bullet_list({ rdfaAware: true }),
   ...tableNodes({ tableGroup: 'block', cellContent: 'inline*' }),
   heading: heading({ rdfaAware: true }),
   blockquote,

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -97,7 +97,7 @@ const nodes = {
   block_rdfa: block_rdfa({ rdfaAware: true }),
 };
 const marks = {
-  inline_rdfa,
+  inline_rdfa: inline_rdfa({ rdfaAware: true }),
   code,
   em,
   strong,

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -77,7 +77,11 @@ const nodes = {
   list_item: list_item({ rdfaAware: true }),
   ordered_list: ordered_list({ rdfaAware: true }),
   bullet_list: bullet_list({ rdfaAware: true }),
-  ...tableNodes({ tableGroup: 'block', cellContent: 'inline*' }),
+  ...tableNodes({
+    tableGroup: 'block',
+    cellContent: 'inline*',
+    rdfaAware: true,
+  }),
   heading: heading({ rdfaAware: true }),
   blockquote,
 

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -7,7 +7,6 @@ import {
   strong,
   underline,
 } from '@lblod/ember-rdfa-editor/plugins/text-style';
-import { link } from '@lblod/ember-rdfa-editor/plugins/link';
 import {
   block_rdfa,
   doc,
@@ -96,7 +95,6 @@ const nodes = {
 const marks = {
   inline_rdfa,
   code,
-  link,
   em,
   strong,
   underline,

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -79,7 +79,7 @@ const nodes = {
   ordered_list,
   bullet_list,
   ...tableNodes({ tableGroup: 'block', cellContent: 'inline*' }),
-  heading,
+  heading: heading({ rdfaAware: true }),
   blockquote,
 
   horizontal_rule,

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -93,7 +93,7 @@ const nodes = {
   image,
 
   hard_break,
-  invisible_rdfa,
+  invisible_rdfa: invisible_rdfa(),
   block_rdfa: block_rdfa({ rdfaAware: true }),
 };
 const marks = {

--- a/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -76,9 +76,9 @@ const schema = new Schema({
 
     repaired_block,
 
-    list_item,
-    ordered_list,
-    bullet_list,
+    list_item: list_item({ rdfaAware: true }),
+    ordered_list: ordered_list({ rdfaAware: true }),
+    bullet_list: bullet_list({ rdfaAware: true }),
     placeholder,
     ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
     heading: heading({ rdfaAware: true }),

--- a/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -91,7 +91,7 @@ const schema = new Schema({
     image,
 
     hard_break,
-    block_rdfa,
+    block_rdfa: block_rdfa({ rdfaAware: true }),
   },
   marks: {
     inline_rdfa,

--- a/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -2,7 +2,7 @@ import { oneLineTrim } from 'common-tags';
 import { module, test } from 'qunit';
 import {
   block_rdfa,
-  docWithConfig,
+  doc,
   hard_break,
   horizontal_rule,
   paragraph,
@@ -68,8 +68,9 @@ import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 
 const schema = new Schema({
   nodes: {
-    doc: docWithConfig({
+    doc: doc({
       defaultLanguage: 'nl-BE',
+      rdfaAware: true,
     }),
     paragraph,
 

--- a/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -80,7 +80,11 @@ const schema = new Schema({
     ordered_list: ordered_list({ rdfaAware: true }),
     bullet_list: bullet_list({ rdfaAware: true }),
     placeholder,
-    ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+    ...tableNodes({
+      tableGroup: 'block',
+      cellContent: 'block+',
+      rdfaAware: true,
+    }),
     heading: heading({ rdfaAware: true }),
     blockquote,
 

--- a/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -81,7 +81,7 @@ const schema = new Schema({
     bullet_list,
     placeholder,
     ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
-    heading,
+    heading: heading({ rdfaAware: true }),
     blockquote,
 
     horizontal_rule,

--- a/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -74,7 +74,7 @@ const schema = new Schema({
     }),
     paragraph,
 
-    repaired_block,
+    repaired_block: repaired_block({ rdfaAware: true }),
 
     list_item: list_item({ rdfaAware: true }),
     ordered_list: ordered_list({ rdfaAware: true }),

--- a/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -99,7 +99,7 @@ const schema = new Schema({
     block_rdfa: block_rdfa({ rdfaAware: true }),
   },
   marks: {
-    inline_rdfa,
+    inline_rdfa: inline_rdfa({ rdfaAware: true }),
     code,
     em,
     strong,

--- a/tests/unit/utils/html-input-parser-test.ts
+++ b/tests/unit/utils/html-input-parser-test.ts
@@ -8,7 +8,7 @@ import { Schema } from 'prosemirror-model';
 
 import HTMLInputParser from '@lblod/ember-rdfa-editor/utils/_private/html-input-parser';
 import { SayView } from '@lblod/ember-rdfa-editor';
-import { docWithConfig, paragraph, text } from '@lblod/ember-rdfa-editor/nodes';
+import { doc, paragraph, text } from '@lblod/ember-rdfa-editor/nodes';
 
 const editorContainerMock = document.createElement('div');
 sinon.stub(editorContainerMock, 'clientWidth').get(() => 800);
@@ -17,8 +17,9 @@ const editorView = new SayView(document.createElement('div'), {
   state: EditorState.create({
     schema: new Schema({
       nodes: {
-        doc: docWithConfig({
+        doc: doc({
           defaultLanguage: 'nl-BE',
+          rdfaAware: true,
         }),
         paragraph,
         text,

--- a/tests/utils/editor.ts
+++ b/tests/utils/editor.ts
@@ -72,7 +72,7 @@ export const SAMPLE_SCHEMA = new Schema({
     bullet_list,
     placeholder,
     ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
-    heading,
+    heading: heading({ rdfaAware: true }),
     blockquote,
 
     horizontal_rule,

--- a/tests/utils/editor.ts
+++ b/tests/utils/editor.ts
@@ -71,7 +71,11 @@ export const SAMPLE_SCHEMA = new Schema({
     ordered_list: ordered_list({ rdfaAware: true }),
     bullet_list: bullet_list({ rdfaAware: true }),
     placeholder,
-    ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
+    ...tableNodes({
+      tableGroup: 'block',
+      cellContent: 'block+',
+      rdfaAware: true,
+    }),
     heading: heading({ rdfaAware: true }),
     blockquote,
 

--- a/tests/utils/editor.ts
+++ b/tests/utils/editor.ts
@@ -65,7 +65,7 @@ export const SAMPLE_SCHEMA = new Schema({
     }),
     paragraph,
 
-    repaired_block,
+    repaired_block: repaired_block({ rdfaAware: true }),
 
     list_item: list_item({ rdfaAware: true }),
     ordered_list: ordered_list({ rdfaAware: true }),

--- a/tests/utils/editor.ts
+++ b/tests/utils/editor.ts
@@ -82,7 +82,7 @@ export const SAMPLE_SCHEMA = new Schema({
     image,
 
     hard_break,
-    block_rdfa,
+    block_rdfa: block_rdfa({ rdfaAware: true }),
   },
   marks: {
     inline_rdfa,

--- a/tests/utils/editor.ts
+++ b/tests/utils/editor.ts
@@ -90,7 +90,7 @@ export const SAMPLE_SCHEMA = new Schema({
     block_rdfa: block_rdfa({ rdfaAware: true }),
   },
   marks: {
-    inline_rdfa,
+    inline_rdfa: inline_rdfa({ rdfaAware: true }),
     code,
     em,
     strong,

--- a/tests/utils/editor.ts
+++ b/tests/utils/editor.ts
@@ -1,7 +1,7 @@
 import type Owner from '@ember/owner';
 import {
   block_rdfa,
-  docWithConfig,
+  doc,
   hard_break,
   horizontal_rule,
   paragraph,
@@ -59,8 +59,9 @@ import sinon from 'sinon';
 
 export const SAMPLE_SCHEMA = new Schema({
   nodes: {
-    doc: docWithConfig({
+    doc: doc({
       defaultLanguage: 'nl-BE',
+      rdfaAware: true,
     }),
     paragraph,
 

--- a/tests/utils/editor.ts
+++ b/tests/utils/editor.ts
@@ -67,9 +67,9 @@ export const SAMPLE_SCHEMA = new Schema({
 
     repaired_block,
 
-    list_item,
-    ordered_list,
-    bullet_list,
+    list_item: list_item({ rdfaAware: true }),
+    ordered_list: ordered_list({ rdfaAware: true }),
+    bullet_list: bullet_list({ rdfaAware: true }),
     placeholder,
     ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
     heading: heading({ rdfaAware: true }),


### PR DESCRIPTION
### Overview
This PR attempts to improve the backwards compatibility of rdfa-aware nodes.
Specifically, it converts each rdfa-aware nodespec to a function producing a node-spec based on an options argument, which is defined as follows:
```typescript
type Config = {
  rdfaAware?: boolean;
};
```
This, of course includes a breaking change as a lot of the nodespecs have been converted to functions. Specifically, the following node-specs have been converted to a function producing a node-spec:
- `block_rdfa`
- `inline_rdfa`
- `invisible_rdfa`
- `repaired_block`
- `list_item`, `bullet_list` and `ordered_list`
- `heading`

The following mark-specs have also been converted to a function:
- `inline_rdfa`

The following node-specs where already produced by a function (their options argument has been extended to include the `rdfaAware` option)
- the table node-specs
- `link`

The `doc` node-spec has been dropped and the `docWithConfig` function has been renamed to `doc`

The `rdfaAware` option always has a default value of false, the new features are thus opt-in.

Regarding the dummy pages:
- The 'index', 'dummy plugins' and 'space invisible' pages are not rdfa-aware
- The `editable nodes POC` page is rdfa-aware

### How to test/reproduce
- Start the dummy app

- Visit the `index`,  'dummy plugins' or 'space invisible' page
- Notice, (using e.g. the prosemirror devtools) that the different node-specs use the classic RDFa attributes
- Using the different sample configs, notice that the RDFa stays preserved (using the classic method)

- Visit the `editable nodes POC` page
- Notice that the different RDFa node-specs use the new API
- Using the different sample configs, notice that the RDFa stays preserved (using the new API)
- The 'editable' RDFa nodes should work as expected

### Challenges/uncertainties
This PR contains quite a few breaking changes, as it converts some node-specs to functions producing node-specs.
**Initially I tried the following approach:**
- Define an optional `rdfaAware` boolean property on node-specs, this property can be supplied to a node-spec using the spread operator: e.g. `block_rdfa: {...block_rdfa, rdfaAware: true }`
- Adapt the `toDOM`, `parseDOM` and `attrs` properties of a node-spec to be reactive to this `rdfaAware` property

This approach had the big following advantage:
- No (new) breaking changes: the `rdfaAware` property has a default value of false/undefined. The node-specs stays node-specs and do not become functions

But this approach did not work out:
- The `toDOM` and `parseDOM` node-spec properties get pulled out of their contexts, so it is not possible to get access to the `this` object inside them. I did not (yet) see an other option on how to access `this.rdfaAware`.

**In order to limit the breaking changes, we could also take the following approach:**
- Introduce seperate `configurable` functions that produce node-specs:
  * `configurableBlockRDFa`
  * `configurableInlineRDFa`
  * `configurableList`
  * ...
- Keep the current `block_rdfa`, `inline_rdfa` ... variables as normal node-specs with `rdfaAware: false`

This approach does have the disadvantage to introduce quite a few new variables/functions.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
