### PR TITLE
Fix issues related to `equals` method defined on RDF term instances

### DIFF
--- a/.changeset/lucky-experts-kneel.md
+++ b/.changeset/lucky-experts-kneel.md
@@ -1,0 +1,11 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Define `equals` as a prototype method on RDF term instances instead of as arrow functions.
+
+**Why is this necessary?**
+Defining `equals` as a prototype method ensures that is not part of the RDF term objects themselves. This makes it easier/less error-prone to compare objects containing these terms. (e.g. the object-comparison library used by prosemirror-tools does not support function properties)
+
+**Possible drawbacks of this approach**
+This approach does have the drawback that spreading an RDF term results in losing the `equals` method.

--- a/addon/core/say-data-factory/blank-node.ts
+++ b/addon/core/say-data-factory/blank-node.ts
@@ -13,9 +13,9 @@ export class SayBlankNode implements RDF.BlankNode {
     this.value = value;
   }
 
-  equals = (other?: Option<SayTerm>) => {
+  equals(other?: Option<SayTerm>) {
     return (
       !!other && other.termType === 'BlankNode' && other.value === this.value
     );
-  };
+  }
 }

--- a/addon/core/say-data-factory/default-graph.ts
+++ b/addon/core/say-data-factory/default-graph.ts
@@ -16,7 +16,7 @@ export class SayDefaultGraph implements RDF.DefaultGraph {
     // Private constructor
   }
 
-  equals = (other?: Option<SayTerm>) => {
+  equals(other?: Option<SayTerm>) {
     return !!other && other.termType === 'DefaultGraph';
-  };
+  }
 }

--- a/addon/core/say-data-factory/literal.ts
+++ b/addon/core/say-data-factory/literal.ts
@@ -37,7 +37,7 @@ export class SayLiteral implements RDF.Literal {
     }
   }
 
-  equals = (other?: Option<SayTerm>) => {
+  equals(other?: Option<SayTerm>) {
     return (
       !!other &&
       other.termType === 'Literal' &&
@@ -45,5 +45,5 @@ export class SayLiteral implements RDF.Literal {
       other.language === this.language &&
       this.datatype.equals(other.datatype)
     );
-  };
+  }
 }

--- a/addon/core/say-data-factory/named-node.ts
+++ b/addon/core/say-data-factory/named-node.ts
@@ -15,9 +15,9 @@ export class SayNamedNode<Iri extends string = string>
     this.value = value;
   }
 
-  equals = (other?: Option<SayTerm>) => {
+  equals(other?: Option<SayTerm>) {
     return (
       !!other && other.termType === 'NamedNode' && other.value === this.value
     );
-  };
+  }
 }

--- a/addon/core/say-data-factory/prosemirror-terms/content-literal.ts
+++ b/addon/core/say-data-factory/prosemirror-terms/content-literal.ts
@@ -33,12 +33,12 @@ export class ContentLiteralTerm {
     }
   }
 
-  equals = (other?: Option<SayTerm>) => {
+  equals(other?: Option<SayTerm>) {
     return (
       !!other &&
       other.termType === 'ContentLiteral' &&
       other.language === this.language &&
       this.datatype.equals(other.datatype)
     );
-  };
+  }
 }

--- a/addon/core/say-data-factory/prosemirror-terms/literal-node.ts
+++ b/addon/core/say-data-factory/prosemirror-terms/literal-node.ts
@@ -37,7 +37,7 @@ export class LiteralNodeTerm {
     }
   }
 
-  equals = (other?: Option<SayTerm>) => {
+  equals(other?: Option<SayTerm>) {
     return (
       !!other &&
       other.termType === 'LiteralNode' &&
@@ -45,5 +45,5 @@ export class LiteralNodeTerm {
       other.language === this.language &&
       this.datatype.equals(other.datatype)
     );
-  };
+  }
 }

--- a/addon/core/say-data-factory/prosemirror-terms/resource-node.ts
+++ b/addon/core/say-data-factory/prosemirror-terms/resource-node.ts
@@ -12,9 +12,9 @@ export class ResourceNodeTerm<Iri extends string = string> {
     this.value = value;
   }
 
-  equals = (other?: Option<SayTerm>) => {
+  equals(other?: Option<SayTerm>) {
     return (
       !!other && other.termType === 'ResourceNode' && other.value === this.value
     );
-  };
+  }
 }

--- a/addon/core/say-data-factory/quad.ts
+++ b/addon/core/say-data-factory/quad.ts
@@ -17,7 +17,7 @@ export class SayQuad implements RDF.BaseQuad {
     public readonly graph: RDF.Term,
   ) {}
 
-  equals = (other?: Option<SayTerm>) => {
+  equals(other?: Option<SayTerm>) {
     // `|| !other.termType` is for backwards-compatibility with old factories without RDF* support.
     return (
       !!other &&
@@ -27,5 +27,5 @@ export class SayQuad implements RDF.BaseQuad {
       this.object.equals(other.object) &&
       this.graph.equals(other.graph)
     );
-  };
+  }
 }

--- a/addon/core/say-data-factory/variable.ts
+++ b/addon/core/say-data-factory/variable.ts
@@ -13,9 +13,9 @@ export class SayVariable implements RDF.Variable {
     this.value = value;
   }
 
-  equals = (other?: Option<SayTerm>) => {
+  equals(other?: Option<SayTerm>) {
     return (
       !!other && other.termType === 'Variable' && other.value === this.value
     );
-  };
+  }
 }

--- a/addon/utils/_private/rdfa-parser/util.ts
+++ b/addon/utils/_private/rdfa-parser/util.ts
@@ -20,15 +20,14 @@ import type {
   ModelTerm,
 } from '@lblod/ember-rdfa-editor/utils/_private/rdfa-parser/rdfa-parser';
 
-export class ModelDataFactory<N> extends DataFactory {
+export class ModelDataFactory<N> extends DataFactory<ModelQuad<N>> {
   quad(
     subject: ModelQuadSubject<N>,
     predicate: ModelQuadPredicate<N>,
     object: ModelQuadObject<N>,
     graph: RDF.Quad_Graph,
   ): ModelQuad<N> {
-    const quad = super.quad(subject, predicate, object, graph);
-    return { ...quad, subject, predicate, object, graph };
+    return super.quad(subject, predicate, object, graph);
   }
 
   namedNode<N, I extends string = string>(


### PR DESCRIPTION
### Overview
This PR includes some changes in how the `equals` method/property is defined on RDF term instances.
It defines `equals` as a prototype method on RDF term instances instead of as arrow functions.
This has two implications:
- The `equals` function is no longer defined on RDF term instances themselves, but rather on their prototype.
- Comparison functions (such as the one used by prosemirror-devtools) no longer fail due to them not supporting function properties.
- Spreading an RDF term results in losing the `equals` method.

##### connected issues and PRs:
None

### How to test/reproduce
- Open up the dummy app
- Insert a sample document containing RDFa
- Ensure that `functions are not supported` error message no longer shows up.
- There should be no issues with missing/undefined `equals` properties.

### Challenges/uncertainties
**The change/rollback included in this PR does have some (possibly unwanted) side-effects:**
- As mentioned before , applying the spread operator on an RDF term instances results in losing the `equals` method. Typescript tries to handle this in the best way possible, but may sometimes make mistakes. An example can be found on: 
[Typescript playground] (https://www.typescriptlang.org/play/?#code/JYOwLgpgTgZghgYwgAgCrQLbIN4FgBQyyGEYAFgPYAmAggBQCUAXMgG4XBUDcBRJ51AEKMW7Tj3wBfAgQQAbOAGdFyAMpwMABzkR0ULMC06S4FXqx5CxUpVrIAvMkYOAfDl5FkCCiEUUdAHRyFADmdADkALI21Mg0TnBQUBQA7sgwAK4gCGDAPgzhDB7SVvy2wgyWnl4+foHBYVExVMiCTprJYBRgAJ6aKGXUBQwSRCUlBAD0AFTTyABiwFCKYMiKSCCJecjTkzL43r6rkPoOyCAQaepGupiMEpOTyABKWSopwAIZq8DKGRCKAgnDABQa0e5TJ6vXzID5fH5-AFAzCg5oVCSyWqrRQdCBwKgQKjmM7YAJk4GSDH4R7IAAycBAIQycBCKEU0FY0BqSQgOTkPWQmmACAA1ioMppkOQ4KsAAZgmiy5C-ZAM1VJVLpLI5PIgVUgFrkDIqXHsqCclopMgQPU4qB4qigEIBAh2h2E8yogTgkb7GnytFKlVwQWdbp9AbNfUtEDdUMAjmEgJoMgq7w8vkCkLATkqEO9frrKDATSraDJKAu6lPN34j2YACMXvKEPwU1mal5Pha6xtWwoOz2bYOWKlmAATCxiY4LlcNNpbvpW4cVmtcXWiROSWSAsDx5TISmVWmKBmwK71wTN-px83qPRfcOafTGczWWtE1ApamQGLkAHvUEIMVBWYA5DkZACRgUBCQAGmQAAjb5lQRc5umTVBUxUYNkDkQxPhlXVkAoGApQjIsS1WKh-ilAdPjQ1YRVjD5GWVUiAPKYDIIgaCLhaHxvxQDpunDfpiK-cgUAoBCACteR+MB2TkGAq1rK9zFvMF0SAA)

**Other possible approaches:**
- Using simple data objects to represent the RDF terms and using separately defined `equals` functions. This does have the drawback that we cannot leverage the RDFJS interfaces.
- Ensuring that the comparison library used by the prosemirror devtools adds support for function properties. This can be a long-term solution which is possibly the best approach, as it may occur in other situations that prosemirror node-attributes contain arrow function properties.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
