### PR TITLE
Fix crash from initially undefined controller

### DIFF
--- a/.changeset/clever-cougars-help.md
+++ b/.changeset/clever-cougars-help.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Fix crash in sample-toolbar-responsive when controller is initially undefined

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
 node_modules
 declarations
+dist
 .eslintcache
+test-results
+playwright-report
+blob-report
+playwright/.cache

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "ember-focus-trap": "^1.1.0",
     "ember-template-imports": "^3.4.2",
     "ember-truth-helpers": "^3.0.0",
-    "ember-velcro": "^2.1.0",
+    "ember-velcro": "^2.2.0",
     "handlebars": "^4.7.7",
     "handlebars-loader": "^1.7.2",
     "iter-tools": "^7.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ dependencies:
     specifier: ^3.0.0
     version: 3.1.1
   ember-velcro:
-    specifier: ^2.1.0
-    version: 2.1.3(ember-modifier@3.2.7)(ember-source@4.12.0)
+    specifier: ^2.2.0
+    version: 2.2.0(ember-modifier@3.2.7)(ember-source@4.12.0)
   handlebars:
     specifier: ^4.7.7
     version: 4.7.8
@@ -8398,8 +8398,8 @@ packages:
       - supports-color
     dev: true
 
-  /ember-velcro@2.1.3(ember-modifier@3.2.7)(ember-source@4.12.0):
-    resolution: {integrity: sha512-4V6rT9b9XSeMaPmiYYA2hIhfMD088vru6AvfGWBY7L1w/st5hYv6iIfamy9+W1l9xKvIH3Hcl8+B0637/SRmzQ==}
+  /ember-velcro@2.2.0(ember-modifier@3.2.7)(ember-source@4.12.0):
+    resolution: {integrity: sha512-+5qVN0xGgr5N+CVEK1cKBGsfUNBfOQrakfz/4qOdE8YYFc0Prlo8ZXs8Je/Juop4OcZTGXMa5QlY/2okMo+X8A==}
     engines: {node: 14.* || >= 16}
     peerDependencies:
       ember-modifier: ^3.2.7 || >= 4.0.0

--- a/tests/dummy/app/components/sample-toolbar-responsive.ts
+++ b/tests/dummy/app/components/sample-toolbar-responsive.ts
@@ -4,12 +4,12 @@ import DocumentInfoPill from '@lblod/ember-rdfa-editor/components/_private/doc-e
 import DocumentLanguagePill from '@lblod/ember-rdfa-editor/components/_private/doc-editor/lang-pill';
 
 interface Args {
-  controller: SayController;
+  controller: SayController | undefined;
 }
 export default class SampleToolbarResponsive extends Component<Args> {
   DocumentLanguagePill = DocumentLanguagePill;
   DocumentInfoPill = DocumentInfoPill;
   get supportsTables() {
-    return this.args.controller.activeEditorState.schema.nodes['table_cell'];
+    return this.args.controller?.activeEditorState.schema.nodes['table_cell'];
   }
 }


### PR DESCRIPTION
### Overview
I'm not sure how this sliipped in, I'm sure I tested the PR before approving it... I threw in an upgrade of ember-velcro as I was doing that when I spotted this. It's in separate commits, so can be split if desired.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
A cold-start of the editor test app no longer crashes.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
