### PR TITLE
Fix deepArrayContains source formatting

### DIFF
--- a/.changeset/four-vans-divide.md
+++ b/.changeset/four-vans-divide.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Fix formatting of test-helpers file

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -100,7 +100,7 @@ QUnit.hooks.afterEach(() => {
   QUnit.dump.maxDepth = defaultDumpDepth;
 });
 
-(QUnit.assert.deepArrayContains = function (
+QUnit.assert.deepArrayContains = function (
   array: unknown[],
   element: unknown,
   message?: string,
@@ -112,7 +112,8 @@ QUnit.hooks.afterEach(() => {
     expected: element,
     message,
   });
-}),
-  setApplication(Application.create(config.APP));
+};
+
+setApplication(Application.create(config.APP));
 
 start();


### PR DESCRIPTION
Follows-up https://github.com/lblod/ember-rdfa-editor/commit/5e963d0ffccafc42790178867a2bb65f994ac112, which introduced it with trailing comma instead of semi-colon.
Follows-up https://github.com/lblod/ember-rdfa-editor/commit/455c4bb39820ce84593af1b6fdc20b42d226f97a, which then auto-fixed this to the odd expression statement that is left in the repo today.

### Checks PR readiness
- [x] npm lint
- [x] no new deprecations
