### PR TITLE
Drop RDFa support from tables

### DIFF
--- a/addon/plugins/table/nodes/table.ts
+++ b/addon/plugins/table/nodes/table.ts
@@ -1,14 +1,3 @@
-// Helper for creating a schema that supports tables.
-import {
-  type RdfaAttrs,
-  getRdfaAttrs,
-  renderInvisibleRdfa,
-  renderRdfaAttrs,
-  renderRdfaAware,
-  getRdfaContentElement,
-  rdfaAttrSpec,
-} from '@lblod/ember-rdfa-editor/core/schema';
-
 import { Node as PNode, type NodeSpec, ResolvedPos } from 'prosemirror-model';
 import { TableView } from '@lblod/ember-rdfa-editor/plugins/table';
 import type SayNodeSpec from '@lblod/ember-rdfa-editor/core/say-node-spec';
@@ -46,7 +35,6 @@ const fixupColWidth = (number: string) => {
 function getCellAttrs(
   dom: HTMLElement,
   extraAttrs: Record<string, ExtraAttribute>,
-  rdfaAware: boolean,
 ): CellAttributes {
   const widthAttr = dom.getAttribute('data-colwidth');
 
@@ -70,14 +58,10 @@ function getCellAttrs(
       result[key] = value;
     }
   }
-  return { ...getRdfaAttrs(dom, { rdfaAware }), ...result };
+  return result;
 }
 
-function setCellAttrs(
-  node: PNode,
-  extraAttrs: Record<string, ExtraAttribute>,
-  useClassicRdfa: boolean,
-) {
+function setCellAttrs(node: PNode, extraAttrs: Record<string, ExtraAttribute>) {
   const attrs: CellAttributes = {};
   if (Number(node.attrs['colspan']) !== 1) {
     attrs.colspan = node.attrs['colspan'] as number;
@@ -92,12 +76,6 @@ function setCellAttrs(
     const setter = attr.setDOMAttr;
     if (setter) {
       setter(node.attrs[key], attrs);
-    }
-  }
-  if (useClassicRdfa) {
-    // The node is still using classic RDFa attributes, set them here
-    for (const key of Object.keys(rdfaAttrSpec({ rdfaAware: false }))) {
-      attrs[key] = node.attrs[key];
     }
   }
 
@@ -119,7 +97,6 @@ interface TableNodeOptions {
     style?: string;
     color: string;
   };
-  rdfaAware?: boolean;
   rowBackground?: {
     even?: string;
     odd?: string;
@@ -191,7 +168,6 @@ const getDefaultCellAttributes = ({
 });
 
 export function tableNodes(options: TableNodeOptions): TableNodes {
-  const rdfaAware = options.rdfaAware ?? false;
   const inlineBorderStyle =
     options.inlineBorderStyle &&
     `${options.inlineBorderStyle.width} ${options.inlineBorderStyle.style || 'solid'} ${options.inlineBorderStyle.color}`;
@@ -229,15 +205,9 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
       content: 'table_row+',
       tableRole: 'table',
       isolating: true,
-      get attrs() {
-        const baseAttrs = {
-          class: { default: 'say-table' },
-          style: { default: tableStyle },
-        };
-        return {
-          ...rdfaAttrSpec({ rdfaAware }),
-          ...baseAttrs,
-        };
+      attrs: {
+        class: { default: 'say-table' },
+        style: { default: tableStyle },
       },
       group: options.tableGroup,
       allowGapCursor: false,
@@ -248,35 +218,20 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
             if (typeof node === 'string') {
               return false;
             }
-            return { ...getRdfaAttrs(node, { rdfaAware }) };
+            return null;
           },
-          contentElement: getRdfaContentElement,
         },
       ],
       toDOM(node: PNode) {
-        if (rdfaAware) {
-          return [
-            'table',
-            {
-              ...renderRdfaAttrs(node.attrs as RdfaAttrs),
-              class: 'say-table',
-              style: constructInlineStyles(tableStyle),
-            },
-            renderInvisibleRdfa(node, 'div'),
-            ['tbody', { 'data-content-container': true }, 0],
-          ];
-        } else {
-          return [
-            'table',
-            {
-              ...node.attrs,
-              class: 'say-table',
-
-              style: constructInlineStyles(tableStyle),
-            },
-            ['tbody', 0],
-          ];
-        }
+        return [
+          'table',
+          {
+            ...node.attrs,
+            class: 'say-table',
+            style: constructInlineStyles(tableStyle),
+          },
+          ['tbody', 0],
+        ];
       },
       serialize(node: PNode) {
         const tableView = new TableView(node, 25);
@@ -286,36 +241,21 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
           '--say-even-row-background': undefined,
           '--say-odd-row-background': undefined,
         };
-        if (rdfaAware) {
-          return [
-            'table',
-            {
-              ...renderRdfaAttrs(node.attrs as RdfaAttrs),
-              class: 'say-table',
-              style: constructInlineStyles(style),
-            },
-            tableView.colgroupElement,
-            renderInvisibleRdfa(node, 'div'),
-            ['tbody', { 'data-content-container': true }, 0],
-          ];
-        } else {
-          return [
-            'table',
-            {
-              ...node.attrs,
-              class: 'say-table',
-              style: constructInlineStyles(style),
-            },
-            tableView.colgroupElement,
-            ['tbody', 0],
-          ];
-        }
+        return [
+          'table',
+          {
+            ...node.attrs,
+            class: 'say-table',
+            style: constructInlineStyles(style),
+          },
+          tableView.colgroupElement,
+          ['tbody', 0],
+        ];
       },
     },
     table_row: {
       content: '(table_cell | table_header)*',
       tableRole: 'row',
-      attrs: rdfaAttrSpec({ rdfaAware }),
       allowGapCursor: false,
       parseDOM: [
         {
@@ -324,9 +264,8 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
             if (typeof node === 'string') {
               return false;
             }
-            return { ...getRdfaAttrs(node, { rdfaAware }) };
+            return null;
           },
-          contentElement: getRdfaContentElement,
         },
       ],
       serialize(node, state) {
@@ -339,33 +278,15 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
             ? options.rowBackground?.even
             : options.rowBackground?.odd,
         };
-        return [
-          'tr',
-          { ...node.attrs, style: constructInlineStyles(style) },
-          0,
-        ];
+        return ['tr', { style: constructInlineStyles(style) }, 0];
       },
-      toDOM(node: PNode) {
-        if (rdfaAware) {
-          return renderRdfaAware({
-            renderable: node,
-            tag: 'tr',
-            attrs: {
-              style: constructInlineStyles(rowStyle),
-            },
-            content: 0,
-          });
-        } else {
-          return ['tr', { ...node.attrs, style: rowStyle }, 0];
-        }
+      toDOM() {
+        return ['tr', { style: constructInlineStyles(rowStyle) }, 0];
       },
     },
     table_cell: {
       content: options.cellContent,
-      attrs: {
-        ...rdfaAttrSpec({ rdfaAware }),
-        ...cellAttrs,
-      },
+      attrs: cellAttrs,
       tableRole: 'cell',
       isolating: true,
       allowGapCursor: false,
@@ -376,35 +297,17 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
             if (typeof dom === 'string') {
               return false;
             }
-            const cellAttrs = getCellAttrs(dom, extraCellAttributes, rdfaAware);
-            return {
-              ...getRdfaAttrs(dom, { rdfaAware }),
-              ...cellAttrs,
-            };
+            return getCellAttrs(dom, extraCellAttributes);
           },
-          contentElement: getRdfaContentElement,
         },
       ],
       toDOM(node) {
-        const cellAttrs = setCellAttrs(node, extraCellAttributes, !rdfaAware);
-        if (rdfaAware) {
-          return renderRdfaAware({
-            renderable: node,
-            tag: 'td',
-            attrs: { ...cellAttrs },
-            content: 0,
-          });
-        } else {
-          return ['td', { ...cellAttrs }, 0];
-        }
+        return ['td', setCellAttrs(node, extraCellAttributes), 0];
       },
     },
     table_header: {
       content: options.cellContent,
-      attrs: {
-        ...rdfaAttrSpec({ rdfaAware }),
-        ...cellAttrs,
-      },
+      attrs: cellAttrs,
       tableRole: 'header_cell',
       isolating: true,
       parseDOM: [
@@ -414,27 +317,12 @@ export function tableNodes(options: TableNodeOptions): TableNodes {
             if (typeof dom === 'string') {
               return false;
             }
-            const cellAttrs = getCellAttrs(dom, extraCellAttributes, rdfaAware);
-            return {
-              ...getRdfaAttrs(dom, { rdfaAware }),
-              ...cellAttrs,
-            };
+            return getCellAttrs(dom, extraCellAttributes);
           },
-          contentElement: getRdfaContentElement,
         },
       ],
       toDOM(node) {
-        const cellAttrs = setCellAttrs(node, extraCellAttributes, !rdfaAware);
-        if (rdfaAware) {
-          return renderRdfaAware({
-            renderable: node,
-            tag: 'th',
-            attrs: { ...cellAttrs },
-            content: 0,
-          });
-        } else {
-          return ['th', { ...cellAttrs }, 0];
-        }
+        return ['th', setCellAttrs(node, extraCellAttributes), 0];
       },
     },
   };

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -99,7 +99,6 @@ export default class EditableBlockController extends Controller {
         tableGroup: 'block',
         cellContent: 'block+',
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
-        rdfaAware: true,
       }),
       heading: headingWithConfig({ rdfaAware: true }),
       blockquote,

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -80,7 +80,6 @@ const nodes = {
   ...tableNodes({
     tableGroup: 'block',
     cellContent: 'inline*',
-    rdfaAware: true,
   }),
   heading: headingWithConfig({ rdfaAware: true }),
   blockquote,

--- a/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -85,7 +85,6 @@ const schema = new Schema({
     ...tableNodes({
       tableGroup: 'block',
       cellContent: 'block+',
-      rdfaAware: true,
     }),
     heading: headingWithConfig({ rdfaAware: true }),
     blockquote,

--- a/tests/utils/editor.ts
+++ b/tests/utils/editor.ts
@@ -74,7 +74,6 @@ export const SAMPLE_SCHEMA = new Schema({
     ...tableNodes({
       tableGroup: 'block',
       cellContent: 'block+',
-      rdfaAware: true,
     }),
     heading: headingWithConfig({ rdfaAware: true }),
     blockquote,


### PR DESCRIPTION
### Overview
This PR drops RDFa support from tables, as it is currently not reasonably possible to support them with the `rdfaAware` system.
We currently cannot support `rdfaAware` tables as tables (and table-rows) do not allow div children (or any other children aside from table-specific children). This means we do not have a proper way to store their RDFa.

### How to test/reproduce
- Start up the dummy app
- Visit the 'editable nodes' page
- Insert a table.
- Notice that the table is rendered correctly and that all resizing features work as expected.
- Notice that the table does not contain any RDFa related properties/features

### Challenges/uncertainties
This PR also support classic RDFa support from tables. Unsure if we need to keep that. It makes this PR technically breaking.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [ ] no new deprecations
