### PR TITLE
fix(styling): revert specificity of general editor margin rule to (0,1,1)

### DIFF
--- a/.changeset/strong-trainers-compare.md
+++ b/.changeset/strong-trainers-compare.md
@@ -1,0 +1,6 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Reduce specificity of general editor margin rule.
+This fix reverts a previous breaking change wherein the specificity of the general editor margin css rule was increased from (0,1,1) to (0,2,1). This fix ensures the specificity is reverted back to (0,1,1).

--- a/app/styles/ember-rdfa-editor/_c-content.scss
+++ b/app/styles/ember-rdfa-editor/_c-content.scss
@@ -134,11 +134,13 @@ $say-editor-highlight-selected-color: var(--au-gray-300) !default;
   h4,
   h5,
   h6 {
-    &:not(.say-hidden) {
-      + * {
-        margin-top: $say-typography-margin;
-      }
+    + * {
+      margin-top: $say-typography-margin;
     }
+  }
+
+  .say-hidden + * {
+    margin-top: 0;
   }
 
   [data-indentation-level='1'] {


### PR DESCRIPTION
### Overview
This PR fixes a styling regression introduced in [10.7.0](https://github.com/lblod/ember-rdfa-editor/releases/tag/v10.7.0) wherein the specificity of the general editor margin css rule was increased from (0,1,1) to (0,2,1). This broke some styling in (among others) the plugins css.

This PR splits the general margin rule in two seperate rules, each with a specificity of (0,1,1).

##### connected issues and PRs:
None


### Setup
https://github.com/lblod/ember-rdfa-editor/pull/1224

### How to test/reproduce
- In the dummy app, styling wise, nothing should have changed
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
