### PR TITLE
Messy version of allowing resources to link to imported resources

### DIFF
--- a/addon/components/_private/rdfa-editor/relationship-editor/modal.gts
+++ b/addon/components/_private/rdfa-editor/relationship-editor/modal.gts
@@ -46,7 +46,7 @@ export default class RelationshipEditorModal extends Component<Sig> {
             id={{formId}}
             @onSubmit={{this.save}}
             @controller={{@controller}}
-            @termTypes={{(array 'LiteralNode' 'ResourceNode')}}
+            @termTypes={{(array 'LiteralNode' 'ResourceNode' 'NamedNode')}}
             @triple={{@triple}}
             @importedResources={{@importedResources}}
           />

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Mark, type Attrs, type DOMOutputSpec } from 'prosemirror-model';
-import { PNode } from '@lblod/ember-rdfa-editor/index';
+import { type PNode } from '@lblod/ember-rdfa-editor';
 import { isSome, unwrap } from '../utils/_private/option';
 import type {
   ContentTriple,
@@ -8,8 +8,9 @@ import type {
   IncomingTriple,
   OutgoingTriple,
 } from './rdfa-processor';
-import { isElement } from '@lblod/ember-rdfa-editor/utils/_private/dom-helpers';
+import { isElement } from '../utils/_private/dom-helpers';
 import { sayDataFactory } from './say-data-factory';
+import { IMPORTED_RESOURCES_ATTR } from '../plugins/imported-resources';
 
 // const logger = createLogger('core/schema');
 
@@ -292,15 +293,28 @@ export function renderRdfaAttrs(
       return {};
     }
 
-    return {
-      about: backlinks[0].subject.value,
-      property: backlinks[0].predicate,
-      datatype: backlinks[0].subject.language.length
-        ? null
-        : backlinks[0].subject.datatype.value,
-      lang: backlinks[0].subject.language,
-      'data-literal-node': 'true',
-    };
+    // @ts-expect-error rdfaAttrs can actually contain any Attrs, but since this is temporary, just
+    // ignore the type error
+    if (rdfaAttrs[IMPORTED_RESOURCES_ATTR]) {
+      // TODO figure out how to add links from resources in the snippet TO imported resources in a
+      // way that doesn't break tooling or require manually typing URIs into a NamedNode
+      // relationship.
+      // For now just warn and avoid crashing.
+      console.warn(
+        'Do not add relationships pointing TO an imported resource as a ResourceNode, use a NamedNode with the correct URI',
+      );
+      return {};
+    } else {
+      return {
+        about: backlinks[0].subject.value,
+        property: backlinks[0].predicate,
+        datatype: backlinks[0].subject.language.length
+          ? null
+          : backlinks[0].subject.datatype.value,
+        lang: backlinks[0].subject.language,
+        'data-literal-node': 'true',
+      };
+    }
   }
 }
 


### PR DESCRIPTION
### Overview
To allow for linking from resources in a snippet to those imported, adds imported resources to those listed for creating relationships, but actually the linking only works if we create a NamedNode relationship instead of a ResourceNode. This is just a draft as we need to figure out a better way to do this.

##### connected issues and PRs:
Made to https://github.com/lblod/ember-rdfa-editor/pull/1212 as that is the more finalised part of the design.

### Setup
Link to plugins PR.

### How to test/reproduce
See plugins PR for most details. When creating a link to an imported resource from a resource in the snippet, click 'add relationship' as normal, but create a NamedNode link with a manually entered URI.

### Challenges/uncertainties
Need to figure out the right way to do this.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
