### PR TITLE
Fix bug where imported resources were repeated

### DIFF
--- a/.changeset/perfect-months-itch.md
+++ b/.changeset/perfect-months-itch.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix bug with multiple imported resource relationships that lead to duplication of these relationships

--- a/.woodpecker/.e2e.yml
+++ b/.woodpecker/.e2e.yml
@@ -5,7 +5,10 @@ steps:
     commands:
       - corepack enable
       - pnpm i --frozen-lockfile
-      - pnpm playwright test
+      - pnpm e2e:run
+      # Ideally we would also run the visual regression tests, but we need to fix the update process
+      # for them first
+      # - pnpm playwright test
 when:
   event:
     - pull_request

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -183,16 +183,21 @@ export function getRdfaAwareDocAttrs(
   if (hasResourceImports) {
     const hidden = findRdfaHiddenElements(node);
     if (hidden) {
+      const imports = new Map<string, OutgoingTriple[]>();
       for (const hid of hidden) {
         const hiddenRdfaAttrs = getRdfaAttrs(hid as HTMLElement, {
           rdfaAware: true,
         });
-        if (hiddenRdfaAttrs) {
-          if ('properties' in hiddenRdfaAttrs) {
-            properties.push(...hiddenRdfaAttrs.properties);
-          }
+        // Since 'getRdfaAttrs' returns the properties for the resource URI, not the node, it
+        // actually gives us *all* of the properties for each hidden element. We need to
+        // de-duplicate these so we only get each set once, per imported resource.
+        // It might make more sense to do this in the rdfa-processor, e.g. in the preprocessRDFa()
+        // function
+        if (hiddenRdfaAttrs && 'properties' in hiddenRdfaAttrs) {
+          imports.set(hiddenRdfaAttrs.subject, hiddenRdfaAttrs.properties);
         }
       }
+      properties.push(...[...imports.values()].flat());
     }
   }
   let externalTriples: FullTriple[] = [];


### PR DESCRIPTION
### Overview
Fixes bug reported by @elpoelma by de-duplicating imported resources for each subject when parsing the doc node.

##### connected issues and PRs:
N/A

### Setup
Easiest to test `pnpm link`ed into the plugins repo.

### How to test/reproduce
At each of these steps, check that the document state, specifically the properties & backlinks, are as you would expect:
- Create a document in an editor with support for imported resources (e.g. the snippet sample in the plugins repo)
- Create at least 2 resources in the document
- Select the document node and add a relationship from an imported resource to one of the resources
- Add another relationship to the same imported resource for the other resource
- Reload the page and check the relationships of the document node

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
