### PR TITLE
Fix weird placeholder margin

### DIFF
--- a/.changeset/fast-bats-jam.md
+++ b/.changeset/fast-bats-jam.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Reduce margin right property of placeholders

--- a/.changeset/fast-bats-jam.md
+++ b/.changeset/fast-bats-jam.md
@@ -1,5 +1,6 @@
 ---
-'@lblod/ember-rdfa-editor': patch
+'@lblod/ember-rdfa-editor': major
 ---
+Remove mark-highlight-manual class and add the styles contained in it to say-placeholder
 
 Reduce margin right property of placeholders

--- a/app/styles/ember-rdfa-editor/_c-placeholder.scss
+++ b/app/styles/ember-rdfa-editor/_c-placeholder.scss
@@ -21,6 +21,9 @@ span.mark-highlight-manual {
     background-color: var(--au-blue-200);
   }
   user-select: none;
+  &.say-placeholder {
+    margin-right: 0 !important;
+  }
 }
 
 span.mark-highlight-manual.ProseMirror-selectednode {
@@ -37,3 +40,5 @@ span.mark-highlight-manual.ProseMirror-selectednode {
   height: 0;
   pointer-events: none;
 }
+
+

--- a/app/styles/ember-rdfa-editor/_c-placeholder.scss
+++ b/app/styles/ember-rdfa-editor/_c-placeholder.scss
@@ -1,10 +1,10 @@
 // Highlighting
-span.mark-highlight-manual {
+.say-placeholder {
   font-style: italic;
   border-radius: 0.3rem;
   color: var(--au-orange-700);
   background-color: var(--au-orange-300);
-  margin-right: 0.5rem !important;
+  margin-right: 0 !important;
   padding: 0 0.2rem !important;
   line-height: 1.2rem !important;
   transition:
@@ -21,12 +21,9 @@ span.mark-highlight-manual {
     background-color: var(--au-blue-200);
   }
   user-select: none;
-  &.say-placeholder {
-    margin-right: 0 !important;
-  }
 }
 
-span.mark-highlight-manual.ProseMirror-selectednode {
+.say-placeholder.ProseMirror-selectednode {
   background-color: var(--au-blue-200);
   outline: 2px solid var(--au-blue-500);
   color: var(--au-black);

--- a/app/styles/ember-rdfa-editor/_c-placeholder.scss
+++ b/app/styles/ember-rdfa-editor/_c-placeholder.scss
@@ -40,5 +40,3 @@ span.mark-highlight-manual.ProseMirror-selectednode {
   height: 0;
   pointer-events: none;
 }
-
-


### PR DESCRIPTION
### Overview
There's a style that sets the right margin of mark-highlight-manual (the old class for placeholder) so it seems like after that node there are 2 spaces instead of 1, I fixed this using our new class for placeholder to minimize the impact on other places, as this class is used a lot in our apps

##### connected issues and PRs:
GN-5445 (maybe?)


### Setup
None

### How to test/reproduce
Insert a placeholder and notice the margin right is reduced to a normal amount

### Challenges/uncertainties
Maybe is just better to remove it from the class



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
