### PR TITLE
GN-5228: fix issues with selection preservation

### DIFF
--- a/.changeset/proud-carpets-taste.md
+++ b/.changeset/proud-carpets-taste.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Introduce fix regarding selection preservation when using the `Transform.setNodeAttribute` or `Transform.setNodeMarkup` methods

--- a/addon/plugins/default-attribute-value-generation/index.ts
+++ b/addon/plugins/default-attribute-value-generation/index.ts
@@ -1,7 +1,7 @@
 import { changedDescendants } from '@lblod/ember-rdfa-editor/utils/_private/changed-descendants';
 import { isNone } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import { Mark, MarkType, NodeType } from 'prosemirror-model';
-import { NodeSelection, Plugin } from 'prosemirror-state';
+import { Plugin, Selection } from 'prosemirror-state';
 
 export type DefaultAttrGenPuginOptions = {
   attribute: string;
@@ -49,9 +49,12 @@ export function defaultAttributeValueGeneration(
             if (!node.hasMarkup(node.type, newAttrs, newMarks)) {
               const oldSelection = tr.selection;
               tr.setNodeMarkup(pos, null, newAttrs, newMarks);
-              if (oldSelection instanceof NodeSelection) {
-                tr.setSelection(NodeSelection.create(tr.doc, pos));
-              }
+              // A bit of a hack: we want to make sure to preserve the old selection, this allows us to easily copy it
+              const newSelection = Selection.fromJSON(
+                tr.doc,
+                oldSelection.toJSON(),
+              );
+              tr.setSelection(newSelection);
             }
           }
         });

--- a/addon/plugins/list/index.ts
+++ b/addon/plugins/list/index.ts
@@ -2,6 +2,7 @@ import {
   EditorState,
   PNode,
   ProsePlugin,
+  Selection,
   Transaction,
 } from '@lblod/ember-rdfa-editor';
 import { changedDescendants } from '@lblod/ember-rdfa-editor/utils/_private/changed-descendants';
@@ -49,9 +50,16 @@ export function listTrackingPlugin(): ProsePlugin {
         );
         if (changedLists.length) {
           const tr = newState.tr;
+          const oldSelection = tr.selection;
           for (const { node, pos } of changedLists) {
             calculateListTree(node, pos, tr);
           }
+          // A bit of a hack: we want to make sure to preserve the old selection, this allows us to easily copy it
+          const newSelection = Selection.fromJSON(
+            tr.doc,
+            oldSelection.toJSON(),
+          );
+          tr.setSelection(newSelection);
           return tr;
         }
       }


### PR DESCRIPTION
### Overview
This PR fixes some issues regarding selection preservation in both the `defaultAttributeValueGeneration` and `listTrackingPlugin` plugins.
Both plugins only manipulate positions or content in the document, they solely manipulate attributes of nodes (which are of course under the hood `ReplaceStep` operations). This however often causes a change in the document selection (I still need to investigate exactly why). 
This PR ensures that the original selections are correctly restored after the attribute manipulations.

##### connected issues and PRs:
https://github.com/lblod/frontend-gelinkt-notuleren/pull/823
[GN-5228](https://binnenland.atlassian.net/browse/GN-5228?atlOrigin=eyJpIjoiNTA5NzAyNWIyZGEwNDlmMjg0NDQ0M2U3NTZmZjcyNjYiLCJwIjoiaiJ9)

### Setup
Check-out https://github.com/lblod/frontend-gelinkt-notuleren/pull/823

### How to test/reproduce
Best tested on GN (https://github.com/lblod/frontend-gelinkt-notuleren/pull/823)
- Start the app
- Create a 'reglement' decision
- Insert some articles containing lists (e.g. mobility measures)
- Move these articles up and down
- Ensure the selection is now correctly preserved.

### Challenges/uncertainties
I realize using the JSON representation to copy selections is a bit of a hack, but I have not yet found a better way to do so. (mapping the selection with an empty `Mapping` object does not seem to work).
How `AttributeStep` is implemented: https://github.com/ProseMirror/prosemirror-transform/blob/master/src/attr_step.ts

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
