### PR TITLE
Add doNotClean option to initialize and setHtmlContent

### DIFF
--- a/.changeset/strong-foxes-remain.md
+++ b/.changeset/strong-foxes-remain.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add option to SayController.initialize() and SayView.setHtmlContent() to prevent cleaning input HTML

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ It allows you to provide an object contain a series of `NodeViewConstructor` fun
 This object contains a series of `string:boolean` pairs. It may contain the following entries:
 - showToggleRdfaAnnotations: Show annotations toggle switch and add rdfa annotations view
 - showRdfa: Show RDFA in the editor
+- editRdfa: Opt in to the [experimental RDFa editing mode](#experimental%3A-a-new-approach-to-handle-rdfa-in-documents)
 - showRdfaHighlight: Show Rdfa highlights
 - showRdfaHover: Show Rdfa information on hover
 - showPaper: Show the editor inside a paper like container

--- a/addon/core/say-controller.ts
+++ b/addon/core/say-controller.ts
@@ -5,7 +5,7 @@ import { shallowEqual } from '@lblod/ember-rdfa-editor/utils/_private/object-uti
 import { datastoreKey } from '@lblod/ember-rdfa-editor/plugins/datastore';
 import { selectionHasMarkEverywhere } from '@lblod/ember-rdfa-editor/utils/_private/mark-utils';
 import SayView, {
-  type DocumentRange,
+  type SetHtmlOptions,
 } from '@lblod/ember-rdfa-editor/core/say-view';
 import SayEditor from '@lblod/ember-rdfa-editor/core/say-editor';
 import { tracked } from '@glimmer/tracking';
@@ -80,11 +80,18 @@ export default class SayController {
    * This method creates a new `doc` node and parses it correctly based on the provided html.
    * Note: plugin state is not preserved when using this method (e.g. the history-plugin state is reset).
    */
-  initialize(html: string, { shouldFocus = true } = {}) {
+  initialize(
+    html: string,
+    {
+      shouldFocus = true,
+      doNotClean = false,
+    }: Exclude<SetHtmlOptions, 'range'> = {},
+  ) {
     const doc = htmlToDoc(html, {
       schema: this.schema,
       editorView: this.editor.mainView,
       parser: this.editor.parser,
+      doNotClean,
     });
 
     this.editor.mainView.updateState(
@@ -105,10 +112,7 @@ export default class SayController {
    * Note: it does not create a new `doc` node and does not update the `doc` node based on the provided html
    * (e.g. `lang` attributes on the `doc` node are not parsed)
    */
-  setHtmlContent(
-    content: string,
-    options: { shouldFocus?: boolean; range?: DocumentRange } = {},
-  ) {
+  setHtmlContent(content: string, options: SetHtmlOptions = {}) {
     this.mainEditorView.setHtmlContent(content, options);
   }
 

--- a/addon/core/say-view.ts
+++ b/addon/core/say-view.ts
@@ -5,10 +5,21 @@ import { htmlToDoc, htmlToFragment } from '../utils/_private/html-utils';
 import { DOMSerializer, ProseParser } from '..';
 import { SetDocAttributesStep } from '../utils/steps';
 
+export interface SetHtmlOptions {
+  shouldFocus?: boolean;
+  range?: DocumentRange;
+  /**
+   * Do not clean, only sanitize the input. This leaves empty elements and proprietary tags intact,
+   * so is only suitable for HTML produced by the editor or otherwise known to be understood by it.
+   * Defaults to false.
+   */
+  doNotClean?: boolean;
+}
 export type DocumentRange = {
   from: number;
   to: number;
 };
+
 export default class SayView extends EditorView {
   isSayView = true;
   @tracked declare state: EditorState;
@@ -37,11 +48,8 @@ export default class SayView extends EditorView {
    * This method creates a new `doc` node and parses it correctly based on the provided html.
    * Note: plugin state is not preserved when using this method (e.g. the history-plugin state is reset).
    */
-  setHtmlContent(
-    content: string,
-    options: { shouldFocus?: boolean; range?: DocumentRange } = {},
-  ) {
-    const { shouldFocus = true } = options;
+  setHtmlContent(content: string, options: SetHtmlOptions = {}) {
+    const { shouldFocus = true, doNotClean } = options;
     if (shouldFocus) {
       this.focus();
     }
@@ -51,6 +59,7 @@ export default class SayView extends EditorView {
       const fragment = htmlToFragment(content, {
         parser: this.domParser,
         editorView: this,
+        doNotClean,
       });
       tr.replaceRange(range.from, range.to, fragment);
     } else {
@@ -58,6 +67,7 @@ export default class SayView extends EditorView {
         schema: this.state.schema,
         parser: this.domParser,
         editorView: this,
+        doNotClean,
       });
       tr.step(new SetDocAttributesStep(doc.attrs));
       tr.replaceWith(0, tr.doc.nodeSize - 2, doc);

--- a/addon/utils/_private/html-input-parser.ts
+++ b/addon/utils/_private/html-input-parser.ts
@@ -276,10 +276,24 @@ export default class HTMLInputParser {
    *
    * @param htmlString {string}
    * @param asHTMLElement {boolean}
+   * @param doNotClean {boolean} - optionally prevent cleaning input (just sanitize it). This should
+   * only be used with html that the editor understands directly, e.g. saved editor contents.
    */
-  prepareHTML(htmlString: string): string;
-  prepareHTML(htmlString: string, asHTMLDocument?: boolean): Document;
-  prepareHTML(htmlString: string, asHTMLDocument?: boolean): string | Document {
+  prepareHTML(
+    htmlString: string,
+    asHTMLDocument?: false,
+    doNotClean?: boolean,
+  ): string;
+  prepareHTML(
+    htmlString: string,
+    asHTMLDocument: true,
+    doNotClean?: boolean,
+  ): Document;
+  prepareHTML(
+    htmlString: string,
+    asHTMLDocument?: boolean,
+    doNotClean?: boolean,
+  ): string | Document {
     const parser = new DOMParser();
 
     const document = parser.parseFromString(
@@ -289,8 +303,10 @@ export default class HTMLInputParser {
 
     const bodyElement = document.body;
 
-    this.cleanDocx({ element: bodyElement });
-    this.setTableColWidthDataset({ element: bodyElement });
+    if (!doNotClean) {
+      this.cleanDocx({ element: bodyElement });
+      this.setTableColWidthDataset({ element: bodyElement });
+    }
     this.sanitizeHTML({ element: bodyElement });
 
     if (asHTMLDocument) {

--- a/addon/utils/_private/html-utils.ts
+++ b/addon/utils/_private/html-utils.ts
@@ -8,11 +8,16 @@ import type { HEADING_ELEMENTS } from './constants';
 
 export function htmlToDoc(
   html: string,
-  options: { schema: Schema; parser: ProseParser; editorView?: EditorView },
+  options: {
+    schema: Schema;
+    parser: ProseParser;
+    editorView?: EditorView;
+    doNotClean?: boolean;
+  },
 ) {
   const { parser } = options;
   const htmlCleaner = new HTMLInputParser();
-  const cleanedHTML = htmlCleaner.prepareHTML(html);
+  const cleanedHTML = htmlCleaner.prepareHTML(html, false, options.doNotClean);
   const domParser = new DOMParser();
   const parsed = domParser.parseFromString(cleanedHTML, 'text/html').body;
   preprocessRDFa(
@@ -35,11 +40,15 @@ export function htmlToDoc(
 
 export function htmlToFragment(
   html: string,
-  options: { parser: ProseParser; editorView: EditorView },
+  options: {
+    parser: ProseParser;
+    editorView: EditorView;
+    doNotClean?: boolean;
+  },
 ) {
   const { parser, editorView } = options;
   const htmlCleaner = new HTMLInputParser();
-  const cleanedHTML = htmlCleaner.prepareHTML(html);
+  const cleanedHTML = htmlCleaner.prepareHTML(html, false, options.doNotClean);
   const domParser = new DOMParser();
   const parsed = domParser.parseFromString(cleanedHTML, 'text/html').body;
   preprocessRDFa(parsed, getPathFromRoot(editorView.dom, false));

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -161,7 +161,7 @@ export default class IndexController extends Controller {
   rdfaEditorInit(rdfaEditor: SayController) {
     const presetContent = localStorage.getItem('EDITOR_CONTENT') ?? '';
     this.rdfaEditor = rdfaEditor;
-    this.rdfaEditor.initialize(presetContent);
+    this.rdfaEditor.initialize(presetContent, { doNotClean: true });
     applyDevTools(rdfaEditor.mainEditorView);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -164,7 +164,7 @@ export default class IndexController extends Controller {
   rdfaEditorInit(rdfaEditor: SayController) {
     const presetContent = localStorage.getItem('EDITOR_CONTENT') ?? '';
     this.rdfaEditor = rdfaEditor;
-    this.rdfaEditor.initialize(presetContent);
+    this.rdfaEditor.initialize(presetContent, { doNotClean: true });
     applyDevTools(rdfaEditor.mainEditorView);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -160,7 +160,7 @@ export default class SpaceInvisibleController extends Controller {
   rdfaEditorInit(rdfaEditor: SayController) {
     const presetContent = localStorage.getItem('EDITOR_CONTENT') ?? '';
     this.rdfaEditor = rdfaEditor;
-    this.rdfaEditor.initialize(presetContent);
+    this.rdfaEditor.initialize(presetContent, { doNotClean: true });
     applyDevTools(rdfaEditor.mainEditorView);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);

--- a/tests/integration/rdfa/blackbox-test.ts
+++ b/tests/integration/rdfa/blackbox-test.ts
@@ -80,7 +80,7 @@ module('Integration | RDFa blackbox test ', function () {
       controller.initialize(html);
       const outputHTML = controller.htmlContent;
       // run through the editor twice to test for stability
-      controller.initialize(outputHTML);
+      controller.initialize(outputHTML, { doNotClean: true });
 
       const finalHTML = controller.htmlContent;
       assert.strictEqual(outputHTML, finalHTML);

--- a/tests/unit/prosemirror/view-test.ts
+++ b/tests/unit/prosemirror/view-test.ts
@@ -97,4 +97,28 @@ module('ProseMirror | view', function () {
     });
     assert.strictEqual(view.htmlContent, expectedHtml);
   });
+
+  test('setHtmlContent will leave not clean the HTML if asked not to', function (assert) {
+    const schema = TEST_SCHEMA;
+
+    const view = new SayView(null, {
+      state: EditorState.create({ schema }),
+    });
+    const htmlToInsert = oneLineTrim`
+    <div lang="en-US" data-say-document="true">
+      <div style="display: none" data-rdfa-container="true"></div>
+      <div data-content-container="true">
+        <p>   </p>
+        <p>
+           Suspendisse molestie ipsum odio, ac dignissim odio vestibulum ut.
+           Ut facilisis purus et blandit posuere.
+           Mauris vitae neque bibendum, rutrum leo ac, euismod magna.
+        </p>
+        <p></p>
+      </div>
+    </div>
+    `;
+    view.setHtmlContent(htmlToInsert, { doNotClean: true });
+    assert.strictEqual(view.htmlContent, htmlToInsert);
+  });
 });

--- a/tests/unit/utils/html-input-parser-test.ts
+++ b/tests/unit/utils/html-input-parser-test.ts
@@ -1767,3 +1767,30 @@ module('Utils | CS | HTMLInputParser', function () {
     );
   });
 });
+
+test('It should remove unsafe url schemes, even when not cleaning', function (assert) {
+  const expectedHtml = oneLineTrim`<a style="color:green">Lorem Ipsum</a>`;
+  const inputParser = new HTMLInputParser();
+  const htmlContent = oneLineTrim`<a href="javascript:console.log('this should not work')" style="color:green">Lorem Ipsum</a>`;
+
+  const actualHtml = inputParser.prepareHTML(htmlContent, false, true);
+  assert.strictEqual(actualHtml, expectedHtml);
+});
+
+test('It should remove src tags, even when not cleaning', function (assert) {
+  const expectedHtml = oneLineTrim`console.log('test')`;
+  const inputParser = new HTMLInputParser();
+  const htmlContent = oneLineTrim`<src>console.log('test')</src>`;
+
+  const actualHtml = inputParser.prepareHTML(htmlContent, false, true);
+  assert.strictEqual(actualHtml, expectedHtml);
+});
+
+test('It should leave empty elements when not cleaning', function (assert) {
+  const expectedHtml = oneLineTrim`<p></p><p>This is the only line including text</p><p>  </p>`;
+  const inputParser = new HTMLInputParser();
+  const htmlContent = oneLineTrim`<p></p><p>This is the only line including text</p><p>  </p>`;
+
+  const actualHtml = inputParser.prepareHTML(htmlContent, false, true);
+  assert.strictEqual(actualHtml, expectedHtml);
+});


### PR DESCRIPTION
### Overview
Allows for HTML generated by the editor to be passed in (e.g. from a saved document) without it being passed through the processing steps intended for handling clipboard contents. This leaves empty elements intact, for instance.

Fixes the issue around empty lines being removed on save.

##### connected issues and PRs:
Jira ticket: https://binnenland.atlassian.net/browse/GN-5051
RB PR: https://github.com/lblod/frontend-reglementaire-bijlage/pull/278
GN PR: https://github.com/lblod/frontend-gelinkt-notuleren/pull/718

### Setup
N/A

### How to test/reproduce
Create a document with newlines with no content. Refresh the page, which stores then re-initializes the HTML from localstorage. Previously this was removing empty lines, but now they remain intact.

### Challenges/uncertainties
I was unsure of which steps we should keep in the processing. I kept the sanitization as it is still user input, but removed the other processing. We could re-enable some parts of it, I think it's the docx handling that's causing the problem.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
