### PR TITLE
fix(utils): remove circular import

### DIFF
--- a/.changeset/shiny-fishes-retire.md
+++ b/.changeset/shiny-fishes-retire.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Move RDF namespace objects out of constants file to prevent circular imports

--- a/addon/nodes/block-rdfa.ts
+++ b/addon/nodes/block-rdfa.ts
@@ -8,7 +8,7 @@ import {
 } from '@lblod/ember-rdfa-editor/core/schema';
 import type SayNodeSpec from '../core/say-node-spec';
 import type { NodeView } from 'prosemirror-view';
-import { RDF, SKOS } from '../utils/_private/constants';
+import { RDF, SKOS } from '../utils/_private/namespaces';
 import { getRDFFragment } from '../utils/namespace';
 
 const FALLBACK_LABEL = 'Data-object';

--- a/addon/utils/_private/constants.ts
+++ b/addon/utils/_private/constants.ts
@@ -3,9 +3,6 @@
  * we've added a, del, ins to the list since we assume they only contain phrasing content in the editor
  * we've removed br from the list to be inline with editor behaviour, which treats it as a block
  **/
-
-import { namespace } from '../namespace';
-
 export const PHRASING_CONTENT = [
   'a',
   'abbr',
@@ -142,9 +139,3 @@ export const RDFA_ATTRIBUTES = [
   'typeof',
   'lang',
 ];
-
-export const SKOS = namespace('http://www.w3.org/2004/02/skos/core#', 'skos');
-export const RDF = namespace(
-  'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-  'rdf',
-);

--- a/addon/utils/_private/namespaces.ts
+++ b/addon/utils/_private/namespaces.ts
@@ -1,0 +1,7 @@
+import { namespace } from '@lblod/ember-rdfa-editor/utils/namespace';
+
+export const SKOS = namespace('http://www.w3.org/2004/02/skos/core#', 'skos');
+export const RDF = namespace(
+  'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+  'rdf',
+);


### PR DESCRIPTION
### Overview
This PR removes a circular import introduced by adding namespace objects in the constants file. Specifically, it moves those namespace objects out to a seperate `namespaces.ts` file.

### How to test/reproduce
- The ember tests should run without errors again

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
