### PR TITLE
Make rdfa blocks non-defining for content

### DIFF
--- a/.changeset/angry-geckos-rescue.md
+++ b/.changeset/angry-geckos-rescue.md
@@ -1,0 +1,8 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Make block-rdfa non-defining for copy operations
+
+This means that when you copy text from inside an rdfa block, the block itself
+no longer gets copied along. It just stays where it is, which is more natural

--- a/addon/nodes/block-rdfa.ts
+++ b/addon/nodes/block-rdfa.ts
@@ -18,7 +18,7 @@ export const blockRdfaWithConfig: (config?: Config) => SayNodeSpec = ({
     content: 'block+',
     group: 'block',
     attrs: rdfaAttrSpec({ rdfaAware }),
-    defining: true,
+    definingAsContext: true,
     editable: rdfaAware,
     isolating: rdfaAware,
     selectable: rdfaAware,


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Copying text from rdfa blocks was annoying as the surrounding rdfa context was
copied along, which is usually not what you want.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

[GN-4685](https://binnenland.atlassian.net/browse/GN-4685)

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
