### PR TITLE
Improve wrapping of list nodes with RDFa

### DIFF
--- a/.changeset/hip-parrots-shout.md
+++ b/.changeset/hip-parrots-shout.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Better handle wrapping with RDFa blocks for nested node structures

--- a/.changeset/orange-icons-search.md
+++ b/.changeset/orange-icons-search.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Improve scoping of findRdfaIdsInSelection rdfa-util

--- a/.changeset/proud-beans-sleep.md
+++ b/.changeset/proud-beans-sleep.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": minor
+---
+
+Make lists no longer RDFa aware

--- a/addon/commands/_private/rdfa-commands/wrap-literal.ts
+++ b/addon/commands/_private/rdfa-commands/wrap-literal.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'prosemirror-state';
-import { wrapIn } from 'prosemirror-commands';
 import { v4 as uuidv4 } from 'uuid';
+import { wrapIncludingParents } from '@lblod/ember-rdfa-editor/commands';
 import { findRdfaIdsInSelection } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
 
 export function wrapLiteral(): Command {
@@ -15,10 +15,13 @@ export function wrapLiteral(): Command {
 
     if (dispatch) {
       const objectId = uuidv4();
-      const wrapStatus = wrapIn(state.schema.nodes['block_rdfa'], {
-        __rdfaId: objectId,
-        rdfaNodeType: 'literal',
-      })(state, dispatch);
+      const wrapStatus = wrapIncludingParents(
+        state.schema.nodes['block_rdfa'],
+        {
+          __rdfaId: objectId,
+          rdfaNodeType: 'literal',
+        },
+      )(state, dispatch);
 
       return wrapStatus;
     }

--- a/addon/commands/_private/rdfa-commands/wrap-resource.ts
+++ b/addon/commands/_private/rdfa-commands/wrap-resource.ts
@@ -1,7 +1,7 @@
 import { addProperty } from '../../rdfa-commands/add-property';
 import type { Command } from 'prosemirror-state';
-import { wrapIn } from 'prosemirror-commands';
 import { v4 as uuidv4 } from 'uuid';
+import { wrapIncludingParents } from '@lblod/ember-rdfa-editor/commands';
 import {
   findNodeByRdfaId,
   generateNewUri,
@@ -18,11 +18,11 @@ export function wrapResource(
       rdfaNodeType: 'resource',
       subject: 'another placeholder',
     };
-    const wrapArgs: Parameters<typeof wrapIn> = [
+    const wrapArgs: Parameters<typeof wrapIncludingParents> = [
       state.schema.nodes['block_rdfa'],
       attrs,
     ];
-    if (!wrapIn(...wrapArgs)(state)) {
+    if (!wrapIncludingParents(...wrapArgs)(state)) {
       return false;
     }
     if (dispatch) {
@@ -35,7 +35,7 @@ export function wrapResource(
         attrs.subject = resource;
       }
 
-      const wrapStatus = wrapIn(...wrapArgs)(state, (tr) => {
+      const wrapStatus = wrapIncludingParents(...wrapArgs)(state, (tr) => {
         // pass the state after this transaction to addProperty so the node exists
         let newState = state.apply(tr);
         const createdWrappingNode = findNodeByRdfaId(

--- a/addon/commands/index.ts
+++ b/addon/commands/index.ts
@@ -15,3 +15,4 @@ export { addProperty } from './rdfa-commands/add-property';
 export { removeProperty } from './rdfa-commands/remove-property';
 export { selectNodeBackward } from './select-node-backward';
 export { selectNodeForward } from './select-node-forward';
+export * from './wrap-including-parents';

--- a/addon/commands/wrap-including-parents.ts
+++ b/addon/commands/wrap-including-parents.ts
@@ -1,0 +1,29 @@
+import type { Command } from 'prosemirror-state';
+import type { Attrs, NodeType } from 'prosemirror-model';
+import { findWrapping } from 'prosemirror-transform';
+import { selectParentNode } from 'prosemirror-commands';
+
+/**
+ * Wrap the selection in a node of the given type with the given attributes.
+ * If the selection is unwrappable, try the parent nodes, to wrap e.g. lists.
+ * Adapted from prosemirror-commands wrapIn
+ */
+export function wrapIncludingParents(
+  nodeType: NodeType,
+  attrs: Attrs | null = null,
+): Command {
+  return function (state, dispatch) {
+    const { $from, $to } = state.selection;
+    const range = $from.blockRange($to);
+    const wrapping = range && findWrapping(range, nodeType, attrs);
+    if (wrapping) {
+      if (dispatch) dispatch(state.tr.wrap(range!, wrapping).scrollIntoView());
+      return true;
+    } else {
+      return selectParentNode(state, (tr) => {
+        const newState = state.apply(tr);
+        return wrapIncludingParents(nodeType, attrs)(newState, dispatch);
+      });
+    }
+  };
+}

--- a/addon/commands/wrap-selection.ts
+++ b/addon/commands/wrap-selection.ts
@@ -17,8 +17,10 @@ export function wrapSelection(
         const tr = state.tr;
         const attrs = attrsFromWrapped && attrsFromWrapped();
         tr.insert(from, nodeType.create(attrs));
-        const selection = NodeSelection.create(tr.doc, from);
-        tr.setSelection(selection);
+        if (tr.doc.resolve(from).nodeAfter) {
+          const selection = NodeSelection.create(tr.doc, from);
+          tr.setSelection(selection);
+        }
         dispatch(tr);
       }
       return true;

--- a/addon/utils/_private/rdfa-utils.ts
+++ b/addon/utils/_private/rdfa-utils.ts
@@ -184,13 +184,17 @@ export function findRdfaIdsInSelection(selection: Selection) {
   const result = new Set<string>();
   const range = selection.$from.blockRange(selection.$to);
   if (!range) return result;
-  selection.content().content.descendants((child) => {
-    const id = getRdfaId(child);
-    if (id) {
-      result.add(id);
-    }
-    return true;
-  });
+  // Could use selection.content() here, but this uses doc.slice() internally but with the 'include
+  // parents' flag true, which then includes too much of the document
+  selection.$from.doc
+    .slice(selection.from, selection.to, false)
+    .content.descendants((child) => {
+      const id = getRdfaId(child);
+      if (id) {
+        result.add(id);
+      }
+      return true;
+    });
   return result;
 }
 

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -93,15 +93,12 @@ export default class EditableBlockController extends Controller {
       repaired_block: repairedBlockWithConfig({ rdfaAware: true }),
 
       list_item: listItemWithConfig({
-        rdfaAware: true,
         enableHierarchicalList: true,
       }),
       ordered_list: orderedListWithConfig({
-        rdfaAware: true,
         enableHierarchicalList: true,
       }),
       bullet_list: bulletListWithConfig({
-        rdfaAware: true,
         enableHierarchicalList: true,
       }),
       placeholder,

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -74,9 +74,9 @@ const nodes = {
 
   repaired_block: repairedBlockWithConfig({ rdfaAware: true }),
 
-  list_item: listItemWithConfig({ rdfaAware: true }),
-  ordered_list: orderedListWithConfig({ rdfaAware: true }),
-  bullet_list: bulletListWithConfig({ rdfaAware: true }),
+  list_item: listItemWithConfig(),
+  ordered_list: orderedListWithConfig(),
+  bullet_list: bulletListWithConfig(),
   ...tableNodes({
     tableGroup: 'block',
     cellContent: 'inline*',

--- a/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -78,9 +78,9 @@ const schema = new Schema({
 
     repaired_block: repairedBlockWithConfig({ rdfaAware: true }),
 
-    list_item: listItemWithConfig({ rdfaAware: true }),
-    ordered_list: orderedListWithConfig({ rdfaAware: true }),
-    bullet_list: bulletListWithConfig({ rdfaAware: true }),
+    list_item: listItemWithConfig(),
+    ordered_list: orderedListWithConfig(),
+    bullet_list: bulletListWithConfig(),
     placeholder,
     ...tableNodes({
       tableGroup: 'block',

--- a/tests/utils/editor.ts
+++ b/tests/utils/editor.ts
@@ -67,9 +67,9 @@ export const SAMPLE_SCHEMA = new Schema({
 
     repaired_block: repairedBlockWithConfig({ rdfaAware: true }),
 
-    list_item: listItemWithConfig({ rdfaAware: true }),
-    ordered_list: orderedListWithConfig({ rdfaAware: true }),
-    bullet_list: bulletListWithConfig({ rdfaAware: true }),
+    list_item: listItemWithConfig(),
+    ordered_list: orderedListWithConfig(),
+    bullet_list: bulletListWithConfig(),
     placeholder,
     ...tableNodes({
       tableGroup: 'block',


### PR DESCRIPTION
### Overview
A slightly weird collection of tweaks and fixes. Makes list nodespecs no longer RDFa aware, prevents finding of RDFa child nodes from including the parent and adds a command which immitates `wrapIn` but goes up by parent nodes to find something that can be wrapped.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4797

### Setup
N/A

### How to test/reproduce
Create arbitrary list nodes and tables and verify that the 'wrap with block literal' and 'wrap with block resource' buttons work in a way that at least makes sense to Prosemirror.

### Challenges/uncertainties
It seems that this kind of behaviour isn't well defined within prosemirror itself and there are many functions with documentation that says things like 'find a set of wrapping nodes that would allow a node of the given type to appear' but that don't handle nodes with very specific children (such as bullet_list) well as they don't include anything that necessarily already exists in the document.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
