### PR TITLE
redesign link to have coherent pills

### DIFF
--- a/.changeset/polite-bees-develop.md
+++ b/.changeset/polite-bees-develop.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Add say-pill class and use it on the link

--- a/addon/components/ember-node/link.hbs
+++ b/addon/components/ember-node/link.hbs
@@ -1,9 +1,7 @@
 {{! @glint-nocheck: not typesafe yet }}
 <this.Velcro @placement='bottom' @offsetOptions={{hash mainAxis=3}} as |velcro|>
   <Pill
-    class='say-link'
-    @icon={{this.LinkIcon}}
-    @iconAlignment='right'
+    class='say-pill'
     @skin='link'
     title={{t 'ember-rdfa-editor.link.ctrlClickDescription'}}
     aria-describedby='link-tooltip'

--- a/addon/components/ember-node/link.ts
+++ b/addon/components/ember-node/link.ts
@@ -10,7 +10,6 @@ import { LinkBrokenIcon } from '@appuniversum/ember-appuniversum/components/icon
 
 export default class Link extends Component<EmberNodeArgs> {
   Velcro = Velcro;
-  LinkIcon = LinkIcon;
   LinkExternalIcon = LinkExternalIcon;
   LinkBrokenIcon = LinkBrokenIcon;
 

--- a/addon/components/ember-node/link.ts
+++ b/addon/components/ember-node/link.ts
@@ -4,7 +4,6 @@ import type { EmberNodeArgs } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import { linkToHref } from '@lblod/ember-rdfa-editor/utils/_private/string-utils';
 import { Velcro } from 'ember-velcro';
 import { EditorState } from '@lblod/ember-rdfa-editor';
-import { LinkIcon } from '@appuniversum/ember-appuniversum/components/icons/link';
 import { LinkExternalIcon } from '@appuniversum/ember-appuniversum/components/icons/link-external';
 import { LinkBrokenIcon } from '@appuniversum/ember-appuniversum/components/icons/link-broken';
 

--- a/app/styles/ember-rdfa-editor/_c-link.scss
+++ b/app/styles/ember-rdfa-editor/_c-link.scss
@@ -42,7 +42,6 @@
     word-break: break-all;
     word-wrap: break-word;
     cursor: text;
-    padding: 2px;
     color: var(--au-blue-700);
   }
 }

--- a/app/styles/ember-rdfa-editor/_c-link.scss
+++ b/app/styles/ember-rdfa-editor/_c-link.scss
@@ -26,10 +26,15 @@
   }
 }
 
-.say-link {
+.say-pill {
   gap: 0;
   vertical-align: bottom;
-
+  min-height: 24px;
+  background-color: var(--au-blue-100);
+  border-color: var(--au-blue-300);
+  border-radius: var(--au-radius);
+  font-weight: var(--au-regular);
+  color: var(--au-blue-700);
   [contenteditable] {
     outline: none;
     white-space: break-spaces;
@@ -37,12 +42,14 @@
     word-wrap: break-word;
     cursor: text;
     min-width: 5rem;
-    padding-right: 0.5rem;
+    padding: 2px;
+    color: var(--au-blue-700);
+
   }
 }
 
 .ember-node.ProseMirror-selectednode {
-  .say-link {
+  .say-pill {
     background-color: var(--au-blue-200);
     outline: 2px solid var(--au-blue-500);
     outline-offset: -2px;

--- a/app/styles/ember-rdfa-editor/_c-link.scss
+++ b/app/styles/ember-rdfa-editor/_c-link.scss
@@ -30,7 +30,7 @@
   gap: 0;
   vertical-align: bottom;
   height: 1.5rem;
-  margin-bottom: -0.2rem;
+  margin-bottom: -0.1rem;
   background-color: var(--au-blue-100);
   border-color: var(--au-blue-300);
   border-radius: var(--au-radius);

--- a/app/styles/ember-rdfa-editor/_c-link.scss
+++ b/app/styles/ember-rdfa-editor/_c-link.scss
@@ -30,6 +30,7 @@
   gap: 0;
   vertical-align: bottom;
   min-height: 24px;
+  margin-bottom: -3px;
   background-color: var(--au-blue-100);
   border-color: var(--au-blue-300);
   border-radius: var(--au-radius);
@@ -41,7 +42,6 @@
     word-break: break-all;
     word-wrap: break-word;
     cursor: text;
-    min-width: 5rem;
     padding: 2px;
     color: var(--au-blue-700);
 

--- a/app/styles/ember-rdfa-editor/_c-link.scss
+++ b/app/styles/ember-rdfa-editor/_c-link.scss
@@ -44,7 +44,6 @@
     cursor: text;
     padding: 2px;
     color: var(--au-blue-700);
-
   }
 }
 

--- a/app/styles/ember-rdfa-editor/_c-link.scss
+++ b/app/styles/ember-rdfa-editor/_c-link.scss
@@ -29,8 +29,8 @@
 .say-pill {
   gap: 0;
   vertical-align: bottom;
-  min-height: 24px;
-  margin-bottom: -3px;
+  height: 1.5rem;
+  margin-bottom: -0.2rem;
   background-color: var(--au-blue-100);
   border-color: var(--au-blue-300);
   border-radius: var(--au-radius);


### PR DESCRIPTION
### Overview
Redesign the links to have a coherent style with the variable pills from the plugins

##### connected issues and PRs:
GN-5121


### Setup
None

### How to test/reproduce
Insert a link an check if the design matches the figma 
https://www.figma.com/design/tfBSv7999dzz1sy6svMfsY/GN_editor?node-id=81-575&node-type=frame&t=heaVowawbkSrqvag-0

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
