### PR TITLE
Add support for alternating row styles

### DIFF
--- a/.changeset/quiet-socks-hammer.md
+++ b/.changeset/quiet-socks-hammer.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Introduce option to configure alternating row background styles

--- a/.changeset/witty-lobsters-shake.md
+++ b/.changeset/witty-lobsters-shake.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Add `constructInlineStyles` utility function

--- a/addon/plugins/table/index.ts
+++ b/addon/plugins/table/index.ts
@@ -15,6 +15,7 @@ import {
   TableView as PluginTableView,
 } from '@say-editor/prosemirror-tables';
 import { findNextCell, selectionCell } from './utils';
+import { constructInlineStyles } from '@lblod/ember-rdfa-editor/utils/_private/html-utils';
 
 export { tableNodes } from './nodes/table';
 export { insertTable } from './commands/insertTable';
@@ -33,13 +34,10 @@ export class TableView extends PluginTableView {
   }
 
   private addAttrs(node: Node): void {
-    const { class: nodeClasses, style } = node.attrs as Record<string, unknown>;
-    if (typeof nodeClasses === 'string') {
-      this.table.classList.add(...nodeClasses.split(' '));
-    }
-    if (typeof style === 'string') {
-      this.table.style.cssText = `${this.table.style.cssText} ${style}`;
-    }
+    const nodeClasses = node.attrs.class as string;
+    const style = node.attrs.style as Record<string, string | undefined>;
+    this.table.classList.add(...nodeClasses.split(' '));
+    this.table.style.cssText = `${this.table.style.cssText} ${constructInlineStyles(style)}`;
   }
 
   get colgroupElement(): HTMLTableColElement {

--- a/addon/plugins/table/nodes/table.ts
+++ b/addon/plugins/table/nodes/table.ts
@@ -218,7 +218,7 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
       serialize(node, state) {
         const pos = getPos(node, state.doc) as ResolvedPos;
         // table rows are 1-indexed
-        const isEven = (pos.index() + 1) % 2 === 0;
+        const isEven = pos.index() % 2 === 1;
         const style = {
           ...rowStyle,
           ...(isEven ? evenRowStyle : oddRowStyle),

--- a/addon/plugins/table/nodes/table.ts
+++ b/addon/plugins/table/nodes/table.ts
@@ -1,9 +1,11 @@
 // Helper for creating a schema that supports tables.
 
-import { Node as PNode, NodeSpec } from 'prosemirror-model';
+import { Node as PNode, NodeSpec, ResolvedPos } from 'prosemirror-model';
 import { getRdfaAttrs, rdfaAttrs } from '@lblod/ember-rdfa-editor/core/schema';
 import { TableView } from '@lblod/ember-rdfa-editor/plugins/table';
 import SayNodeSpec from '@lblod/ember-rdfa-editor/core/say-node-spec';
+import { getPos } from '@lblod/ember-rdfa-editor/utils/node-utils';
+import { constructInlineStyles } from '@lblod/ember-rdfa-editor/utils/_private/html-utils';
 
 interface ExtraAttribute {
   default: unknown;
@@ -97,13 +99,17 @@ interface TableNodeOptions {
     style?: string;
     color: string;
   };
+  rowBackground?: {
+    even?: string;
+    odd?: string;
+  };
 }
 
 interface TableNodes extends Record<string, NodeSpec> {
   table: SayNodeSpec;
-  table_row: NodeSpec;
-  table_cell: NodeSpec;
-  table_header: NodeSpec;
+  table_row: SayNodeSpec;
+  table_cell: SayNodeSpec;
+  table_header: SayNodeSpec;
 }
 
 export function tableNodes(options: TableNodeOptions): TableNodes {
@@ -119,12 +125,24 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
   const inlineBorderStyle =
     options.inlineBorderStyle &&
     `${options.inlineBorderStyle.width} ${options.inlineBorderStyle.style || 'solid'} ${options.inlineBorderStyle.color}`;
-  const tableStyle =
-    inlineBorderStyle &&
-    `border: ${inlineBorderStyle}; border-collapse: collapse;`;
-  const rowStyle = inlineBorderStyle && `border-top: ${inlineBorderStyle};`;
-  const cellStyle = inlineBorderStyle && `border-left: ${inlineBorderStyle};`;
-
+  const tableStyle = {
+    border: inlineBorderStyle,
+    'border-collapse': inlineBorderStyle && 'collapse',
+    '--say-even-row-background': options.rowBackground?.even,
+    '--say-odd-row-background': options.rowBackground?.odd,
+  };
+  const rowStyle = {
+    'border-top': inlineBorderStyle,
+  };
+  const cellStyle = {
+    'border-left': inlineBorderStyle,
+  };
+  const evenRowStyle = {
+    background: 'var(--say-even-row-background)',
+  };
+  const oddRowStyle = {
+    background: 'var(--say-odd-row-background)',
+  };
   return {
     table: {
       content: 'table_row+',
@@ -156,20 +174,23 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
           {
             ...node.attrs,
             class: 'say-table',
-            style: tableStyle,
+            style: constructInlineStyles(tableStyle),
           },
           ['tbody', 0],
         ];
       },
       serialize(node: PNode) {
         const tableView = new TableView(node, 25);
-
+        const style = {
+          width: '100%',
+          ...tableStyle,
+        };
         return [
           'table',
           {
             ...node.attrs,
             class: 'say-table',
-            style: `width: 100%; ${tableStyle || ''}`,
+            style: constructInlineStyles(style),
           },
           tableView.colgroupElement,
           ['tbody', 0],
@@ -194,8 +215,26 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
           },
         },
       ],
+      serialize(node, state) {
+        const pos = getPos(node, state.doc) as ResolvedPos;
+        // table rows are 1-indexed
+        const isEven = (pos.index() + 1) % 2 === 0;
+        const style = {
+          ...rowStyle,
+          ...(isEven ? evenRowStyle : oddRowStyle),
+        };
+        return [
+          'tr',
+          { ...node.attrs, style: constructInlineStyles(style) },
+          0,
+        ];
+      },
       toDOM(node: PNode) {
-        return ['tr', { ...node.attrs, style: rowStyle }, 0];
+        return [
+          'tr',
+          { ...node.attrs, style: constructInlineStyles(rowStyle) },
+          0,
+        ];
       },
     },
     table_cell: {
@@ -213,7 +252,10 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
       toDOM(node) {
         return [
           'td',
-          { ...setCellAttrs(node, extraAttrs), style: cellStyle },
+          {
+            ...setCellAttrs(node, extraAttrs),
+            style: constructInlineStyles(cellStyle),
+          },
           0,
         ];
       },
@@ -232,7 +274,10 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
       toDOM(node) {
         return [
           'th',
-          { ...setCellAttrs(node, extraAttrs), style: cellStyle },
+          {
+            ...setCellAttrs(node, extraAttrs),
+            style: constructInlineStyles(cellStyle),
+          },
           0,
         ];
       },

--- a/addon/plugins/table/nodes/table.ts
+++ b/addon/plugins/table/nodes/table.ts
@@ -137,12 +137,6 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
   const cellStyle = {
     'border-left': inlineBorderStyle,
   };
-  const evenRowStyle = {
-    background: 'var(--say-even-row-background)',
-  };
-  const oddRowStyle = {
-    background: 'var(--say-odd-row-background)',
-  };
   return {
     table: {
       content: 'table_row+',
@@ -181,9 +175,12 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
       },
       serialize(node: PNode) {
         const tableView = new TableView(node, 25);
+        // Delete variables as we do not need them in serialized version
         const style = {
           width: '100%',
           ...tableStyle,
+          '--say-even-row-background': undefined,
+          '--say-odd-row-background': undefined,
         };
         return [
           'table',
@@ -221,7 +218,9 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
         const isEven = pos.index() % 2 === 1;
         const style = {
           ...rowStyle,
-          ...(isEven ? evenRowStyle : oddRowStyle),
+          background: isEven
+            ? options.rowBackground?.even
+            : options.rowBackground?.odd,
         };
         return [
           'tr',

--- a/addon/utils/_private/html-utils.ts
+++ b/addon/utils/_private/html-utils.ts
@@ -35,3 +35,15 @@ export function htmlToDoc(
   }
   return doc;
 }
+
+export function constructInlineStyles(
+  styles: Record<string, string | undefined>,
+) {
+  let result = '';
+  Object.entries(styles).forEach(([key, value]) => {
+    if (value) {
+      result += `${key}: ${value};`;
+    }
+  });
+  return result;
+}

--- a/addon/utils/_private/node-utils.ts
+++ b/addon/utils/_private/node-utils.ts
@@ -1,4 +1,4 @@
-import { PNode } from '@lblod/ember-rdfa-editor';
+import { PNode, ResolvedPos } from '@lblod/ember-rdfa-editor';
 
 export function getGroups(node: PNode) {
   return node.type.spec.group?.split(' ') ?? [];
@@ -7,4 +7,33 @@ export function getGroups(node: PNode) {
 export function hasGroups(node: PNode, ...groups: string[]) {
   const nodeGroups = getGroups(node);
   return groups.every((group) => nodeGroups.includes(group));
+}
+
+export function getParent(node: PNode, doc: PNode) {
+  const pos = getPos(node, doc);
+  if (!pos) {
+    return;
+  }
+  if (pos === -1) {
+    console.warn(`getParent: ${node.toString()} has no parent`);
+    return;
+  }
+  return pos.parent;
+}
+
+export function getPos(node: PNode, doc: PNode): ResolvedPos | -1 | undefined {
+  if (node === doc) {
+    return -1;
+  }
+  let result: ResolvedPos | undefined;
+  doc.descendants((descendant, pos) => {
+    if (node === descendant) {
+      result = doc.resolve(pos);
+    }
+    return !result;
+  });
+  if (!result) {
+    console.warn(`getPos: ${node.toString()} not found in ${doc.toString()}`);
+  }
+  return result;
 }

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -298,9 +298,6 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
   }
 
   // Table styling
-  table th {
-    background-color: var(--au-white);
-  }
 
   .data-table th,
   .data-table td {

--- a/app/styles/ember-rdfa-editor/_c-table.scss
+++ b/app/styles/ember-rdfa-editor/_c-table.scss
@@ -34,6 +34,13 @@
     border-top: 0.1rem solid var(--au-gray-300);
   }
 
+  tr:nth-child(even){
+    background: var(--say-even-row-background);
+  }
+  tr:nth-child(odd){
+    background: var(--say-odd-row-background);
+  }
+
   th + th,
   td + td,
   th + td,

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -86,6 +86,9 @@ export default class IndexController extends Controller {
         tableGroup: 'block',
         cellContent: 'block+',
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
+        rowBackground: {
+          odd: 'whitesmoke',
+        },
       }),
       heading,
       blockquote,


### PR DESCRIPTION
### Overview
This PR adds support for configuring alternating row styles of tables. 
Developers making use of the table plugin can configure the background for the odd and even rows of a table.

It is implemented as follows:
- If background colors for odd or even rows are provided, the following variables are set in the inline styles of the table element:
   * `--say-even-row-background`
   * `--say-odd-row-background`
- The following css has been added to `_c-table.scss`:
```
tr:nth-child(even){
  	background: var(--say-even-row-background);
}
tr:nth-child(odd){
  	background: var(--say-odd-row-background);
}
```
- The `serialize` method of the `table_row` nodespec adds inline styles based on if the row is even or odd. This is only possible in `serialize`, not in `toDOM`, as only `serialize` has access to the state.

Additionally, this PR includes the following changes:
- Addition of a `constructInlineStyles` utility function, which takes a css object and converts it to an inline styles string
- Addition of `getParent` and `getPos` utilities. These utilities allow you to resolve a prosemirror-node in a document. (needed to check if a row is even/odd in a table)

##### connected issues and PRs:
Solution to: https://binnenland.atlassian.net/browse/GN-4705?atlOrigin=eyJpIjoiMzRlNzA1NzcwNDdkNGMwOGJmMzlhYzg0Y2YxYWIzNDkiLCJwIjoiaiJ9


### How to test/reproduce
- `npm start`
- Open the index dummy page
- Insert a table with a few rows
- Notice that the rows alternate
- Export to html and observe the inline styles responsible for the alternating row backgrounds.

### Challenges/uncertainties
I was not able to enable the `nth-child` css rules in the table inline css, as inline css does not allow for setting children styles. The approach with css variables seemed the best second option.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
