### PR TITLE
GN-5369: hide gapcursor when editor is not focused

### DIFF
--- a/.changeset/tasty-garlics-judge.md
+++ b/.changeset/tasty-garlics-judge.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Hide gapcursor when editor is not focused

--- a/app/styles/ember-rdfa-editor.scss
+++ b/app/styles/ember-rdfa-editor.scss
@@ -16,6 +16,7 @@
 // VARIABLES
 
 .ProseMirror-gapcursor {
+  display: none;
   border-top: 1px solid black;
   animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
   margin-top: 0.5rem;


### PR DESCRIPTION
### Overview
This PR adjust the gap-cursor styles to ensure it is not shown when the editor is focused.

##### connected issues and PRs:
Possible solution to [GN-5369](https://binnenland.atlassian.net/browse/GN-5369)

### How to test/reproduce
- Start the dummy app
- Insert an isolating block node (e.g. table)
- Click underneath to trigger a gapcursor
- Unfocus the editor: ensure the gapcursor is no longer visible

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
