### PR TITLE
internal: disable `rdfa-aware` setting for `heading` nodes in dummy app

### DIFF
--- a/.changeset/eighty-suns-melt.md
+++ b/.changeset/eighty-suns-melt.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Disable `rdfaAware` setting for heading nodes in dummy app

--- a/tests/dummy/app/controllers/editable-node.ts
+++ b/tests/dummy/app/controllers/editable-node.ts
@@ -107,7 +107,7 @@ export default class EditableBlockController extends Controller {
         cellContent: 'block+',
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
       }),
-      heading: headingWithConfig({ rdfaAware: true }),
+      heading: headingWithConfig({ rdfaAware: false }),
       blockquote,
 
       horizontal_rule,


### PR DESCRIPTION
### Overview
This PR disables the `rdfaAware` setting on `heading` nodes in the dummy app to ensure consistency with the frontends.

##### connected issues and PRs:
https://github.com/lblod/frontend-gelinkt-notuleren/pull/748
https://github.com/lblod/frontend-reglementaire-bijlage/pull/291

### How to test/reproduce
- Start the dummy app
- Open the 'Editable Nodes' page
- Ensure that headings are no longer 'rdfa-aware': there is no border shown around them, you can enter inside them etc.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
