### PR TITLE
Feat/recreate uuids rework

### DIFF
--- a/.changeset/hungry-zoos-hide.md
+++ b/.changeset/hungry-zoos-hide.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Recreate uuids plugin rework

--- a/.changeset/tiny-tables-arrive.md
+++ b/.changeset/tiny-tables-arrive.md
@@ -1,9 +1,0 @@
----
-'@lblod/ember-rdfa-editor': major
----
-
-Recreate uuids plugin rework
-Now in order to make the recreateUuids on a node you must specify a function, called recreateUriFunction in the spec, that gets your node attributes and returns
-a new set of attributes with the uuids recreated, a function called `recreateUriAttribute(attrs: Attrs, uriAttributes: [string])`
-is exported from the plugin file, to help recreate the old behaviour.
-Also the function `recreateUri(oldUri: string)` is provided to help recreate a specific uri.

--- a/.changeset/tiny-tables-arrive.md
+++ b/.changeset/tiny-tables-arrive.md
@@ -1,0 +1,9 @@
+---
+'@lblod/ember-rdfa-editor': major
+---
+
+Recreate uuids plugin rework
+Now in order to make the recreateUuids on a node you must specify a function, called recreateUriFunction in the spec, that gets your node attributes and returns
+a new set of attributes with the uuids recreated, a function called `recreateUriAttribute(attrs: Attrs, uriAttributes: [string])`
+is exported from the plugin file, to help recreate the old behaviour.
+Also the function `recreateUri(oldUri: string)` is provided to help recreate a specific uri.

--- a/addon/plugins/recreateUuidsOnPaste.ts
+++ b/addon/plugins/recreateUuidsOnPaste.ts
@@ -48,6 +48,14 @@ function recreateUuidsOnNode(node: Node, schema: Schema) {
   if (spec['recreateUriFunction']) {
     attrs = spec['recreateUriFunction'](node.attrs);
   }
+  if (spec['recreateUri']) {
+    if (spec['uriAttributes']) {
+      attrs = {
+        ...attrs,
+        ...recreateUriAttribute(attrs, spec['uriAttributes']),
+      };
+    }
+  }
   return schema.node(
     node.type,
     attrs,
@@ -67,7 +75,7 @@ export function recreateUriAttribute(attrs: Attrs, uriAttributes: [string]) {
     const newUri = oldUriParts.join('/');
     newAttributes[uriAttribute as string] = newUri;
   }
-  attrs = { ...attrs, ...newAttributes };
+  return { ...attrs, ...newAttributes };
 }
 
 export function recreateUri(oldUri: string) {

--- a/addon/plugins/recreateUuidsOnPaste.ts
+++ b/addon/plugins/recreateUuidsOnPaste.ts
@@ -1,4 +1,10 @@
-import { Fragment, Slice, Node, Schema } from '@lblod/ember-rdfa-editor';
+import {
+  Fragment,
+  Slice,
+  Node,
+  Schema,
+  type Attrs,
+} from '@lblod/ember-rdfa-editor';
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -39,18 +45,8 @@ function recreateUuidsOnNode(node: Node, schema: Schema) {
   let attrs = node.attrs;
   const type = node.type;
   const spec = type.spec;
-  if (spec['recreateUri']) {
-    if (spec['uriAttributes']) {
-      const newAttributes: Record<string, string> = {};
-      for (const uriAttribute of spec['uriAttributes']) {
-        const oldUri = node.attrs[uriAttribute as string] as string;
-        const oldUriParts = oldUri.split('/');
-        oldUriParts[oldUriParts.length - 1] = uuidv4();
-        const newUri = oldUriParts.join('/');
-        newAttributes[uriAttribute as string] = newUri;
-      }
-      attrs = { ...node.attrs, ...newAttributes };
-    }
+  if (spec['recreateUriFunction']) {
+    attrs = spec['recreateUriFunction'](node.attrs);
   }
   return schema.node(
     node.type,
@@ -61,3 +57,22 @@ function recreateUuidsOnNode(node: Node, schema: Schema) {
 }
 
 export default recreateUuidsOnPaste;
+
+export function recreateUriAttribute(attrs: Attrs, uriAttributes: [string]) {
+  const newAttributes: Record<string, string> = {};
+  for (const uriAttribute of uriAttributes) {
+    const oldUri = attrs[uriAttribute as string] as string;
+    const oldUriParts = oldUri.split('/');
+    oldUriParts[oldUriParts.length - 1] = uuidv4();
+    const newUri = oldUriParts.join('/');
+    newAttributes[uriAttribute as string] = newUri;
+  }
+  attrs = { ...attrs, ...newAttributes };
+}
+
+export function recreateUri(oldUri: string) {
+  const oldUriParts = oldUri.split('/');
+  oldUriParts[oldUriParts.length - 1] = uuidv4();
+  const newUri = oldUriParts.join('/');
+  return newUri;
+}

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -18,6 +18,7 @@ import type {
   DOMOutputSpec,
   TagParseRule,
   Node as PNode,
+  Attrs,
 } from 'prosemirror-model';
 import {
   Decoration,
@@ -337,9 +338,7 @@ export type EmberNodeConfig = {
   /** @see {@link https://prosemirror.net/docs/ref/#model.NodeSpec.defining} */
   defining?: boolean;
   /** Generate a new URI when pasting the node? */
-  recreateUri?: boolean;
-  /** A list of attribute names which contain URIs to be regenerated on paste */
-  uriAttributes?: string[];
+  recreateUriFunction: (attrs: Attrs) => Attrs;
   /** A map of attributes to assign to this node */
   attrs?: {
     [name: string]: AttributeSpec & {
@@ -397,8 +396,7 @@ export function createEmberNodeSpec(config: EmberNodeConfig): SayNodeSpec {
     atom,
     draggable,
     defining,
-    recreateUri,
-    uriAttributes,
+    recreateUriFunction,
     attrs,
     parseDOM,
     toDOM,
@@ -410,8 +408,7 @@ export function createEmberNodeSpec(config: EmberNodeConfig): SayNodeSpec {
     atom,
     group,
     content,
-    recreateUri,
-    uriAttributes,
+    recreateUriFunction,
     attrs,
     draggable,
     defining,

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -338,7 +338,7 @@ export type EmberNodeConfig = {
   /** @see {@link https://prosemirror.net/docs/ref/#model.NodeSpec.defining} */
   defining?: boolean;
   /** Generate a new URI when pasting the node? */
-  recreateUriFunction: (attrs: Attrs) => Attrs;
+  recreateUriFunction?: (attrs: Attrs) => Attrs;
   /** A map of attributes to assign to this node */
   attrs?: {
     [name: string]: AttributeSpec & {

--- a/addon/utils/_private/ember-node.ts
+++ b/addon/utils/_private/ember-node.ts
@@ -337,6 +337,14 @@ export type EmberNodeConfig = {
   draggable?: boolean;
   /** @see {@link https://prosemirror.net/docs/ref/#model.NodeSpec.defining} */
   defining?: boolean;
+  /**
+   * @deprecated
+   */
+  recreateUri?: boolean;
+  /**
+   * @deprecated
+   */
+  uriAttributes?: [string];
   /** Generate a new URI when pasting the node? */
   recreateUriFunction?: (attrs: Attrs) => Attrs;
   /** A map of attributes to assign to this node */
@@ -396,6 +404,8 @@ export function createEmberNodeSpec(config: EmberNodeConfig): SayNodeSpec {
     atom,
     draggable,
     defining,
+    recreateUri,
+    uriAttributes,
     recreateUriFunction,
     attrs,
     parseDOM,
@@ -408,6 +418,8 @@ export function createEmberNodeSpec(config: EmberNodeConfig): SayNodeSpec {
     atom,
     group,
     content,
+    recreateUri,
+    uriAttributes,
     recreateUriFunction,
     attrs,
     draggable,


### PR DESCRIPTION
### Overview
Rework the recreate uuids function so it works better with the actual use case

##### connected issues and PRs:



### Setup
None

### How to test/reproduce
Test on https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/511

### Challenges/uncertainties
As I broke the retrocompatibility for the plugin I decided to do a major release



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
