### PR TITLE
fix: make sure to update editor ref in cached serializer

### DIFF
--- a/.changeset/green-dogs-lay.md
+++ b/.changeset/green-dogs-lay.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+make sure to update editor ref in cached serializer

--- a/addon/core/say-serializer.ts
+++ b/addon/core/say-serializer.ts
@@ -123,7 +123,7 @@ export default class SaySerializer extends DOMSerializer {
           editor,
         );
       }
-      return schema.cached.saySerializer;
+      return schema.cached.saySerializer as SaySerializer;
     } else {
       return (
         (schema.cached.domSerializer as DOMSerializer) ||

--- a/addon/core/say-serializer.ts
+++ b/addon/core/say-serializer.ts
@@ -56,6 +56,7 @@ export default class SaySerializer extends DOMSerializer {
     [node: string]: NodeSerializer;
   };
   declare marks: { [mark: string]: MarkSerializer };
+  editor: SayEditor;
 
   constructor(
     /// The node serialization functions.
@@ -64,9 +65,10 @@ export default class SaySerializer extends DOMSerializer {
     },
     /// The mark serialization functions.
     marks: { [mark: string]: MarkSerializer },
-    readonly editor: SayEditor,
+    editor: SayEditor,
   ) {
     super(nodes, marks);
+    this.editor = editor;
   }
 
   get state() {
@@ -112,14 +114,16 @@ export default class SaySerializer extends DOMSerializer {
   static fromSchema(schema: Schema, editor: SayEditor): SaySerializer;
   static fromSchema(schema: Schema, editor?: SayEditor): DOMSerializer {
     if (editor) {
-      return (
-        (schema.cached.saySerializer as SaySerializer) ||
-        (schema.cached.saySerializer = new SaySerializer(
+      if (schema.cached.saySerializer) {
+        (schema.cached.saySerializer as SaySerializer).editor = editor;
+      } else {
+        schema.cached.saySerializer = new SaySerializer(
           SaySerializer.nodesFromSchema(schema),
           SaySerializer.marksFromSchema(schema),
           editor,
-        ))
-      );
+        );
+      }
+      return schema.cached.saySerializer;
     } else {
       return (
         (schema.cached.domSerializer as DOMSerializer) ||


### PR DESCRIPTION
-------

### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->
We cache the serializer in the schema for performance, but when we make a new editor instance
we need to make sure that the reference to the editor is updated.

When initializing the
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

https://github.com/lblod/frontend-gelinkt-notuleren/issues/632

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
relationships)
- [x] changelog
- [x] npm lint
