### PR TITLE
Ensure `rdfa-parsing` unit tests run correctly

### DIFF
--- a/.woodpecker/.e2e.yml
+++ b/.woodpecker/.e2e.yml
@@ -1,7 +1,7 @@
 steps:
   e2e:
     # this image must be the same as in `scripts/e2e.sh`
-    image: mcr.microsoft.com/playwright:v1.42.1-jammy
+    image: mcr.microsoft.com/playwright:v1.41.2-jammy
     commands:
       - corepack enable
       - pnpm i --frozen-lockfile

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -18,5 +18,5 @@ docker run -it --rm \
 -e DISPLAY=$DISPLAY_ENV \
 -w /e2e \
 --platform linux/amd64 \
-mcr.microsoft.com/playwright:v1.42.1-jammy \
+mcr.microsoft.com/playwright:v1.41.2-jammy \
 npx playwright "$@"

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -7,7 +7,7 @@ import config from 'dummy/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 import { setup } from 'qunit-dom';
-
+import { equiv } from 'qunit';
 setup(QUnit.assert);
 const defaultDumpDepth = QUnit.dump.maxDepth;
 
@@ -99,6 +99,20 @@ QUnit.dump.setParser('node', nodeParser);
 QUnit.hooks.afterEach(() => {
   QUnit.dump.maxDepth = defaultDumpDepth;
 });
+
+QUnit.assert.deepArrayContains = function (
+  array: unknown[],
+  element: unknown,
+  message?: string,
+) {
+  const result = array.some((val) => equiv(val, element));
+  this.pushResult({
+    result,
+    actual: array,
+    expected: element,
+    message,
+  });
+},
 
 setApplication(Application.create(config.APP));
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -19,3 +19,13 @@ declare module 'yup' {
     curie(options?: CurieOptions): this;
   }
 }
+
+declare global {
+  interface Assert {
+    deepArrayContains(
+      array: unknown[],
+      element: unknown,
+      message?: string,
+    ): void;
+  }
+}


### PR DESCRIPTION
### Overview
This PR includes the following changes:
- Addition of a `deepArrayContains` extension to qunit-assert
- Modifications to the `rdfa-parsing` unit tests to ensure these run

##### connected issues and PRs:
None

### How to test/reproduce
- Observe that all tests succeed (especially the `rdfa-parsing` tests)

### Challenges/uncertainties
While (if strictly following their interfaces) the objects/subjects of node properties/backlinks should follow the `RDF.Term` interfaces, they currently do not. It is currently not possible to deep compare NamedNodes constructed by `sayDataFactory.namedNode` and objects present in properties/backlinks.
The objects/subjects of properties/backlinks lack the `equals` method. This is due to `JSON.parse` and `JSON.serialize`.

Possible solution to this problem:
- When calling `JSON.parse` when parsing incoming-triples/outgoing-triples, we could configure it to recreate `RDF.Term` objects (literals, namednodes etc.)
- Find another way to pass the incoming-triples/outgoing-triples than using JSON serialization.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
