### PR TITLE
Ignore instead of fail when rendering BlankNode with no subject

### DIFF
--- a/.changeset/witty-moose-mate.md
+++ b/.changeset/witty-moose-mate.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+If trying to render a BlankNode with no subject, ignore it instead of crashing

--- a/addon/core/schema.ts
+++ b/addon/core/schema.ts
@@ -289,6 +289,13 @@ export function renderInvisibleRdfa(
       case 'BlankNode': {
         // the triple refers to a URI which does not have a corresponding
         // resource node
+        if (!isSome(nodeOrMark.attrs['subject'])) {
+          console.warn(
+            'Trying to render a BlankNode with no subject, ignoring',
+            nodeOrMark.attrs,
+          );
+          break;
+        }
         const subject: string = unwrap(nodeOrMark.attrs['subject'] as string);
         propElements.push(namedNodeSpan(subject, predicate, object.value));
         break;


### PR DESCRIPTION
### Overview
Spotted when trying to figure out a different problem, but this makes sense on it's own.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
An easy way to trigger this is to link to the plugins repo and use the regulatory statement sample page with the 'DecisionTemplate' example.

### Challenges/uncertainties
I don't know why it decides this template includes a snippet, but this at least makes it not crash.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
