### PR TITLE
fix(rdfa-parser): ignore `language` of content when `datatype` of content is defined and not `rdf:langString`

### DIFF
--- a/addon/utils/_private/rdfa-parser/rdfa-parser.ts
+++ b/addon/utils/_private/rdfa-parser/rdfa-parser.ts
@@ -34,6 +34,7 @@ import {
   languageOrDataType,
   sayDataFactory,
 } from '@lblod/ember-rdfa-editor/core/say-data-factory';
+import { LANG_STRING } from '../constants';
 
 export type ModelTerm<N> =
   | ModelQuadObject<N>
@@ -1014,6 +1015,12 @@ export class RdfaParser<N> {
     contentDatatype?: ModelNamedNode<N>,
     contentLanguage?: string,
   ) => {
+    if (
+      contentDatatype &&
+      !contentDatatype.equals(sayDataFactory.namedNode(LANG_STRING))
+    ) {
+      contentLanguage = undefined;
+    }
     this.resourceNodeMapping.set(node, {
       subject: this.util.getResourceOrBaseIri(resource, activeTag),
       contentPredicate: contentPredicate


### PR DESCRIPTION
### Overview
This PR includes a change to `markAsResourceNode` of the rdfa-parser.
The fix ensures that the `language` of content is ignored if a `datatype` is supplied that is not equal to `rdf:langString`

##### connected issues and PRs:
closes #1157 

### How to test/reproduce
- `pnpm start`
- Open the 'Editable Nodes' dummy page
- Insert a resource node with some content inside
- Add a `content-literal` property to the resource node with datatype `rdf:string` (or another datatype that is not equal to `rdf:langString`
- Reload the page and ensure the `content-literal` property is kept intact (the datatype should stay intact and no language should be added)

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
