### PR TITLE
Fix document RDFa extractor to get subject attributes

### DIFF
--- a/.changeset/rude-pillows-confess.md
+++ b/.changeset/rude-pillows-confess.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix crash when saving documents with subjects

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -174,7 +174,9 @@ export function getRdfaAwareDocAttrs(
   }
 
   let properties: OutgoingTriple[] = [];
+  let subject: string | undefined = undefined;
   if (node.dataset['outgoingProps']) {
+    subject = node.dataset['subject'];
     properties = JSON.parse(
       node.dataset['outgoingProps'],
       jsonToTerm,
@@ -208,6 +210,7 @@ export function getRdfaAwareDocAttrs(
   return {
     backlinks,
     externalTriples,
+    subject,
     properties,
   };
 }

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -174,9 +174,8 @@ export function getRdfaAwareDocAttrs(
   }
 
   let properties: OutgoingTriple[] = [];
-  let subject: string | undefined = undefined;
+  const subject = node.dataset['subject'];
   if (node.dataset['outgoingProps']) {
-    subject = node.dataset['subject'];
     properties = JSON.parse(
       node.dataset['outgoingProps'],
       jsonToTerm,


### PR DESCRIPTION
### Overview
Currently causes RB to crash when attempting to save new regulatory statement templates as they have properties but no subject.

##### connected issues and PRs:
N/A

### Setup
I tested linked to RB.

### How to test/reproduce
Create a new blank regulatory statement template in RB and then save it. It should save and not crash.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
