### PR TITLE
Remove css-rule from toolbar css which breaks toolbar spacing on bigger screens

### DIFF
--- a/.changeset/four-tigers-admire.md
+++ b/.changeset/four-tigers-admire.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+Remove css rule from toolbar which breaks toolbar spacing on bigger screens

--- a/app/styles/ember-rdfa-editor/_c-toolbar.scss
+++ b/app/styles/ember-rdfa-editor/_c-toolbar.scss
@@ -82,7 +82,6 @@ $say-toolbar-height: 44px !default;
   padding-left: 0.1rem;
   padding-right: 0.1rem;
   flex-shrink: 0;
-  flex-grow: 1;
   align-items: center;
 }
 


### PR DESCRIPTION
### Overview
This PR removes a css rule which broke the toolbar spacing on bigger screens.

#### Before
![image](https://github.com/user-attachments/assets/db6f0c40-67b4-4c3a-b3bc-1d3e7fb888e4)

#### After
![image](https://github.com/user-attachments/assets/640b30a2-9044-4c62-8e3d-7045374332ec)


### How to test/reproduce
- Open the dummy app
- Ensure that the spacing of the toolbar seems correct
- When decreasing the screen size, the spacing should still hold up. The dropdown menus should not overflow.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
