### PR TITLE
Fix doc content container and rdfa context parsing

### DIFF
--- a/.changeset/curly-hairs-grin.md
+++ b/.changeset/curly-hairs-grin.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Parse full doc context when parsing rdfa

--- a/.changeset/weak-berries-fix.md
+++ b/.changeset/weak-berries-fix.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Fix doc-node content container parsing

--- a/addon/commands/insert-html-command.ts
+++ b/addon/commands/insert-html-command.ts
@@ -1,5 +1,8 @@
 import type { Command } from 'prosemirror-state';
-import { isTextNode } from '@lblod/ember-rdfa-editor/utils/_private/dom-helpers';
+import {
+  getPathFromRoot,
+  isTextNode,
+} from '@lblod/ember-rdfa-editor/utils/_private/dom-helpers';
 import { DOMParser as ProseParser, Fragment, Mark } from 'prosemirror-model';
 import { normalToPreWrapWhiteSpace } from '@lblod/ember-rdfa-editor/utils/_private/whitespace-collapsing';
 import { preprocessRDFa } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
@@ -26,7 +29,10 @@ export function insertHtml(
         cleanUpNode(htmlNode);
       }
       if (shouldPreprocessRdfa) {
-        preprocessRDFa('body' in htmlNode ? htmlNode.body : htmlNode);
+        preprocessRDFa(
+          'body' in htmlNode ? htmlNode.body : htmlNode,
+          view ? getPathFromRoot(view.dom, false) : [],
+        );
       }
       let fragment = ProseParser.fromSchema(state.schema).parseSlice(htmlNode, {
         preserveWhitespace,

--- a/addon/core/rdfa-processor.ts
+++ b/addon/core/rdfa-processor.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import {
+  getPathFromRoot,
   isElement,
   isTextNode,
   tagName,
@@ -79,7 +80,7 @@ export type IncomingTriple =
  * Function responsible for computing the properties and backlinks of a given document.
  * The properties and backlinks are stored in data-attributes in the nodes themselves.
  */
-export function preprocessRDFa(dom: Node) {
+export function preprocessRDFa(dom: Node, pathFromRoot: Node[]) {
   // parse the html
   const datastore = EditorStore.fromParse<Node>({
     parseRoot: true,
@@ -100,7 +101,7 @@ export function preprocessRDFa(dom: Node) {
     children(node: Node): Iterable<Node> {
       return node.childNodes;
     },
-    pathFromDomRoot: [],
+    pathFromDomRoot: pathFromRoot,
     textContent(node: Node): string {
       return node.textContent || '';
     },

--- a/addon/core/rdfa-processor.ts
+++ b/addon/core/rdfa-processor.ts
@@ -1,6 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 import {
-  getPathFromRoot,
   isElement,
   isTextNode,
   tagName,

--- a/addon/nodes/doc.ts
+++ b/addon/nodes/doc.ts
@@ -1,6 +1,11 @@
 import type SayNodeSpec from '../core/say-node-spec';
 import { isElement } from '../utils/_private/dom-helpers';
-import { getRdfaAttrs, rdfaAttrSpec, renderRdfaAware } from '../core/schema';
+import {
+  getRdfaAttrs,
+  getRdfaContentElement,
+  rdfaAttrSpec,
+  renderRdfaAware,
+} from '../core/schema';
 import type { AttributeSpec } from 'prosemirror-model';
 
 interface DocumentConfig {
@@ -72,9 +77,10 @@ export const docWithConfig = ({
           if (!isElement(node)) {
             throw new Error('node is not an element');
           }
-          const result: HTMLElement =
-            node.querySelector('[data-content-container="true"]') ?? node;
-          return result;
+          if (rdfaAware) {
+            return getRdfaContentElement(node);
+          }
+          return node;
         },
       },
     ],

--- a/addon/utils/_private/html-utils.ts
+++ b/addon/utils/_private/html-utils.ts
@@ -2,7 +2,7 @@ import { PNode, ProseParser } from '@lblod/ember-rdfa-editor';
 import { preprocessRDFa } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import type { Attrs, Schema } from 'prosemirror-model';
 import HTMLInputParser from './html-input-parser';
-import { tagName } from './dom-helpers';
+import { getPathFromRoot, tagName } from './dom-helpers';
 import { EditorView } from 'prosemirror-view';
 import type { HEADING_ELEMENTS } from './constants';
 
@@ -15,7 +15,7 @@ export function htmlToDoc(
   const cleanedHTML = htmlCleaner.prepareHTML(html);
   const domParser = new DOMParser();
   const parsed = domParser.parseFromString(cleanedHTML, 'text/html').body;
-  preprocessRDFa(parsed);
+  preprocessRDFa(parsed, getPathFromRoot(options.editorView.dom, false));
   const topNodeMatch = matchTopNode(parsed, { schema: options.schema });
   let doc: PNode;
   if (topNodeMatch) {
@@ -39,7 +39,7 @@ export function htmlToFragment(
   const cleanedHTML = htmlCleaner.prepareHTML(html);
   const domParser = new DOMParser();
   const parsed = domParser.parseFromString(cleanedHTML, 'text/html').body;
-  preprocessRDFa(parsed);
+  preprocessRDFa(parsed, getPathFromRoot(editorView.dom, false));
   return parser.parseSlice(parsed, { preserveWhitespace: true });
 }
 


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

2 small fixes:
- the doc node's contentElement search was too aggressive, because it used queryselector, it would find other nodes' contentContainer if the docnode itself was not rdfaAware but other nodes were.
- take the path to document root into account everywhere we parse rdfa, so the parser is aware of all the defined prefixes and context

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations