### PR TITLE
Improvements/additions to title attributes of toolbar buttons

### DIFF
--- a/.changeset/curvy-clocks-pump.md
+++ b/.changeset/curvy-clocks-pump.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Add title attribute to heading-menu

--- a/.changeset/cyan-flies-vanish.md
+++ b/.changeset/cyan-flies-vanish.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Add `title` attribute to more-options toolbar button

--- a/.changeset/selfish-boats-yawn.md
+++ b/.changeset/selfish-boats-yawn.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Improve translations of toolbar button labels/titles

--- a/.changeset/selfish-rabbits-rule.md
+++ b/.changeset/selfish-rabbits-rule.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Add title attribute to table menu

--- a/.changeset/strong-lies-rescue.md
+++ b/.changeset/strong-lies-rescue.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Add title attribute for rdfa-toggle

--- a/.changeset/tidy-roses-greet.md
+++ b/.changeset/tidy-roses-greet.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Add title attribute to formatting toggle

--- a/addon/components/plugins/formatting/formatting-toggle.hbs
+++ b/addon/components/plugins/formatting/formatting-toggle.hbs
@@ -1,4 +1,7 @@
-<div class="say-rdfa-toggle">
+<div
+  class="say-rdfa-toggle"
+  title={{t "ember-rdfa-editor.show-formatting-marks"}}
+>
   <AuNativeToggle {{on "change" this.toggle}} checked={{this.isActive}}>
     {{t "ember-rdfa-editor.show-formatting-marks"}}
   </AuNativeToggle>

--- a/addon/components/plugins/heading/heading-menu.hbs
+++ b/addon/components/plugins/heading/heading-menu.hbs
@@ -4,6 +4,7 @@
   @iconSize="small"
   @controller={{@controller}}
   @disabled={{not this.enabled}}
+  title={{t "ember-rdfa-editor.text-styles"}}
   as |Menu|
 >
   <Menu.Item

--- a/addon/components/plugins/rdfa-block-render/rdfa-blocks-toggle.hbs
+++ b/addon/components/plugins/rdfa-block-render/rdfa-blocks-toggle.hbs
@@ -1,8 +1,8 @@
-<div class="say-rdfa-toggle">
+<div class="say-rdfa-toggle" title={{t "ember-rdfa-editor.show-annotations"}}>
   <AuToggleSwitch
     @checked={{@controller.isShowingRdfaBlocks}}
     @onChange={{this.toggle}}
   >
-    {{t 'ember-rdfa-editor.show-annotations'}}
+    {{t "ember-rdfa-editor.show-annotations"}}
   </AuToggleSwitch>
 </div>

--- a/addon/components/plugins/table/table-menu.hbs
+++ b/addon/components/plugins/table/table-menu.hbs
@@ -2,6 +2,7 @@
   @controller={{@controller}}
   @icon="table"
   @label={{t 'ember-rdfa-editor.table.table-options'}}
+  title={{t 'ember-rdfa-editor.table.table-options'}}
   @hideLabel={{true}}
   @disabled={{not this.canInsertTable}}
   as |Menu|

--- a/addon/components/responsive-toolbar.hbs
+++ b/addon/components/responsive-toolbar.hbs
@@ -8,18 +8,19 @@
       <this.Velcro @placement="bottom-end" @offsetOptions={{hash mainAxis=10}} as |velcro|>
         {{#if this.main.enableDropdown}}
           <Toolbar::Group data-ignore-resize {{velcro.hook}}>
-            <Toolbar::Button 
-              @icon="three-dots" 
-              {{on 'click' this.toggleMainDropdown}} 
+            <Toolbar::Button
+              @icon="three-dots"
+              title={{t "ember-rdfa-editor.utils.more-options"}}
+              {{on 'click' this.toggleMainDropdown}}
               @active={{this.main.showDropdown}}
             />
           </Toolbar::Group>
         {{/if}}
-        <div 
-          class="say-toolbar__main-dropdown" 
-          data-ignore-resize 
-          data-hidden={{if this.main.showDropdown 'false' 'true'}} 
-          {{velcro.loop}} 
+        <div
+          class="say-toolbar__main-dropdown"
+          data-ignore-resize
+          data-hidden={{if this.main.showDropdown 'false' 'true'}}
+          {{velcro.loop}}
           {{this.setUpMainDropdown}}
         >
           {{yield (hash
@@ -39,18 +40,19 @@
       <this.Velcro @placement="bottom-end" @offsetOptions={{hash mainAxis=10}} as |velcro|>
         {{#if this.side.enableDropdown}}
           <Toolbar::Group data-ignore-resize {{velcro.hook}}>
-            <Toolbar::Button 
-              @icon="nav-down" 
+            <Toolbar::Button
+              @icon="nav-down"
+              title={{t "ember-rdfa-editor.utils.more-options"}}
               {{on 'click' this.toggleSideDropdown}}
               @active={{this.side.showDropdown}}
             />
           </Toolbar::Group>
         {{/if}}
-        <div 
-          class="say-toolbar__side-dropdown" 
-          data-ignore-resize 
-          data-hidden={{if this.side.showDropdown 'false' 'true'}} 
-          {{velcro.loop}} 
+        <div
+          class="say-toolbar__side-dropdown"
+          data-ignore-resize
+          data-hidden={{if this.side.showDropdown 'false' 'true'}}
+          {{velcro.loop}}
           {{this.setUpSideDropdown}}
         >
           {{yield (hash

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1,6 +1,7 @@
 ember-rdfa-editor:
   utils:
     back: Back
+    more-options: More options
   undo: Undo
   redo: Redo
   bold: Bold

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -79,3 +79,4 @@ ember-rdfa-editor:
       center: Center align
       right: Right align
       justify: Justify
+  text-styles: Text styles

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -10,9 +10,9 @@ ember-rdfa-editor:
   strikethrough: Strikethrough
   subscript: Subscript
   superscript: Superscript
-  unordered-list: Unordered list
+  unordered-list: Bulleted list
   ordered-list:
-    button-label: Ordered list
+    button-label: Numbered list
     options-label: List styles
     styles:
       decimal: Numbers

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -1,6 +1,7 @@
 ember-rdfa-editor:
   utils:
     back: Terug
+    more-options: Meer opties
   undo: Ongedaan maken
   redo: Herstellen
   bold: Vetgedrukt

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -78,3 +78,4 @@ ember-rdfa-editor:
       center: Centreren
       right: Rechts uitlijnen
       justify: Uitvullen
+  text-styles: Tekststijlen

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -3,16 +3,16 @@ ember-rdfa-editor:
     back: Terug
     more-options: Meer opties
   undo: Ongedaan maken
-  redo: Herstellen
+  redo: Opnieuw uitvoeren
   bold: Vetgedrukt
-  italic: Schuingedrukt
+  italic: Cursief
   underline: Onderstreept
-  strikethrough: Doorstreept
+  strikethrough: Doorgehaald
   subscript: Subscript
   superscript: Superscript
-  unordered-list: Ongeordende lijst
+  unordered-list: Lijst met opsommingstekens
   ordered-list:
-    button-label: Geordende lijst
+    button-label: Genummerde lijst
     options-label: Lijststijlen
     styles:
       decimal: Getallen
@@ -36,7 +36,7 @@ ember-rdfa-editor:
     split-cell: Cel splitsen
     columns: Kolommen
     rows: Rijen
-  normalText: Gewone tekst
+  normalText: Normale tekst
   heading: Koptitel
   insert-heading: Voeg koptitel toe
 
@@ -56,7 +56,7 @@ ember-rdfa-editor:
       title: Snelkoppeling wijzigen
       uncouple: Snelkoppeling loskoppelen
   highlight:
-    button-label: Markering
+    button-label: Markeringskleur
     options-label: Markeringsopties
   color:
       button-label: Tekstkleur


### PR DESCRIPTION
### Overview
This PR contains several improvements/additions to the title attributes of toolbar buttons:
- Some improvements in translations
- Addition of missing title attributes
- Changed 'gewone tekst' to 'normale tekst'

##### connected issues and PRs:
[GN-4736](https://binnenland.atlassian.net/browse/GN-4736?atlOrigin=eyJpIjoiNTY3NjJhNTE4ZTViNGYyMGFjMmM4NjliOWRhOWNkMDkiLCJwIjoiaiJ9)
Closes #1163 

### How to test/reproduce
- `npm start`
- Open the dummy app
- Notice that each toolbar button now has a title attribute. Some translations have changed.

### Challenges/uncertainties
Another option is to use 'Hoofdtekst' instead of 'Gewone tekst' or 'Normale tekst'.
Word uses 'Hoofdtekst', while google docs uses 'Normale tekst'.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
