### PR TITLE
Tweaks to support article structure changes

### DIFF
--- a/.changeset/grumpy-games-itch.md
+++ b/.changeset/grumpy-games-itch.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add util for wrapping including parents without using a command

--- a/.changeset/nervous-terms-boil.md
+++ b/.changeset/nervous-terms-boil.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Fix removePropertiesOfDeletedNodes plugin to only remove properties if they link to the subject being removed, not just matching the predicate of the relationship

--- a/.woodpecker/.test-compat-4.12.yml
+++ b/.woodpecker/.test-compat-4.12.yml
@@ -10,3 +10,6 @@ steps:
 when:
   event:
     - pull_request
+
+depends_on:
+  - verify-pr

--- a/.woodpecker/.test-compat-embroider-optimized.yml
+++ b/.woodpecker/.test-compat-embroider-optimized.yml
@@ -10,3 +10,6 @@ steps:
 when:
   event:
     - pull_request
+
+depends_on:
+  - verify-pr

--- a/.woodpecker/.test-compat-release.yml
+++ b/.woodpecker/.test-compat-release.yml
@@ -10,3 +10,6 @@ steps:
 when:
   event:
     - pull_request
+
+depends_on:
+  - verify-pr

--- a/addon/commands/rdfa-commands/remove-property.ts
+++ b/addon/commands/rdfa-commands/remove-property.ts
@@ -14,14 +14,7 @@ import {
 import type { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import type { Command, Transaction } from 'prosemirror-state';
 
-type RemovePropertyArgs = {
-  /**
-   A transaction to use in place of getting a new one from state.tr
-   This can be used to call this command from within another, but care must be taken to not use
-   the passed transaction between passing it in and when the callback is called.
-   */
-  transaction?: Transaction;
-} & (
+export type RemovePropertyArgs = (
   | {
       /** The resource from which to remove a property */
       resource: string;
@@ -47,7 +40,14 @@ type RemovePropertyArgs = {
 export function removeProperty({
   transaction,
   ...args
-}: RemovePropertyArgs): Command {
+}: {
+  /**
+   A transaction to use in place of getting a new one from state.tr
+   This can be used to call this command from within another, but care must be taken to not use
+   the passed transaction between passing it in and when the callback is called.
+   */
+  transaction?: Transaction;
+} & RemovePropertyArgs): Command {
   return (state, dispatch) => {
     let resource: string | undefined;
     let resourceNodes: ResolvedPNode[];

--- a/addon/commands/wrap-including-parents.ts
+++ b/addon/commands/wrap-including-parents.ts
@@ -1,11 +1,11 @@
 import type { Command } from 'prosemirror-state';
 import type { Attrs, NodeType } from 'prosemirror-model';
-import { GapCursor } from '../plugins/gap-cursor';
-import { findWrappingIncludingParents } from '../utils/wrap-utils';
+import { findHowToWrapIncludingParents } from '../utils/wrap-utils';
 
 /**
  * Wrap the selection in a node of the given type with the given attributes.
  * If the selection is unwrappable, try the parent nodes, to wrap e.g. lists.
+ * For gap cursors, there is nothing to wrap, but create a node if possible.
  * Adapted from prosemirror-commands wrapIn
  */
 export function wrapIncludingParents(
@@ -13,27 +13,9 @@ export function wrapIncludingParents(
   attrs: Attrs | null = null,
 ): Command {
   return function (state, dispatch) {
-    // Treat gap-cursor selections as a special case, do not wrap around its parent.
-    // This ensures that its behaviour is similar as that of normal collapsed text cursors.
-    if (state.selection instanceof GapCursor) {
-      const { $from } = state.selection;
-      const contentMatch = $from.parent.contentMatchAt($from.index());
-      if (!contentMatch.matchType(nodeType)) {
-        return false;
-      }
-      const node = nodeType.createAndFill(attrs);
-      if (!node) {
-        return false;
-      }
-      if (dispatch) {
-        dispatch(state.tr.replaceRangeWith($from.pos, $from.pos, node));
-      }
-      return true;
-    }
-    const wrappingRange = findWrappingIncludingParents(state, nodeType, attrs);
-    if (wrappingRange && wrappingRange[1]) {
-      const [range, wrapping] = wrappingRange;
-      if (dispatch) dispatch(state.tr.wrap(range, wrapping).scrollIntoView());
+    const tr = findHowToWrapIncludingParents(state, nodeType, attrs);
+    if (tr) {
+      if (dispatch) dispatch(tr);
       return true;
     } else {
       return false;

--- a/addon/plugins/table/commands/insertTable.ts
+++ b/addon/plugins/table/commands/insertTable.ts
@@ -10,6 +10,16 @@ export function insertTable(rows: number, columns: number): Command {
       selection: { $from },
     } = state;
 
+    // table nodespecs don't necessarily exist, for example in an embedded editor or if
+    // misconfigured
+    if (
+      ['table', 'table_row', 'table_header', 'table_cell'].some(
+        (nodeType) => !schema.nodes[nodeType],
+      )
+    ) {
+      return false;
+    }
+
     const specAllowSplitByTable = $from.parent.type.spec[
       'allowSplitByTable'
     ] as boolean | undefined;

--- a/addon/utils/_private/node-utils.ts
+++ b/addon/utils/_private/node-utils.ts
@@ -1,4 +1,9 @@
-import { PNode, ResolvedPos } from '@lblod/ember-rdfa-editor';
+import {
+  type EditorState,
+  NodeSelection,
+  type PNode,
+  type ResolvedPos,
+} from '@lblod/ember-rdfa-editor';
 
 export function getGroups(node: PNode) {
   return node.type.spec.group?.split(' ') ?? [];
@@ -44,4 +49,21 @@ export function getPos(node: PNode, doc: PNode): ResolvedPos | -1 | undefined {
     console.warn(`getPos: ${node.toString()} not found in ${doc.toString()}`);
   }
   return result;
+}
+
+/**
+ * Based on prosemirror-commands 'selectParentNode' but is not a command
+ */
+export function parentNodeSelection({
+  doc,
+  selection,
+}: Pick<EditorState, 'doc' | 'selection'>): NodeSelection | null {
+  const { $from, to } = selection;
+  const sharedDepth = $from.sharedDepth(to);
+  if (sharedDepth === 0) {
+    // we're at the doc
+    return null;
+  }
+  const pos = $from.before(sharedDepth);
+  return NodeSelection.create(doc, pos);
 }

--- a/addon/utils/transaction-utils.ts
+++ b/addon/utils/transaction-utils.ts
@@ -106,3 +106,21 @@ export function transactionCombinator<R>(
     };
   };
 }
+
+/**
+ * Creates a monad which applies the passed function to generate a list of monads based on the
+ * incoming EditorState and applies them all.
+ */
+export function composeMonads(
+  generator: (state: EditorState) => TransactionMonad<boolean>[],
+): TransactionMonad<boolean> {
+  return (state) => {
+    const monads: TransactionMonad<boolean>[] = generator(state);
+    const {
+      transactions: _,
+      result,
+      ...res
+    } = transactionCombinator<boolean>(state)(monads);
+    return { ...res, result: result.every(Boolean) };
+  };
+}

--- a/addon/utils/wrap-utils.ts
+++ b/addon/utils/wrap-utils.ts
@@ -1,7 +1,8 @@
-import { type EditorState } from 'prosemirror-state';
-import { NodeType, type Attrs, type NodeRange } from 'prosemirror-model';
+import { type Transaction, type EditorState } from 'prosemirror-state';
+import { type NodeType, type Attrs, type NodeRange } from 'prosemirror-model';
 import { findWrapping } from 'prosemirror-transform';
 import { parentNodeSelection } from './_private/node-utils';
+import { GapCursor } from '../plugins/gap-cursor';
 
 export function findWrappingIncludingParents(
   { doc, selection }: Pick<EditorState, 'doc' | 'selection'>,
@@ -19,6 +20,50 @@ export function findWrappingIncludingParents(
       parentSel &&
       findWrappingIncludingParents(
         { doc, selection: parentSel },
+        nodeType,
+        attrs,
+      )
+    );
+  }
+}
+
+/**
+ * Produce a transaction that wraps the selection in a node of the given type with the given
+ * attributes. If the selection is unwrappable, try the parent nodes, to wrap e.g. lists.
+ * For gap cursors, there is nothing to wrap, but create a node if possible.
+ * Adapted from prosemirror-commands wrapIn
+ */
+export function findHowToWrapIncludingParents(
+  { doc, selection, tr }: Pick<EditorState, 'doc' | 'selection' | 'tr'>,
+  nodeType: NodeType,
+  attrs: Attrs | null = null,
+): Transaction | false {
+  // Treat gap-cursor selections as a special case, do not wrap around its parent.
+  // This ensures that its behaviour is similar as that of normal collapsed text cursors.
+  if (selection instanceof GapCursor) {
+    const { $from } = selection;
+    const contentMatch = $from.parent.contentMatchAt($from.index());
+    if (!contentMatch.matchType(nodeType)) {
+      return false;
+    }
+    const node = nodeType.createAndFill(attrs);
+    if (!node) {
+      return false;
+    }
+    return tr.replaceRangeWith($from.pos, $from.pos, node);
+  }
+
+  const { $from, $to } = selection;
+  const range = $from.blockRange($to);
+  const wrapping = range && findWrapping(range, nodeType, attrs);
+  if (wrapping) {
+    return tr.wrap(range, wrapping).scrollIntoView();
+  } else {
+    const parentSel = parentNodeSelection({ doc, selection });
+    return (
+      !!parentSel &&
+      findHowToWrapIncludingParents(
+        { doc, selection: parentSel, tr },
         nodeType,
         attrs,
       )

--- a/addon/utils/wrap-utils.ts
+++ b/addon/utils/wrap-utils.ts
@@ -1,0 +1,27 @@
+import { type EditorState } from 'prosemirror-state';
+import { NodeType, type Attrs, type NodeRange } from 'prosemirror-model';
+import { findWrapping } from 'prosemirror-transform';
+import { parentNodeSelection } from './_private/node-utils';
+
+export function findWrappingIncludingParents(
+  { doc, selection }: Pick<EditorState, 'doc' | 'selection'>,
+  nodeType: NodeType,
+  attrs: Attrs | null = null,
+): [NodeRange, ReturnType<typeof findWrapping>] | null {
+  const { $from, $to } = selection;
+  const range = $from.blockRange($to);
+  const wrapping = range && findWrapping(range, nodeType, attrs);
+  if (wrapping) {
+    return [range, wrapping];
+  } else {
+    const parentSel = parentNodeSelection({ doc, selection });
+    return (
+      parentSel &&
+      findWrappingIncludingParents(
+        { doc, selection: parentSel },
+        nodeType,
+        attrs,
+      )
+    );
+  }
+}


### PR DESCRIPTION
### Overview
Pull some command logic into utils that handle transactions, to allow them to be used outside of commands.

Also fix a bug in table inserting, that required the nodes to exist, which isn't true, e.g. in an embedded editor.

##### connected issues and PRs:
Part of https://binnenland.atlassian.net/browse/GN-4866
Plugins PR: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/535

### Setup
Not needed to test, but it makes sense to test this in the article structures PR in the plugins.

### How to test/reproduce
In the editor repo, these are used in the RDFa wrapping tools in the sidebar, which should work as expected.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
