### PR TITLE
Styling: improve margins around editor elements

### DIFF
--- a/.changeset/famous-rabbits-leave.md
+++ b/.changeset/famous-rabbits-leave.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Adjust margin rules to not target invisible elements

--- a/.changeset/selfish-poems-change.md
+++ b/.changeset/selfish-poems-change.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Adjust margin rules to be consistent across all types of elements (including headings). Note: this reduces the margin around headings

--- a/.changeset/soft-points-study.md
+++ b/.changeset/soft-points-study.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Reduce editor padding

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -305,7 +305,12 @@ export function renderInvisibleRdfa(
   }
   return [
     tag,
-    { style: 'display: none', 'data-rdfa-container': true, ...attrs },
+    {
+      style: 'display: none',
+      class: 'say-hidden',
+      'data-rdfa-container': true,
+      ...attrs,
+    },
     ...propElements,
   ];
 }

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -123,14 +123,22 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
   }
 
   // Setup some margin rules
-  p + *,
-  div + *,
-  span + *,
-  ul + *,
-  ol + *,
-  i + *,
-  table + * {
-    margin-top: $say-typography-margin;
+  p,
+  ul,
+  ol,
+  table,
+  div,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    &:not(.say-hidden) {
+      + * {
+        margin-top: $say-typography-margin;
+      }
+    }
   }
 
   [data-indentation-level='1'] {
@@ -167,25 +175,6 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
   i + br,
   br + br {
     margin-top: 0;
-  }
-
-  h1,
-  .h1 {
-    margin-top: $say-typography-margin * 2;
-    margin-bottom: $say-typography-margin * 2;
-  }
-
-  h2,
-  .h2,
-  h3,
-  .h3,
-  h4,
-  .h4,
-  h5,
-  .h5,
-  h6 {
-    margin-top: $say-typography-margin * 2;
-    margin-bottom: $say-typography-margin;
   }
 
   // Style links

--- a/app/styles/ember-rdfa-editor/_c-editor.scss
+++ b/app/styles/ember-rdfa-editor/_c-editor.scss
@@ -10,7 +10,7 @@ $say-editor-background: var(--au-gray-100) !default;
 $say-editor-sidebar-medium: 30% !default;
 $say-editor-sidebar-large: 30% !default;
 $say-paper-min-height: calc(100vh + #{$au-unit}) !default;
-$say-paper-padding: $au-unit-large !default;
+$say-paper-padding: $au-unit !default;
 $say-paper-background: var(--au-white) !default;
 $say-paper-box-shadow:
   0 1px 3px rgba($au-gray-900, 0.1),

--- a/tests/unit/prosemirror/view-test.ts
+++ b/tests/unit/prosemirror/view-test.ts
@@ -12,7 +12,7 @@ module('ProseMirror | view', function () {
     });
     const htmlToInsert = oneLineTrim`
     <div lang="en-US" data-say-document="true">
-      <div style="display: none" data-rdfa-container="true"></div>
+      <div style="display: none" class="say-hidden" data-rdfa-container="true"></div>
       <div data-content-container="true">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
            Fusce euismod mauris in lacus mollis, eu laoreet risus sollicitudin.
@@ -67,7 +67,7 @@ module('ProseMirror | view', function () {
     `;
     const expectedHtml = oneLineTrim`
     <div lang="en-US" data-say-document="true">
-      <div style="display: none" data-rdfa-container="true"></div>
+      <div style="display: none" class="say-hidden" data-rdfa-container="true"></div>
       <div data-content-container="true">
         <p>Lorem ips<strong>um dolor s</strong>
         </p>
@@ -106,7 +106,7 @@ module('ProseMirror | view', function () {
     });
     const htmlToInsert = oneLineTrim`
     <div lang="en-US" data-say-document="true">
-      <div style="display: none" data-rdfa-container="true"></div>
+      <div style="display: none" class="say-hidden" data-rdfa-container="true"></div>
       <div data-content-container="true">
         <p>   </p>
         <p>


### PR DESCRIPTION
### Overview
This PR includes some improvements/simplifications around editor element margins. Specifically:
- Ensure only visible elements are targeted when adding margins between subsequent elements
- Addition of the `say-hidden` class
- Adjust margins of `heading` elements to be consistent with the margins of other elements.
- A reduction in editor padding, based on the figma design

**Before**
![image](https://github.com/user-attachments/assets/1e624507-5a81-4454-a245-81fb61cdc3ca)

**After**
![image](https://github.com/user-attachments/assets/684db225-8ded-471b-90c6-06e0a5523be5)


##### connected issues and PRs:
[Figma design](https://www.figma.com/design/tfBSv7999dzz1sy6svMfsY/GN_editor?node-id=81-575&node-type=frame&t=dtIH7fBJWRzp9lLW-0)

### How to test/reproduce
- Start the dummy app
- Notice that there are no longer any additional margins above paragraphs, headings etc. where it doesn't seem needed.

### Challenges/uncertainties
I don't know if the reduction in margins around headings is desired. But it seemed more user-friendly to make it consistent with the margins of other elements.
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
