### PR TITLE
Allow multiline pills

### DIFF
--- a/.changeset/rich-toys-eat.md
+++ b/.changeset/rich-toys-eat.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix bug not allowing multiline pills

--- a/app/styles/ember-rdfa-editor/_c-link.scss
+++ b/app/styles/ember-rdfa-editor/_c-link.scss
@@ -29,8 +29,9 @@
 .say-pill {
   gap: 0;
   vertical-align: bottom;
-  height: 1.5rem;
+  min-height: 2.55rem;
   margin-bottom: -0.1rem;
+  margin-top: 2px;
   background-color: var(--au-blue-100);
   border-color: var(--au-blue-300);
   border-radius: var(--au-radius);


### PR DESCRIPTION
### Overview
Contrary to what I thought we have an use case for multiline pills, they are used on very long links/variables. This is okay because the text before and after the pill gets broken in different lines, so it looks good.
I also added some margin top to the pill so there's a gap between the multiline pill and the pills on the line below

##### connected issues and PRs:
GN-5229


### Setup
None
### How to test/reproduce
Insert a link with multiple lines and check that is rendered correctly

### Challenges/uncertainties
While testing this PR I noticed that the number variable has a weird outline
![image](https://github.com/user-attachments/assets/96d37b95-393b-4a4e-9f2d-58349c01e4b5)
I don't know where is coming from, but doesn't seem to be a regression 



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
