### PR TITLE
`addPropertyToNode`: do not add property if already included

### DIFF
--- a/.changeset/curvy-chicken-drum.md
+++ b/.changeset/curvy-chicken-drum.md
@@ -1,0 +1,5 @@
+---
+"@lblod/ember-rdfa-editor": patch
+---
+
+fix in `addPropertyToNode` function: when property is already included, do not add it a second time (this prevents duplications)

--- a/addon/utils/_private/rdfa-utils.ts
+++ b/addon/utils/_private/rdfa-utils.ts
@@ -348,6 +348,10 @@ export function addPropertyToNode({
     }
 
     const properties = getProperties(resourceNodes[0].value);
+    // Do not add the property if it is already present
+    if (properties?.some((prop) => deepEqualProperty(prop, property))) {
+      return { initialState: state, transaction: tr, result: false };
+    }
     const updatedProperties = properties
       ? [...properties, property]
       : [property];


### PR DESCRIPTION
### Overview
This PR includes a fix in the `addPropertyToNode` function. It ensures a property is not added if it is already included in the list of properties for a resource.

##### connected issues and PRs:
Discovered while working on [GN-4899](https://binnenland.atlassian.net/browse/GN-4899)

### How to test/reproduce
This PR cannot really be tested using the dummy app.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
