### PR TITLE
Add ember-modifier 4.x to peer deps. Tested on 4.0 and 4.1.

### DIFF
--- a/.changeset/hot-items-allow.md
+++ b/.changeset/hot-items-allow.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Correct peer-dependency range of ember-modifier to include 4.x

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "ember-changeset": "^4.1.2",
     "ember-cli-sass": "^11.0.1",
     "ember-intl": "^5.7.2 || ^6.1.0",
-    "ember-modifier": "^3.2.7",
+    "ember-modifier": "^3.2.7 || ^4.0.0",
     "ember-source": "^4.12.0"
   },
   "overrides": {


### PR DESCRIPTION
### Overview
Works fine on 4.0 and 4.1. Doesn't change it here, so we keep on the lowest supported, but allows for upgrade elsewhere.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Change the dep version to something 4.x and check that everything works (especially the toolbar as it uses a lot of modifiers).

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
