### PR TITLE
Add helper to export HTML document and add debug tool to unstyled export

### DIFF
--- a/.changeset/spicy-meals-promise.md
+++ b/.changeset/spicy-meals-promise.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Expose helper method to export document as a HTML page

--- a/addon/components/debug-tools.hbs
+++ b/addon/components/debug-tools.hbs
@@ -1,10 +1,12 @@
 <div {{this.setUpListeners}}>
-  <p>
-    <button type="button" {{on "click" this.showExportPreview}}>Show Export
-      Preview</button>
-  </p>
+  <button type="button" {{on "click" this.showStyledExportPreview}}>
+    Show Styled Export
+  </button>
+  <button type="button" {{on "click" this.showRawExportPreview}}>
+    Show Raw Export
+  </button>
   {{#if @controller}}
-    <p>Sample data:
+    <span>Sample data:
       <button
         type="button"
         {{on "click" (fn this.setEditorContent "")}}
@@ -22,7 +24,7 @@
         >{{name}}</button>
         |
       {{/each-in}}
-    </p>
+    </span>
   {{else}}
     Waiting for editor init
   {{/if}}

--- a/addon/components/debug-tools.ts
+++ b/addon/components/debug-tools.ts
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import sampleData from '../config/sample-data';
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import { modifier } from 'ember-modifier';
+import { generatePageForExport } from '@lblod/ember-rdfa-editor/utils/export-utils';
 
 interface DebugToolArgs {
   controller?: SayController;
@@ -54,42 +55,18 @@ export default class RdfaEditorDebugTools extends Component<DebugToolArgs> {
   }
 
   @action
-  showExportPreview() {
+  showStyledExportPreview() {
     const wnd = window.open('about:blank', '', '_blank');
+    if (this.controller && wnd) {
+      wnd.document.write(generatePageForExport(this.controller, true));
+    }
+  }
 
-    if (wnd) {
-      const parser = new DOMParser();
-      const basicDocument = parser.parseFromString(
-        '<html><head></head><body class="say-content"></body></html>',
-        'text/html',
-      );
-
-      const styleSheets = Array.from(document.styleSheets);
-
-      styleSheets.forEach((styleSheet) => {
-        if (styleSheet.href) {
-          const linkElement = basicDocument.createElement('link');
-
-          linkElement.rel = 'stylesheet';
-          linkElement.href = styleSheet.href;
-          linkElement.type = 'text/css';
-
-          basicDocument.head.appendChild(linkElement);
-        }
-      });
-
-      const contentDocument = parser.parseFromString(
-        this.controller?.htmlContent || '',
-        'text/html',
-      );
-
-      if (contentDocument.body.firstChild) {
-        basicDocument.body.appendChild(contentDocument.body.firstChild);
-      }
-
-      wnd.document.write(
-        '<!DOCTYPE html>' + basicDocument.documentElement.outerHTML,
-      );
+  @action
+  showRawExportPreview() {
+    const wnd = window.open('about:blank', '', '_blank');
+    if (this.controller && wnd) {
+      wnd.document.write(generatePageForExport(this.controller, false));
     }
   }
 

--- a/addon/components/plugins/html-editor/modal.hbs
+++ b/addon/components/plugins/html-editor/modal.hbs
@@ -5,6 +5,7 @@
   @closeModal={{this.cancel}}
   @modalOpen={{true}}
   @size="large"
+  @padding="none"
 >
   <:title>{{t "ember-rdfa-editor.html-editor.modal.title"}}</:title>
   <:body>

--- a/addon/utils/export-utils.ts
+++ b/addon/utils/export-utils.ts
@@ -1,0 +1,38 @@
+import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
+
+export function generatePageForExport(
+  controller: SayController,
+  includeStyles: boolean,
+) {
+  const parser = new DOMParser();
+  const basicDocument = parser.parseFromString(
+    '<html><head></head><body class="say-content"></body></html>',
+    'text/html',
+  );
+
+  if (includeStyles) {
+    const styleSheets = Array.from(document.styleSheets);
+    styleSheets.forEach((styleSheet) => {
+      if (styleSheet.href) {
+        const linkElement = basicDocument.createElement('link');
+
+        linkElement.rel = 'stylesheet';
+        linkElement.href = styleSheet.href;
+        linkElement.type = 'text/css';
+
+        basicDocument.head.appendChild(linkElement);
+      }
+    });
+  }
+
+  const contentDocument = parser.parseFromString(
+    controller?.htmlContent || '',
+    'text/html',
+  );
+
+  if (contentDocument.body.firstChild) {
+    basicDocument.body.appendChild(contentDocument.body.firstChild);
+  }
+
+  return '<!DOCTYPE html>' + basicDocument.documentElement.outerHTML;
+}


### PR DESCRIPTION
### Overview
Changes to support easier debugging of embeddable.

##### connected issues and PRs:
https://github.com/lblod/frontend-embeddable-notule-editor/issues/238

### Setup
N/A

### How to test/reproduce
In the dummy app look at the results of the 'Show Styled Export' and 'Show Raw Export' buttons.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
