### PR TITLE
ci(woodpecker): improved detection of prerelease tags in release pipeline

### DIFF
--- a/.changeset/fair-stingrays-float.md
+++ b/.changeset/fair-stingrays-float.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Release to npm with tag `next` if the semantic version qualifier is equal to `next`

--- a/.changeset/good-fishes-breathe.md
+++ b/.changeset/good-fishes-breathe.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Do not perform a stable release when tag contains semantic version qualifier (used for prereleases)

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -4,11 +4,23 @@ steps:
     commands:
       - corepack enable
       - pnpm i --frozen-lockfile
+  release-next:
+    image: plugins/npm
+    settings:
+      token:
+        from_secret: npm_access_token
+      tag: next
+    when:
+      ref:
+        include: refs/tags/*-next.*
   release:
     image: plugins/npm
     settings:
       token:
         from_secret: npm_access_token
+    when:
+      ref:
+        exclude: refs/tags/*-*
   push-tagged-build:
     image: plugins/docker
     settings:


### PR DESCRIPTION
### Overview
This PR contains improved detection of prerelease tags in the release pipeline:
- Only perform a stable release if git tag does not contain a pre-release suffix (e.g. `-alpha`, `-dev`, `-next`)
- Perform an npm release with tag `next` if qualifier part of pre-release suffix is equal to `next`

### Challenges/uncertainties
I tried to generically extract the qualifier from the pre-release suffix based on the `CI_COMMIT_TAG` env var and string substitutions (https://woodpecker-ci.org/docs/usage/environment#string-substitution), but was unable to make it work. Apparently woodpecker does not support nested substitutions (remove both prefix and suffix from strings). Ideas to make this work are very welcome :)
I now limited it to the `next` qualifier.
