### PR TITLE
Fix regression in parsing logic of `docWithConfig`

### DIFF
--- a/.changeset/beige-coins-add.md
+++ b/.changeset/beige-coins-add.md
@@ -1,0 +1,7 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Fix regression in parsing logic of `extraAttributes` of `doc` node-spec.
+This regression was introduced in version [9.6.0](https://github.com/lblod/ember-rdfa-editor/releases/tag/v9.6.0).
+This fix ensures that the `extraAttributes` are now once again correctly parsed when loading a document.

--- a/addon/nodes/doc.ts
+++ b/addon/nodes/doc.ts
@@ -48,13 +48,19 @@ export const docWithConfig = ({
             return false;
           }
           if (node.dataset['sayDocument']) {
+            const extraAttrs: Record<string, unknown> = {};
+            Object.keys(extraAttributes).forEach((attr) => {
+              extraAttrs[attr] = node.getAttribute(attr);
+            });
             if (rdfaAware) {
               return {
+                ...extraAttrs,
                 lang: node.getAttribute('lang'),
                 ...getRdfaAttrs(node, { rdfaAware: true }),
               };
             } else {
               return {
+                ...extraAttrs,
                 lang: node.getAttribute('lang'),
               };
             }


### PR DESCRIPTION
### Overview
This PR fixes a regression in parsing logic of `extraAttributes` of `doc` node-spec.
This regression was introduced in version [9.6.0](https://github.com/lblod/ember-rdfa-editor/releases/tag/v9.6.0).
This fix ensures that the `extraAttributes` are now once again correctly parsed when loading a document.

##### connected issues and PRs:
None

### How to test/reproduce
You can test the solution of this regression in combination with the plugins/frontend-RB.
This PR should ensure the snippet-ids for a template are correctly loaded. 
The `data-snippet-list-ids` attribute should correctly be taken into account when loading a template.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
