### PR TITLE
Reproducing the Firefox SVG bug

### DIFF
--- a/.changeset/poor-windows-raise.md
+++ b/.changeset/poor-windows-raise.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Update prosemirror-view to version [1.43.3](https://github.com/ProseMirror/prosemirror-view/releases/tag/1.34.3)

--- a/addon/config/sample-data.ts
+++ b/addon/config/sample-data.ts
@@ -594,4 +594,16 @@ world
     </div>
   </div>
   `,
+  FirefoxSVGBug: `
+  <div data-say-document="true">
+    <h1>Firefox SVG bug</h1>
+    <p>This sample contains a way to reproduce the so-called svg-bug in firefox.</p>
+    <p>You'll notice issues if you try to select across the different UI elements containing inline SVGs</p>
+    <p>As of prosemirror-view <a href="https://github.com/ProseMirror/prosemirror-view/releases/tag/1.34.3">v1.34.3</a> some issues around this case have been fixed. E.g. for links, but not for all cases, as can be seen with the 'firefox-svg-bug' nodes</p>
+    <p>BUT: selection around link nodes does remain buggy in firefox</p>
+    <p>This issue does not occur in chromium-based browsers</p>
+    <p>text <span data-firefox-svg-bug></span> text <span data-firefox-svg-bug></span> text <span data-firefox-svg-bug></span> text</p>
+    <p><a href="https://redpencil.io">redpencil.io</a>gerger <a href="https://redpencil.io">redpencil.io</a> ergerg reg <a href="https://redpencil.io">redpencil.io</a>gerg eg r ger</p>
+  </div>
+  `
 };

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "prosemirror-schema-list": "^1.4.0",
     "prosemirror-state": "^1.4.3",
     "prosemirror-transform": "^1.9.0",
-    "prosemirror-view": "^1.33.8",
+    "prosemirror-view": "^1.34.3",
     "rdf-data-factory": "^1.1.2",
     "relative-to-absolute-iri": "^1.0.7",
     "stream-browserify": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
         version: 0.8.0-beta.6
       '@say-editor/prosemirror-invisibles':
         specifier: ^0.1.1
-        version: 0.1.1(prosemirror-model@1.21.3)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)
+        version: 0.1.1(prosemirror-model@1.21.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.3)
       '@say-editor/prosemirror-tables':
         specifier: ^0.3.0
         version: 0.3.0
@@ -152,8 +152,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       prosemirror-view:
-        specifier: ^1.33.8
-        version: 1.33.8
+        specifier: ^1.34.3
+        version: 1.34.3
       rdf-data-factory:
         specifier: ^1.1.2
         version: 1.1.2
@@ -4855,7 +4855,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -7115,8 +7115,8 @@ packages:
   prosemirror-transform@1.9.0:
     resolution: {integrity: sha512-5UXkr1LIRx3jmpXXNKDhv8OyAOeLTGuXNwdVfg8x27uASna/wQkr9p6fD3eupGOi4PLJfbezxTyi/7fSJypXHg==}
 
-  prosemirror-view@1.33.8:
-    resolution: {integrity: sha512-4PhMr/ufz2cdvFgpUAnZfs+0xij3RsFysreeG9V/utpwX7AJtYCDVyuRxzWoMJIEf4C7wVihuBNMPpFLPCiLQw==}
+  prosemirror-view@1.34.3:
+    resolution: {integrity: sha512-mKZ54PrX19sSaQye+sef+YjBbNu2voNwLS1ivb6aD2IRmxRGW64HU9B644+7OfJStGLyxvOreKqEgfvXa91WIA==}
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -10732,11 +10732,11 @@ snapshots:
       release-it: 16.3.0(typescript@5.3.3)
       string-template: 1.0.0
 
-  '@say-editor/prosemirror-invisibles@0.1.1(prosemirror-model@1.21.3)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)':
+  '@say-editor/prosemirror-invisibles@0.1.1(prosemirror-model@1.21.3)(prosemirror-state@1.4.3)(prosemirror-view@1.34.3)':
     dependencies:
       prosemirror-model: 1.21.3
       prosemirror-state: 1.4.3
-      prosemirror-view: 1.33.8
+      prosemirror-view: 1.34.3
 
   '@say-editor/prosemirror-tables@0.3.0':
     dependencies:
@@ -10744,7 +10744,7 @@ snapshots:
       prosemirror-model: 1.21.3
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.9.0
-      prosemirror-view: 1.33.8
+      prosemirror-view: 1.34.3
 
   '@simple-dom/document@1.4.0':
     dependencies:
@@ -11060,7 +11060,7 @@ snapshots:
 
   '@types/prosemirror-dev-tools@3.0.6':
     dependencies:
-      prosemirror-view: 1.33.8
+      prosemirror-view: 1.34.3
 
   '@types/qs@6.9.15': {}
 
@@ -17579,13 +17579,13 @@ snapshots:
     dependencies:
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.9.0
-      prosemirror-view: 1.33.8
+      prosemirror-view: 1.34.3
 
   prosemirror-history@1.4.0:
     dependencies:
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.9.0
-      prosemirror-view: 1.33.8
+      prosemirror-view: 1.34.3
       rope-sequence: 1.3.4
 
   prosemirror-inputrules@1.4.0:
@@ -17616,13 +17616,13 @@ snapshots:
     dependencies:
       prosemirror-model: 1.21.3
       prosemirror-transform: 1.9.0
-      prosemirror-view: 1.33.8
+      prosemirror-view: 1.34.3
 
   prosemirror-transform@1.9.0:
     dependencies:
       prosemirror-model: 1.21.3
 
-  prosemirror-view@1.33.8:
+  prosemirror-view@1.34.3:
     dependencies:
       prosemirror-model: 1.21.3
       prosemirror-state: 1.4.3

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -74,6 +74,10 @@ import {
   inlineRdfaWithConfigView,
   inlineRdfaWithConfig,
 } from '@lblod/ember-rdfa-editor/nodes/inline-rdfa';
+import {
+  FirefoxSVGBugView,
+  firefox_svg_bug,
+} from '../dummy-nodes/firefox-svg-bug';
 
 export default class EditableBlockController extends Controller {
   DebugInfo = DebugInfo;
@@ -91,6 +95,7 @@ export default class EditableBlockController extends Controller {
       paragraph,
 
       repaired_block: repairedBlockWithConfig({ rdfaAware: true }),
+      firefox_svg_bug,
 
       list_item: listItemWithConfig({
         enableHierarchicalList: true,
@@ -168,6 +173,7 @@ export default class EditableBlockController extends Controller {
       link: linkView(this.linkOptions)(controller),
       image: imageView(controller),
       inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
+      firefox_svg_bug: () => new FirefoxSVGBugView(),
     };
   };
 

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -66,6 +66,10 @@ import type { PluginConfig } from '@lblod/ember-rdfa-editor';
 import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 import { getOwner } from '@ember/application';
 import { headingWithConfig } from '@lblod/ember-rdfa-editor/plugins/heading/nodes/heading';
+import {
+  FirefoxSVGBugView,
+  firefox_svg_bug,
+} from '../dummy-nodes/firefox-svg-bug';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
@@ -78,6 +82,7 @@ export default class IndexController extends Controller {
       paragraph,
 
       repaired_block: repairedBlockWithConfig(),
+      firefox_svg_bug,
 
       list_item: listItemWithConfig({ enableHierarchicalList: true }),
       ordered_list: orderedListWithConfig({ enableHierarchicalList: true }),
@@ -150,6 +155,7 @@ export default class IndexController extends Controller {
     return {
       link: linkView(this.linkOptions)(controller),
       image: imageView(controller),
+      firefox_svg_bug: () => new FirefoxSVGBugView(),
     };
   };
 

--- a/tests/dummy/app/controllers/plugins.ts
+++ b/tests/dummy/app/controllers/plugins.ts
@@ -71,6 +71,10 @@ import {
   dropdownView,
 } from '../dummy-nodes';
 import { heading } from '@lblod/ember-rdfa-editor/plugins/heading/nodes/heading';
+import {
+  firefox_svg_bug,
+  FirefoxSVGBugView,
+} from '../dummy-nodes/firefox-svg-bug';
 
 export default class IndexController extends Controller {
   @tracked rdfaEditor?: SayController;
@@ -82,6 +86,7 @@ export default class IndexController extends Controller {
       paragraph,
 
       repaired_block: repairedBlockWithConfig(),
+      firefox_svg_bug,
 
       list_item: listItemWithConfig(),
       ordered_list: orderedListWithConfig(),
@@ -139,6 +144,7 @@ export default class IndexController extends Controller {
       dropdown: dropdownView(proseController),
       link: linkView(this.linkOptions)(proseController),
       image: imageView(proseController),
+      firefox_svg_bug: () => new FirefoxSVGBugView(),
     };
   };
   @tracked plugins: PluginConfig = [

--- a/tests/dummy/app/controllers/space-invisible.ts
+++ b/tests/dummy/app/controllers/space-invisible.ts
@@ -66,6 +66,10 @@ import type { PluginConfig } from '@lblod/ember-rdfa-editor';
 import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
 import { getOwner } from '@ember/application';
 import { headingWithConfig } from '@lblod/ember-rdfa-editor/plugins/heading/nodes/heading';
+import {
+  FirefoxSVGBugView,
+  firefox_svg_bug,
+} from '../dummy-nodes/firefox-svg-bug';
 
 export default class SpaceInvisibleController extends Controller {
   @tracked rdfaEditor?: SayController;
@@ -78,6 +82,7 @@ export default class SpaceInvisibleController extends Controller {
       paragraph,
 
       repaired_block: repairedBlockWithConfig(),
+      firefox_svg_bug,
 
       list_item: listItemWithConfig(),
       ordered_list: orderedListWithConfig(),
@@ -149,6 +154,7 @@ export default class SpaceInvisibleController extends Controller {
     return {
       link: linkView(this.linkOptions)(controller),
       image: imageView(controller),
+      firefox_svg_bug: () => new FirefoxSVGBugView(),
     };
   };
 

--- a/tests/dummy/app/dummy-nodes/firefox-svg-bug.ts
+++ b/tests/dummy/app/dummy-nodes/firefox-svg-bug.ts
@@ -1,0 +1,37 @@
+import type { NodeView } from 'prosemirror-view';
+import type SayNodeSpec from '@lblod/ember-rdfa-editor/core/say-node-spec';
+import { oneLineTrim } from 'common-tags';
+
+/**
+ * This file contains a simple prosemirror node-spec and nodeview which can be used to reproduce the so-called 'Firefox SVG bug'.
+ * If several of these nodes are included in a document, you'll notice issues if you try to select across the different nodes containing inline SVGs.
+ * This issue does not occur in chromium-based browsers.
+ * The solution (for now), is to simply disable inline SVGs in your nodes if the browser used is firefox.
+ */
+
+export const firefox_svg_bug: SayNodeSpec = {
+  inline: true,
+  group: 'inline',
+  selectable: false,
+  parseDOM: [{ tag: 'span[data-firefox-svg-bug]' }],
+  toDOM() {
+    return ['span', { 'data-firefox-svg-bug': 'true' }];
+  },
+};
+
+export class FirefoxSVGBugView implements NodeView {
+  dom: HTMLElement;
+  constructor() {
+    this.dom = document.createElement('span');
+    this.dom.contentEditable = 'false';
+    // this.dom.className = 'ember-node';
+    const html = `<span class='firefox-svg-bug'>
+                    firefox svg bug
+                    <svg class='firefox-svg-bug__icon' width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                      <path d="M20.4931636,7.78162645 C21.0549636,8.34412645 21.3705636,9.10662645 21.3705636,9.90162645 C21.3705636,10.6303398 21.1053719,11.3317777 20.6284443,11.8768917 L20.4931636,12.0215864 L15.53998,16.99998 L11.99998,20.48998 C11.43748,21.05178 10.67498,21.36738 9.88002,21.36738 C9.15127,21.36738 8.44982903,21.1021883 7.90471473,20.6252607 L7.76002,20.48998 L9.17002,19.07998 C9.35738,19.26618 9.61083,19.37078 9.87502,19.37078 C10.0951533,19.37078 10.3078144,19.2981411 10.4810357,19.1661735 L10.57998,19.07998 L14.11998,15.53998 L19.0831636,10.6015864 C19.2694636,10.4141864 19.3739636,10.1607864 19.3739636,9.89662645 C19.3739636,9.67646811 19.3013941,9.46376811 19.1693918,9.2905577 L19.0831636,9.19162645 L20.4931636,7.78162645 Z M9.88001,12.70998 L11.28998,14.11998 L4.22001,21.18998 L2.81001,19.77998 L9.88001,12.70998 Z M14.11998,2.63264 C14.91498,2.63264 15.67748,2.9482 16.23998,3.51 L16.23998,3.51 L14.81998,4.92 C14.63258,4.73375 14.37918,4.62921 14.11498,4.62921 C13.85078,4.62921 13.59728,4.73375 13.40998,4.92 L13.40998,4.92 L8.45865,9.87864 L8.46001,9.88 L4.93001,13.41998 C4.74376,13.60738 4.63922,13.86078 4.63922,14.12498 C4.63922,14.38918 4.74376,14.64258 4.93001,14.82998 L4.93001,14.82998 L3.52001,16.23998 C2.95821,15.67748 2.64265,14.91498 2.64265,14.11998 C2.64265,13.32498 2.95821,12.56248 3.52001,11.99998 L3.52001,11.99998 L7.05001,8.46 L7.05365,8.46364 L11.99998,3.51 C12.515605,2.99501667 13.1992856,2.68694333 13.922004,2.63917405 Z M19.77998,2.81001 L21.18998,4.22001 L14.11998,11.28998 L12.70998,9.88001 L19.77998,2.81001 Z">
+                      </path>
+                    </svg>
+                  </span>`;
+    this.dom.innerHTML = oneLineTrim(html);
+  }
+}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -11,3 +11,16 @@ code {
   font-family: courier, monospace;
   padding: 0 3px;
 }
+
+.firefox-svg-bug {
+  display: inline-flex;
+  align-items: center;
+  border: 0.1rem solid gray;
+  padding: 0.1rem 0.6rem;
+  border-radius: 0.6rem;
+}
+
+.firefox-svg-bug__icon {
+  width: 1.3rem;
+  height: 1.3rem;
+}


### PR DESCRIPTION
### Overview
Ok, so this PR is a weird one.
It seems that Firefox + inline SVGs + prosemirror do not mix well in combination with selections.

**Why?**
I can't say I have really an idea

**What is the solution?**
There is no real (complete) solution at the moment. 
[prosemirror-view 1.43.3](https://github.com/ProseMirror/prosemirror-view/releases/tag/1.34.3) contains some fixes related to this, but they don't solve all cases/issues.

**What does this PR contain?**
- An update to [prosemirror-view 1.43.3](https://github.com/ProseMirror/prosemirror-view/releases/tag/1.34.3)
- A way to easily reproduce the bug on the sample pages. I have added a `FirefoxSVGBug` sample document to be able to easily reproduce the issues. I have added a specific node-spec + non-ember node-view containing an inline SVG.

TODOS:
- [ ] We can detect whether the current browser engine is Gecko, and then disable the inline SVGs in nodes

##### connected issues and PRs:
None

### How to test/reproduce
- Open any dummy page on firefox
- Insert the `FirefoxSVGBug` sample
- Try to create selections around both `link` and the `firefox_svg_bug` nodes.
   * The behaviour around `link` nodes should be improved, but is far from perfect (flickering etc.)
   * The behaviour around `firefox_svg_bug` nodes should be completely broken.
- Test the same sample in a chromium browser, it should work without issues.

### Challenges/uncertainties
I was kinda losing my mind when trying to reproduce this issues, so it could very well be I missed something trivial.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
