### PR TITLE
Tweak style used by active ember-nodes to have rounded corners

### DIFF
--- a/.changeset/popular-starfishes-mix.md
+++ b/.changeset/popular-starfishes-mix.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Tweak style used by active ember nodes such as snippet placeholders to have rounded corners

--- a/app/styles/ember-rdfa-editor/_c-inline-rdfa.scss
+++ b/app/styles/ember-rdfa-editor/_c-inline-rdfa.scss
@@ -14,6 +14,7 @@
   white-space: normal !important;
   &.say-active {
     outline: 0.2rem solid var(--au-blue-500);
+    border-radius: var(--au-radius);
   }
   .say-inline-rdfa {
     [contenteditable] {


### PR DESCRIPTION
### Overview
Fixes snippet-placeholders. This style is normally overridden for most ember-nodes, e.g. by anything including a pill. Also affects mandatee tables and inserted snippets.

##### connected issues and PRs:
There will be a plugins PR to fix mandatee tables and snippets.

### Setup
Needs to be tested where these nodes are available, e.g. linked to the plugins

### How to test/reproduce
Insert a snippet-placeholder, select it, note that the blue border matches the border-radius of the node.

### Challenges/uncertainties
There's a chance that this causes visual issues somewhere I didn't spot.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
