### PR TITLE
Add util function to strip specially marked elements when publishing

### DIFF
--- a/.changeset/slow-games-cry.md
+++ b/.changeset/slow-games-cry.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add util for filtering out html elements marked with a special attribute, to allow for filtering these on publish

--- a/addon/components/debug-tools.hbs
+++ b/addon/components/debug-tools.hbs
@@ -1,10 +1,13 @@
 {{! @glint-nocheck: not typesafe yet }}
 <div {{this.setUpListeners}}>
-  <button type='button' {{on 'click' this.showStyledExportPreview}}>
+  <button type='button' {{on 'click' (fn this.showExportPreview true false)}}>
     Show Styled Export
   </button>
-  <button type='button' {{on 'click' this.showRawExportPreview}}>
+  <button type='button' {{on 'click' (fn this.showExportPreview false false)}}>
     Show Raw Export
+  </button>
+  <button type='button' {{on 'click' (fn this.showExportPreview true true)}}>
+    Show Export For Publish
   </button>
   {{#if @controller}}
     <span>Sample data:

--- a/addon/components/debug-tools.ts
+++ b/addon/components/debug-tools.ts
@@ -52,18 +52,12 @@ export default class RdfaEditorDebugTools extends Component<DebugToolArgs> {
   }
 
   @action
-  showStyledExportPreview() {
+  showExportPreview(isStyled: boolean, filterForPublish: boolean) {
     const wnd = window.open('about:blank', '', '_blank');
     if (this.controller && wnd) {
-      wnd.document.write(generatePageForExport(this.controller, true));
-    }
-  }
-
-  @action
-  showRawExportPreview() {
-    const wnd = window.open('about:blank', '', '_blank');
-    if (this.controller && wnd) {
-      wnd.document.write(generatePageForExport(this.controller, false));
+      wnd.document.write(
+        generatePageForExport(this.controller, isStyled, filterForPublish),
+      );
     }
   }
 

--- a/addon/utils/export-utils.ts
+++ b/addon/utils/export-utils.ts
@@ -1,8 +1,10 @@
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
+import { stripHtmlForPublish } from './strip-html-for-publish';
 
 export function generatePageForExport(
   controller: SayController,
   includeStyles: boolean,
+  filterForPublish?: boolean,
 ) {
   const parser = new DOMParser();
   const basicDocument = parser.parseFromString(
@@ -25,10 +27,11 @@ export function generatePageForExport(
     });
   }
 
-  const contentDocument = parser.parseFromString(
-    controller?.htmlContent || '',
-    'text/html',
-  );
+  let content = controller?.htmlContent || '';
+  if (filterForPublish) {
+    content = stripHtmlForPublish(content);
+  }
+  const contentDocument = parser.parseFromString(content, 'text/html');
 
   if (contentDocument.body.firstChild) {
     basicDocument.body.appendChild(contentDocument.body.firstChild);

--- a/addon/utils/strip-html-for-publish.ts
+++ b/addon/utils/strip-html-for-publish.ts
@@ -1,0 +1,15 @@
+export const HIDE_FOR_PUBLISH_ATTR = 'data-say-hide-for-publish';
+
+export function stripHtmlForPublish(content: string) {
+  const parser = new DOMParser();
+  const parsed = parser.parseFromString(content, 'text/html');
+
+  const allToBeFiltered = parsed.querySelectorAll(
+    `[${HIDE_FOR_PUBLISH_ATTR}=true]`,
+  );
+  allToBeFiltered.forEach((toFilter) => {
+    toFilter?.remove();
+  });
+
+  return parsed.body.innerHTML;
+}


### PR DESCRIPTION
### Overview
This is the simplest approach to this problem, so I've gone for that due to the lack of clarity on how this would ideally be used. This most likely could be pulled out/copied to be used in the pre-publish flow if needed.

##### connected issues and PRs:
Plugins PR: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/483
PR for GN: https://github.com/lblod/frontend-gelinkt-notuleren/pull/723.
Jira ticket: https://binnenland.atlassian.net/browse/GN-4999

### Setup
If not testing linked to the plugins repo (to have access to the template comment plugin) or within GN, will need to modify a nodespec or markspec to set the `HIDE_FOR_PUBLISH_ATTR` property to be `true`.

### How to test/reproduce
Create a document with the nodespec you added the attribute to and click 'Show Export For Publish' and verify the elements are removed. The other exports should work as before.

### Challenges/uncertainties
Understanding how this is actually intended to be used as it is not clear from the ticket. It would make more sense to me if the publishing flow involved creating a new entity with a 'frozen' document, exported from the editor and stored in the triplestore; allowing for this processing to be more nuanced and avoiding the need for the publish flow to process the content of the document.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
