### PR TITLE
pnpm patch: add pnpm patch to silence slicing warning

### DIFF
--- a/.changeset/silly-years-talk.md
+++ b/.changeset/silly-years-talk.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Add `ember-source` pnpm patch to silence `unexpectedly found... slicing...` warning

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN corepack enable
 RUN corepack prepare pnpm@9.4 --activate
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches/
 COPY public ./public/
 RUN pnpm i --frozen-lockfile
 COPY . .

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "ember-intl": "^6.4.0 || ^7.0.2",
     "ember-modifier": "^4.1.0",
     "ember-power-select": "^7.1.0",
-    "ember-source": "^4.12.0",
+    "ember-source": "~4.12.0",
     "ember-template-imports": "^4.1.1",
     "ember-truth-helpers": "^4.0.3"
   },
@@ -241,6 +241,9 @@
   "pnpm": {
     "overrides": {
       "babel-plugin-ember-template-compilation": "^2.2.5"
+    },
+    "patchedDependencies": {
+      "ember-source@4.12.0": "patches/ember-source@4.12.0.patch"
     }
   },
   "engines": {

--- a/patches/ember-source@4.12.0.patch
+++ b/patches/ember-source@4.12.0.patch
@@ -1,0 +1,19 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index 48f31b2e46b5f9d084ee0d98f630868bc999a639..0000000000000000000000000000000000000000
+diff --git a/dist/ember-template-compiler.js b/dist/ember-template-compiler.js
+index ad57835740cf3a5d7ed718daa40099652652ffed..a013df374d58d2f956b8441db70e415c05896243 100644
+--- a/dist/ember-template-compiler.js
++++ b/dist/ember-template-compiler.js
+@@ -7079,7 +7079,7 @@ define("@glimmer/syntax", ["exports", "@glimmer/util", "simple-html-tokenizer",
+       if (true /* DEBUG */) {
+         if (expected !== undefined && chars !== expected) {
+           // eslint-disable-next-line no-console
+-          console.warn("unexpectedly found " + JSON.stringify(chars) + " when slicing source, but expected " + JSON.stringify(expected));
++          // console.warn("unexpectedly found " + JSON.stringify(chars) + " when slicing source, but expected " + JSON.stringify(expected));
+         }
+       }
+       return new SourceSlice({
+diff --git a/dist/packages/@ember/-internals/runtime/.gitignore b/dist/packages/@ember/-internals/runtime/.gitignore
+deleted file mode 100644
+index a1136368651e6eb6d0d93a09c478f4978f4196fa..0000000000000000000000000000000000000000

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   babel-plugin-ember-template-compilation: ^2.2.5
 
+patchedDependencies:
+  ember-source@4.12.0:
+    hash: u3rjvvvb34otslzesbyv5oflde
+    path: patches/ember-source@4.12.0.patch
+
 importers:
 
   .:
@@ -37,7 +42,7 @@ importers:
         version: 2.1.0
       '@ember/render-modifiers':
         specifier: ^2.1.0
-        version: 2.1.0(@babel/core@7.24.7)(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+        version: 2.1.0(@babel/core@7.24.7)(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       '@embroider/macros':
         specifier: ^1.16.5
         version: 1.16.5(@glint/template@1.4.0)
@@ -88,13 +93,13 @@ importers:
         version: 6.3.0
       ember-focus-trap:
         specifier: ^1.1.0
-        version: 1.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+        version: 1.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       ember-template-imports:
         specifier: ^4.1.1
         version: 4.1.1
       ember-velcro:
         specifier: ^2.2.0
-        version: 2.2.0(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+        version: 2.2.0(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       handlebars:
         specifier: ^4.7.8
         version: 4.7.8
@@ -163,7 +168,7 @@ importers:
         version: 3.3.0
       tracked-toolbox:
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.24.7)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+        version: 2.0.0(@babel/core@7.24.7)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -173,7 +178,7 @@ importers:
     devDependencies:
       '@appuniversum/ember-appuniversum':
         specifier: ~3.4.2
-        version: 3.4.2(yenc6o4wruytt4u2jbwlbsqcl4)
+        version: 3.4.2(n4k5gj47exoacervf6fsvqlity)
       '@changesets/changelog-github':
         specifier: ^0.5.0
         version: 0.5.0
@@ -182,7 +187,7 @@ importers:
         version: 2.27.7
       '@ember/test-helpers':
         specifier: ^2.9.4
-        version: 2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+        version: 2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       '@embroider/test-setup':
         specifier: ^3.0.3
         version: 3.0.3
@@ -194,10 +199,10 @@ importers:
         version: 1.4.0(typescript@5.3.3)
       '@glint/environment-ember-loose':
         specifier: ~1.4.0
-        version: 1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))
+        version: 1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))
       '@glint/environment-ember-template-imports':
         specifier: ~1.4.0
-        version: 1.4.0(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__helper@4.0.8(@babel/core@7.24.7))(@types/ember__modifier@4.0.9(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))
+        version: 1.4.0(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__helper@4.0.8(@babel/core@7.24.7))(@types/ember__modifier@4.0.9(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))
       '@glint/template':
         specifier: ~1.4.0
         version: 1.4.0
@@ -368,22 +373,22 @@ importers:
         version: 2.1.2(@babel/core@7.24.7)
       ember-modifier:
         specifier: ~4.1.0
-        version: 4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+        version: 4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       ember-page-title:
         specifier: ^8.2.3
-        version: 8.2.3(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+        version: 8.2.3(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       ember-power-select:
         specifier: ^7.2.0
-        version: 7.2.0(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1)
+        version: 7.2.0(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1)
       ember-qunit:
         specifier: ^6.2.0
-        version: 6.2.0(@ember/test-helpers@2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(qunit@2.21.0)(webpack@5.92.1)
+        version: 6.2.0(kdoifwcwzjhzof5rsc53fpnxdu)
       ember-resolver:
         specifier: ^11.0.1
-        version: 11.0.1(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+        version: 11.0.1(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       ember-source:
         specifier: 4.12.0
-        version: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+        version: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0
@@ -395,7 +400,7 @@ importers:
         version: 6.0.0
       ember-truth-helpers:
         specifier: ^4.0.3
-        version: 4.0.3(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+        version: 4.0.3(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       ember-try:
         specifier: ^3.0.0
         version: 3.0.0
@@ -8736,7 +8741,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@appuniversum/ember-appuniversum@3.4.2(yenc6o4wruytt4u2jbwlbsqcl4)':
+  '@appuniversum/ember-appuniversum@3.4.2(n4k5gj47exoacervf6fsvqlity)':
     dependencies:
       '@babel/core': 7.24.7
       '@duetds/date-picker': 1.4.0
@@ -8747,21 +8752,21 @@ snapshots:
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.92.1)
       ember-cli-babel: 8.2.0(@babel/core@7.24.7)
       ember-cli-htmlbars: 6.3.0
-      ember-concurrency: 3.1.1(@babel/core@7.24.7)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-concurrency: 3.1.1(@babel/core@7.24.7)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       ember-data-table: 2.1.0
-      ember-file-upload: 8.4.1(5wwr7b7nh524s3xgly7alhhfcy)
-      ember-focus-trap: 1.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
-      ember-modifier: 4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-file-upload: 8.4.1(zy5ul7ssuc3vzilqffobwmente)
+      ember-focus-trap: 1.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-modifier: 4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
       ember-template-imports: 4.1.1
       ember-test-selectors: 6.0.0
-      ember-truth-helpers: 4.0.3(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-truth-helpers: 4.0.3(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       inputmask: 5.0.9
       merge-anything: 5.1.7
       tracked-built-ins: 3.3.0
-      tracked-toolbox: 2.0.0(@babel/core@7.24.7)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      tracked-toolbox: 2.0.0(@babel/core@7.24.7)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
     optionalDependencies:
-      ember-power-select: 7.2.0(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1)
+      ember-power-select: 7.2.0(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1)
     transitivePeerDependencies:
       - '@ember/test-helpers'
       - '@glint/environment-ember-loose'
@@ -9960,12 +9965,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/render-modifiers@2.1.0(@babel/core@7.24.7)(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))':
+  '@ember/render-modifiers@2.1.0(@babel/core@7.24.7)(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))':
     dependencies:
       '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       ember-cli-babel: 7.26.11
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.24.7)
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     optionalDependencies:
       '@glint/template': 1.4.0
     transitivePeerDependencies:
@@ -9978,17 +9983,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/test-helpers@2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))':
+  '@ember/test-helpers@2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))':
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.16.5(@glint/template@1.4.0)
-      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
       ember-destroyable-polyfill: 2.0.3(@babel/core@7.24.7)
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/environment-ember-loose'
@@ -10059,14 +10064,14 @@ snapshots:
       lodash: 4.17.21
       resolve: 1.22.8
 
-  '@embroider/util@1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))':
+  '@embroider/util@1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))':
     dependencies:
       '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     optionalDependencies:
-      '@glint/environment-ember-loose': 1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))
+      '@glint/environment-ember-loose': 1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))
       '@glint/template': 1.4.0
     transitivePeerDependencies:
       - supports-color
@@ -10380,7 +10385,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))':
+  '@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.24.7)
       '@glint/template': 1.4.0
@@ -10391,11 +10396,11 @@ snapshots:
       '@types/ember__object': 4.0.12(@babel/core@7.24.7)
       '@types/ember__routing': 4.0.22(@babel/core@7.24.7)
       ember-cli-htmlbars: 6.3.0
-      ember-modifier: 4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-modifier: 4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
 
-  '@glint/environment-ember-template-imports@1.4.0(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__helper@4.0.8(@babel/core@7.24.7))(@types/ember__modifier@4.0.9(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))':
+  '@glint/environment-ember-template-imports@1.4.0(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__helper@4.0.8(@babel/core@7.24.7))(@types/ember__modifier@4.0.9(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))':
     dependencies:
-      '@glint/environment-ember-loose': 1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))
+      '@glint/environment-ember-loose': 1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))
       '@glint/template': 1.4.0
       content-tag: 2.0.1
     optionalDependencies:
@@ -13408,23 +13413,23 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-basic-dropdown@7.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1):
+  ember-basic-dropdown@7.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1):
     dependencies:
       '@embroider/macros': 1.16.5(@glint/template@1.4.0)
-      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       '@glimmer/component': 1.1.2(@babel/core@7.24.7)
       '@glimmer/tracking': 1.1.2
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.92.1)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
       ember-cli-typescript: 5.3.0
-      ember-element-helper: 0.8.6(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-element-helper: 0.8.6(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       ember-get-config: 2.1.1(@glint/template@1.4.0)
       ember-maybe-in-element: 2.1.0
-      ember-modifier: 4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
-      ember-style-modifier: 3.1.1(@ember/string@3.1.1)(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1)
-      ember-truth-helpers: 4.0.3(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-modifier: 4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-style-modifier: 3.1.1(@ember/string@3.1.1)(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1)
+      ember-truth-helpers: 4.0.3(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
     transitivePeerDependencies:
       - '@babel/core'
       - '@ember/string'
@@ -13934,7 +13939,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-concurrency@3.1.1(@babel/core@7.24.7)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
+  ember-concurrency@3.1.1(@babel/core@7.24.7)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
     dependencies:
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/types': 7.24.7
@@ -13943,7 +13948,7 @@ snapshots:
       ember-cli-babel-plugin-helpers: 1.1.1
       ember-cli-htmlbars: 6.3.0
       ember-compatibility-helpers: 1.2.7(@babel/core@7.24.7)
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -13971,11 +13976,11 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-element-helper@0.8.6(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
+  ember-element-helper@0.8.6(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
     dependencies:
       '@embroider/addon-shim': 1.8.9
-      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - '@glint/environment-ember-loose'
       - '@glint/template'
@@ -13994,36 +13999,36 @@ snapshots:
     transitivePeerDependencies:
       - eslint
 
-  ember-file-upload@8.4.1(5wwr7b7nh524s3xgly7alhhfcy):
+  ember-file-upload@8.4.1(zy5ul7ssuc3vzilqffobwmente):
     dependencies:
-      '@ember/test-helpers': 2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      '@ember/test-helpers': 2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': 1.8.9
       '@embroider/macros': 1.16.5(@glint/template@1.4.0)
       '@glimmer/component': 1.1.2(@babel/core@7.24.7)
       '@glimmer/tracking': 1.1.2
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.92.1)
-      ember-modifier: 4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-modifier: 4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       tracked-built-ins: 3.3.0
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
       - webpack
 
-  ember-focus-trap@1.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
+  ember-focus-trap@1.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
     dependencies:
       '@embroider/addon-shim': 1.8.9
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
       focus-trap: 6.9.4
     transitivePeerDependencies:
       - supports-color
 
-  ember-functions-as-helper-polyfill@2.1.2(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
+  ember-functions-as-helper-polyfill@2.1.2(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
     dependencies:
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.3.0
       ember-cli-version-checker: 5.1.2
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14098,40 +14103,40 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
+  ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
     dependencies:
       '@embroider/addon-shim': 1.8.9
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
     optionalDependencies:
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-page-title@8.2.3(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
+  ember-page-title@8.2.3(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
     dependencies:
       '@embroider/addon-shim': 1.8.9
       '@simple-dom/document': 1.4.0
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-power-select@7.2.0(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1):
+  ember-power-select@7.2.0(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1):
     dependencies:
-      '@ember/render-modifiers': 2.1.0(@babel/core@7.24.7)(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      '@ember/render-modifiers': 2.1.0(@babel/core@7.24.7)(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       '@ember/string': 3.1.1
-      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       '@glimmer/component': 1.1.2(@babel/core@7.24.7)
       '@glimmer/tracking': 1.1.2
       ember-assign-helper: 0.4.0
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.92.1)
-      ember-basic-dropdown: 7.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1)
+      ember-basic-dropdown: 7.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
       ember-cli-typescript: 5.3.0
-      ember-concurrency: 3.1.1(@babel/core@7.24.7)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-concurrency: 3.1.1(@babel/core@7.24.7)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       ember-text-measurer: 0.6.0
-      ember-truth-helpers: 4.0.3(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-truth-helpers: 4.0.3(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/environment-ember-loose'
@@ -14140,16 +14145,16 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-qunit@6.2.0(@ember/test-helpers@2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(qunit@2.21.0)(webpack@5.92.1):
+  ember-qunit@6.2.0(kdoifwcwzjhzof5rsc53fpnxdu):
     dependencies:
-      '@ember/test-helpers': 2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      '@ember/test-helpers': 2.9.4(@babel/core@7.24.7)(@glint/environment-ember-loose@1.4.0(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(@types/ember__array@4.0.10(@babel/core@7.24.7))(@types/ember__component@4.0.22(@babel/core@7.24.7))(@types/ember__controller@4.0.12(@babel/core@7.24.7))(@types/ember__object@4.0.12(@babel/core@7.24.7))(@types/ember__routing@4.0.22(@babel/core@7.24.7))(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))))(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.92.1)
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.1.0
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
       qunit: 2.21.0
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -14159,11 +14164,11 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-resolver@11.0.1(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
+  ember-resolver@11.0.1(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
     dependencies:
       ember-cli-babel: 7.26.11
     optionalDependencies:
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14183,7 +14188,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1):
+  ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1):
     dependencies:
       '@babel/helper-module-imports': 7.24.7
       '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.7)
@@ -14218,12 +14223,12 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-style-modifier@3.1.1(@ember/string@3.1.1)(@glint/template@1.4.0)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1):
+  ember-style-modifier@3.1.1(@ember/string@3.1.1)(@glint/template@1.4.0)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))(webpack@5.92.1):
     dependencies:
       '@ember/string': 3.1.1
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.92.1)
       ember-cli-babel: 7.26.11
-      ember-modifier: 4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-modifier: 4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
     transitivePeerDependencies:
       - '@glint/template'
       - ember-source
@@ -14328,11 +14333,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-truth-helpers@4.0.3(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
+  ember-truth-helpers@4.0.3(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
     dependencies:
       '@embroider/addon-shim': 1.8.9
-      ember-functions-as-helper-polyfill: 2.1.2(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-functions-as-helper-polyfill: 2.1.2(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14363,13 +14368,13 @@ snapshots:
       - encoding
       - supports-color
 
-  ember-velcro@2.2.0(ember-modifier@4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
+  ember-velcro@2.2.0(ember-modifier@4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)))(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
     dependencies:
       '@embroider/addon-shim': 1.8.9
       '@floating-ui/dom': 1.6.7
-      ember-functions-as-helper-polyfill: 2.1.2(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
-      ember-modifier: 4.1.0(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-functions-as-helper-polyfill: 2.1.2(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-modifier: 4.1.0(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1))
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18952,12 +18957,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  tracked-toolbox@2.0.0(@babel/core@7.24.7)(ember-source@4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
+  tracked-toolbox@2.0.0(@babel/core@7.24.7)(ember-source@4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)):
     dependencies:
       '@embroider/addon-shim': 1.8.9
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.7)
     optionalDependencies:
-      ember-source: 4.12.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
+      ember-source: 4.12.0(patch_hash=u3rjvvvb34otslzesbyv5oflde)(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glint/template@1.4.0)(webpack@5.92.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color


### PR DESCRIPTION
### Overview
This PR adds a pnpm patch (https://pnpm.io/cli/patch) which silences the erroneous `unexpectedly found... slicing...` warnings. It reduces a lot of clutter + whitespace-eating when running the dev server.

### Related issues
https://github.com/emberjs/ember.js/issues/19392