### PR TITLE
allow inline images with config and checkPasteSize plugin

### DIFF
--- a/.changeset/rude-eagles-help.md
+++ b/.changeset/rude-eagles-help.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Allow inline images with a new config and added checkPasteSize plugin

--- a/addon/plugins/image/index.ts
+++ b/addon/plugins/image/index.ts
@@ -1,1 +1,2 @@
-export { image, imageView } from './nodes/image';
+export { image, imageView, imageWithConfig } from './nodes/image';
+export { checkPasteSize, checkPasteSizeKey } from './plugins/checkPasteSize';

--- a/addon/plugins/image/nodes/image.ts
+++ b/addon/plugins/image/nodes/image.ts
@@ -8,7 +8,11 @@ import Image from '@lblod/ember-rdfa-editor/components/plugins/image/node';
 import { Node as PNode } from 'prosemirror-model';
 import getClassnamesFromNode from '@lblod/ember-rdfa-editor/utils/get-classnames-from-node';
 
-const emberNodeConfig: EmberNodeConfig = {
+const emberNodeConfig = ({
+  allowBase64Images,
+}: {
+  allowBase64Images?: boolean;
+}): EmberNodeConfig => ({
   name: 'image',
   component: Image as unknown as ComponentLike,
   inline: true,
@@ -24,7 +28,7 @@ const emberNodeConfig: EmberNodeConfig = {
   },
   parseDOM: [
     {
-      tag: 'img[src]:not([src^="data:"])',
+      tag: allowBase64Images ? 'img[src]' : 'img[src]:not([src^="data:"])',
       getAttrs(dom: string | HTMLElement) {
         if (typeof dom === 'string') {
           return false;
@@ -57,7 +61,14 @@ const emberNodeConfig: EmberNodeConfig = {
   stopEvent() {
     return false;
   },
-};
+});
 
-export const image = createEmberNodeSpec(emberNodeConfig);
-export const imageView = createEmberNodeView(emberNodeConfig);
+export const image = createEmberNodeSpec(
+  emberNodeConfig({ allowBase64Images: false }),
+);
+export const imageWithConfig = ({
+  allowBase64Images,
+}: {
+  allowBase64Images: boolean;
+}) => createEmberNodeSpec(emberNodeConfig({ allowBase64Images }));
+export const imageView = createEmberNodeView(emberNodeConfig({}));

--- a/addon/plugins/image/plugins/checkPasteSize.ts
+++ b/addon/plugins/image/plugins/checkPasteSize.ts
@@ -1,0 +1,39 @@
+import { Plugin, PluginKey } from 'prosemirror-state';
+
+export const checkPasteSizeKey = new PluginKey('CHECK_PASTE_SIZE');
+
+export function checkPasteSize({
+  pasteLimit = 100000,
+  onLimitReached,
+}: {
+  pasteLimit?: number;
+  onLimitReached?: () => void;
+}): Plugin {
+  return new Plugin({
+    key: checkPasteSizeKey,
+    props: {
+      handlePaste(_, event) {
+        const data = event.clipboardData;
+        if (!data) return;
+        const dataItems = data.items;
+        let totalSize = 0;
+        for (let item of dataItems) {
+          const file = item.getAsFile();
+          if (file) {
+            totalSize += file.size;
+          }
+        }
+        if (totalSize > pasteLimit) {
+          if (onLimitReached) {
+            onLimitReached();
+          } else {
+            console.error('Paste size is bigger than expected');
+          }
+
+          return true;
+        }
+        return;
+      },
+    },
+  });
+}

--- a/addon/plugins/image/plugins/checkPasteSize.ts
+++ b/addon/plugins/image/plugins/checkPasteSize.ts
@@ -17,7 +17,7 @@ export function checkPasteSize({
         if (!data) return;
         const dataItems = data.items;
         let totalSize = 0;
-        for (let item of dataItems) {
+        for (const item of dataItems) {
           const file = item.getAsFile();
           if (file) {
             totalSize += file.size;

--- a/addon/plugins/image/plugins/checkPasteSize.ts
+++ b/addon/plugins/image/plugins/checkPasteSize.ts
@@ -3,7 +3,7 @@ import { Plugin, PluginKey } from 'prosemirror-state';
 export const checkPasteSizeKey = new PluginKey('CHECK_PASTE_SIZE');
 
 export function checkPasteSize({
-  pasteLimit = 100000,
+  pasteLimit = 1000000,
   onLimitReached,
 }: {
   pasteLimit?: number;

--- a/tests/dummy/app/controllers/index.ts
+++ b/tests/dummy/app/controllers/index.ts
@@ -27,7 +27,11 @@ import {
   tableNodes,
   tablePlugins,
 } from '@lblod/ember-rdfa-editor/plugins/table';
-import { image, imageView } from '@lblod/ember-rdfa-editor/plugins/image';
+import {
+  imageWithConfig,
+  imageView,
+  checkPasteSize,
+} from '@lblod/ember-rdfa-editor/plugins/image';
 import { blockquote } from '@lblod/ember-rdfa-editor/plugins/blockquote';
 import { code_block } from '@lblod/ember-rdfa-editor/plugins/code';
 import {
@@ -100,7 +104,7 @@ export default class IndexController extends Controller {
 
       text,
 
-      image,
+      image: imageWithConfig({ allowBase64Images: true }),
 
       hard_break,
       invisible_rdfa: invisibleRdfaWithConfig(),
@@ -145,6 +149,10 @@ export default class IndexController extends Controller {
       ],
     }),
     emberApplication({ application: unwrap(getOwner(this)) }),
+    checkPasteSize({
+      pasteLimit: 100000,
+      onLimitReached: () => console.error('You cannot paste more than 100kb'),
+    }),
   ];
 
   @tracked nodeViews = (controller: SayController) => {


### PR DESCRIPTION
### Overview
Add configuration so the inline images can be enabled and added a plugin to check and avoid big paste sizes

##### connected issues and PRs:
GN-5423


### Setup
None

### How to test/reproduce
I enabled the base64 pasting in the index route, so you can try pasting the image there, if it's over 100kb (configurable by the host app) you will receive a console error (the host app will be able to hook a notification system there so the final user knows what is happening)

### Challenges/uncertainties
I added the configuration needed in the index route so the PR testing is easier, but is still unknown to me if I should make some configuration changes to any of the testing environments, because in my head I will delete that config before merging the PR



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
