### PR TITLE
`wrapIncludeParents`: improve behaviour with gap-cursor selections

### DIFF
--- a/.changeset/tame-hornets-boil.md
+++ b/.changeset/tame-hornets-boil.md
@@ -1,0 +1,6 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Improve behaviour of `wrapIncludingParents` when working with gap-cursor selections. When the selection is a gap-cursor, do not wrap around its parent, but rather simply insert a node of the given `nodeType` at that selection.
+This ensures the behaviour of the command is similar as when it is dealing with a collapsed text-selection. 

--- a/addon/commands/wrap-including-parents.ts
+++ b/addon/commands/wrap-including-parents.ts
@@ -19,7 +19,7 @@ export function wrapIncludingParents(
     if (state.selection instanceof GapCursor) {
       const { $from } = state.selection;
       const contentMatch = $from.parent.contentMatchAt($from.index());
-      if(!contentMatch.matchType(nodeType)){
+      if (!contentMatch.matchType(nodeType)) {
         return false;
       }
       const node = nodeType.createAndFill(attrs);

--- a/addon/commands/wrap-including-parents.ts
+++ b/addon/commands/wrap-including-parents.ts
@@ -2,6 +2,7 @@ import type { Command } from 'prosemirror-state';
 import type { Attrs, NodeType } from 'prosemirror-model';
 import { findWrapping } from 'prosemirror-transform';
 import { selectParentNode } from 'prosemirror-commands';
+import { GapCursor } from '../plugins/gap-cursor';
 
 /**
  * Wrap the selection in a node of the given type with the given attributes.
@@ -13,6 +14,23 @@ export function wrapIncludingParents(
   attrs: Attrs | null = null,
 ): Command {
   return function (state, dispatch) {
+    // Treat gap-cursor selections as a special case, do not wrap around its parent.
+    // This ensures that its behaviour is similar as that of normal collapsed text cursors.
+    if (state.selection instanceof GapCursor) {
+      const { $from } = state.selection;
+      const contentMatch = $from.parent.contentMatchAt($from.index());
+      if(!contentMatch.matchType(nodeType)){
+        return false;
+      }
+      const node = nodeType.createAndFill(attrs);
+      if (!node) {
+        return false;
+      }
+      if (dispatch) {
+        dispatch(state.tr.replaceRangeWith($from.pos, $from.pos, node));
+      }
+      return true;
+    }
     const { $from, $to } = state.selection;
     const range = $from.blockRange($to);
     const wrapping = range && findWrapping(range, nodeType, attrs);


### PR DESCRIPTION
### Overview
The `wrapIncludeParents` command typically tries to create a node which wraps around the parent of the current selection. 
This PR includes a slight modification to that command: if the current selection is a `gap-cursor`, it will not try to find a wrapping, but rather try to replace that current selection directly with a node of the given `nodeType`.
This might be a bit counter-intuitive, but it actually ensures that the behaviour of the command of the command is similar as when it is dealing with a collapsed text-selection.

##### connected issues and PRs:
None

### How to test/reproduce
- Start the test-app
- Get a gap-cursor selection somewhere
- Click on the 'Wrap with Block Resource'/'Wrap with Block Literal'
- Ensure the command does not try to wrap the new node around the parent of the gap-cursor selection


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
