### PR TITLE
Add the ability to update an attribute without registering into the hstory

### DIFF
--- a/.changeset/chilly-experts-confess.md
+++ b/.changeset/chilly-experts-confess.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+updateAttribute now allows a third argument to avoid adding the change to the history

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -47,7 +47,7 @@ export interface EmberNodeArgs {
    *    `get someText() { return this.args.node.attrs.someText; }`
    *    `set someText(value) { return this.args.updateAttribute('someText', value); }`
    */
-  updateAttribute: (attr: string, value: unknown, ignoreHistory: boolean | undefined) => void;
+  updateAttribute: (attr: string, value: unknown, ignoreHistory?: boolean) => void;
   /**
    * Util method which selects the node within the editor
    */

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -47,7 +47,7 @@ export interface EmberNodeArgs {
    *    `get someText() { return this.args.node.attrs.someText; }`
    *    `set someText(value) { return this.args.updateAttribute('someText', value); }`
    */
-  updateAttribute: (attr: string, value: unknown) => void;
+  updateAttribute: (attr: string, value: unknown, ignoreHistory: boolean | undefined) => void;
   /**
    * Util method which selects the node within the editor
    */
@@ -184,7 +184,7 @@ class EmberNodeView implements NodeView {
       {
         getPos,
         node: pNode,
-        updateAttribute: (attr: string, value, ignoreHistory: boolean) => {
+        updateAttribute: (attr, value, ignoreHistory) => {
           const pos = getPos();
           if (pos !== undefined) {
             const transaction = view.state.tr;

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -47,7 +47,11 @@ export interface EmberNodeArgs {
    *    `get someText() { return this.args.node.attrs.someText; }`
    *    `set someText(value) { return this.args.updateAttribute('someText', value); }`
    */
-  updateAttribute: (attr: string, value: unknown, ignoreHistory?: boolean) => void;
+  updateAttribute: (
+    attr: string,
+    value: unknown,
+    ignoreHistory?: boolean,
+  ) => void;
   /**
    * Util method which selects the node within the editor
    */

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -184,12 +184,12 @@ class EmberNodeView implements NodeView {
       {
         getPos,
         node: pNode,
-        updateAttribute: (attr: string, value: any, ignoreHistory: boolean) => {
+        updateAttribute: (attr: string, value, ignoreHistory: boolean) => {
           const pos = getPos();
           if (pos !== undefined) {
             const transaction = view.state.tr;
-            if(ignoreHistory) {
-              transaction.setMeta('addToHistory', false)
+            if (ignoreHistory) {
+              transaction.setMeta('addToHistory', false);
             }
             transaction.setNodeAttribute(pos, attr, value);
             view.dispatch(transaction);

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -184,10 +184,13 @@ class EmberNodeView implements NodeView {
       {
         getPos,
         node: pNode,
-        updateAttribute: (attr, value) => {
+        updateAttribute: (attr: string, value: any, ignoreHistory: boolean) => {
           const pos = getPos();
           if (pos !== undefined) {
             const transaction = view.state.tr;
+            if(ignoreHistory) {
+              transaction.setMeta('addToHistory', false)
+            }
             transaction.setNodeAttribute(pos, attr, value);
             view.dispatch(transaction);
           }


### PR DESCRIPTION
### Overview
Now you can update attribute without registering the change in the history. Needed for loading the regulatory statements in GN.
I also added some missing types

##### connected issues and PRs:
GN-4961


### Setup
None

### How to test/reproduce
You can test with my GN pr I will post below when creating it 

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
