### PR TITLE
Ensure `SaySerializer` can be used in a headless way

### DIFF
--- a/.changeset/gentle-shoes-repeat.md
+++ b/.changeset/gentle-shoes-repeat.md
@@ -1,0 +1,7 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Ensure `SaySerializer` can be used in a headless way.
+- Deprecation of passing instance of `SayEditor` to `SaySerializer` constructor and its static functions.
+- Add option to pass instance of `StateGenerator` instead of `SayEditor` to `SaySerializer` constructor and its static functions. This is the preffered way of using the serializer going forward and removes its dependency on a view.

--- a/.changeset/silly-pumpkins-remember.md
+++ b/.changeset/silly-pumpkins-remember.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix issue in `addPropertyToNode` transaction-monad: ensure backlinks are added when needed

--- a/addon/core/say-editor.ts
+++ b/addon/core/say-editor.ts
@@ -143,7 +143,10 @@ export default class SayEditor {
       doc: this.parser.parse(target),
       plugins: pluginConf,
     });
-    this.serializer = SaySerializer.fromSchema(this.schema, this);
+    this.serializer = SaySerializer.fromSchema(
+      this.schema,
+      () => this.mainView.state,
+    );
     this.mainView = new SayView(target, {
       state,
       attributes: { class: 'say-editor__inner say-content' },


### PR DESCRIPTION
### Overview
This PR contains the following changes:
- Deprecation of passing instance of `SayEditor` to `SaySerializer` constructor and its static functions.
- Add option to pass instance of `StateGenerator` instead of `SayEditor` to `SaySerializer` constructor and its static functions. This is the preffered way of using the serializer going forward and removes its dependency on a view.

##### connected issues and PRs:
https://github.com/lblod/frontend-gelinkt-notuleren/pull/694

### How to test/reproduce
- Everything should work as before
- Especially test the `counter` dummy component in combination with a language change and serialization, as this node depends on have an instance of `EditorState` available upon serialization

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
