### PR TITLE
fix(rdfa-utils): ensure backlinks are added when necessary

### DIFF
--- a/.changeset/silly-pumpkins-remember.md
+++ b/.changeset/silly-pumpkins-remember.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix issue in `addPropertyToNode` transaction-monad: ensure backlinks are added when needed


### PR DESCRIPTION
### Overview
This PR fixes an issue occurring in an edge-case of the `addPropertyToNode` transaction-monad. It ensures that backlinks are always correctly added.
Specifically, it fixes the following issue:
- State: `<resource-node-1(http://besluit/1)>` has relationship with `<resource-node-2(http://mandatee/1)>`
- Transaction is created
- `<resource-node-2(http://mandatee/1)>` is removed
- `<resource-node-1(http://besluit/1)>` still has a (dead) property linking to `<resource-node-2>`
- `<resource-node-2(http://mandatee/1)>` is re-added (does not yet have a backlink)
- the property linking to `<resource-node-2>` defined on `<resource-node-1>` is no longer dead
- the `addPropertyToNode` function is called, to re-add the relationship between `<resource-node-1>` and `<resource-node-2>`
   * [BUG solved by this PR]:  `addPropertyToNode` checks if the property to add is already present, if it is, return; => this is not completely correct
   * [Correct behaviour introducing in this PR]: Only add property if it is not yet present, but do not return and continue the execution of the function. Ensure that if the backlink is not (yet) present, add it too.


##### connected issues and PRs:
https://github.com/lblod/frontend-gelinkt-notuleren/pull/694

### How to test/reproduce
- Can not be tested in the editor dummy app
- Test with:
  * dummy app of the editor-plugins (specifically the mandatee_table plugin): synchronizing the document several times consecutively should not impact the backlinks of the mandatees
  * https://github.com/lblod/frontend-gelinkt-notuleren/pull/694: synchronizing an inauguration meeting (containing docs with mandatee_tables) several times consecutively should not impact the properties/backlinks of the mandatees.

### Challenges/uncertainties
This PR adds 3 new functions:
- `addProperty`: an immutable function which takes in a list of properties and a property to be added, it creates a new list containing the new property if that property has not been added yet
- `addBacklink`: similar as `addProperty` but for backlinks
- `deepEqualBacklink`: compares two backlinks
We should probably use  some sort of set data-structure to store properties and backlinks, to ensure duplicates never occur.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
