### PR TITLE
Remove cache from SaySerializer fromSchema method

### DIFF
--- a/.changeset/wet-cats-compete.md
+++ b/.changeset/wet-cats-compete.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Remove caching of SaySerializer

--- a/addon/core/say-serializer.ts
+++ b/addon/core/say-serializer.ts
@@ -110,22 +110,20 @@ export default class SaySerializer extends DOMSerializer {
    * If an instance of `SayEditor` is provided to this method, an instance of `SaySerializer` is returned.
    * Otherwise an instance of the default `DOMSerializer` is returned.
    * `SaySerializer` needs an instance of `SayEditor` to properly work.
+   * NOTE: the behaviour of this differs from `DOMSerializer` as the ProseMirror version caches the
+   * serializer, whereas we do not.
    */
   static fromSchema(schema: Schema): DOMSerializer;
   static fromSchema(schema: Schema, editor: SayEditor): SaySerializer;
   static fromSchema(schema: Schema, editor?: SayEditor): DOMSerializer {
     if (editor) {
-      if (schema.cached['saySerializer']) {
-        (schema.cached['saySerializer'] as SaySerializer).editor = editor;
-      } else {
-        schema.cached['saySerializer'] = new SaySerializer(
-          SaySerializer.nodesFromSchema(schema, editor),
-          SaySerializer.marksFromSchema(schema, editor),
-          editor,
-        );
-      }
-      return schema.cached['saySerializer'] as SaySerializer;
+      return new SaySerializer(
+        SaySerializer.nodesFromSchema(schema, editor),
+        SaySerializer.marksFromSchema(schema, editor),
+        editor,
+      );
     } else {
+      // Use the cached stock `DOMSerializer` to mimic ProseMirror code
       return (
         (schema.cached['domSerializer'] as DOMSerializer) ||
         (schema.cached['domSerializer'] = new DOMSerializer(


### PR DESCRIPTION
### Overview
It seems that #1177 wasn't sufficient to prevent errors when the `serialize(node, state)` method of a NodeSpec is called with a `state` argument. This removes the caching completely.

##### connected issues and PRs:
https://github.com/lblod/frontend-gelinkt-notuleren/issues/632

### Setup
Easiest to reproduce in the 'latest editor' branch of [GN](https://github.com/lblod/frontend-gelinkt-notuleren/pull/636) or [RB](https://github.com/lblod/frontend-reglementaire-bijlage/pull/230). The build for this branch is `9.6.0-next.0-dev.61a9941227b251d147a4f081ef7e26e99f5a76ce`

### How to test/reproduce
In GN or RB, create a document containing a table with content. Save the document, modify the table content, then save again. The changes should save rather than error.

### Challenges/uncertainties
It's very difficult to see where the cached version causes problems.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
