### PR TITLE
fix(tooling): adjust `package.json` `imports` field to not include `declarations` folder

### DIFF
--- a/packages/ember-rdfa-editor/package.json
+++ b/packages/ember-rdfa-editor/package.json
@@ -168,14 +168,8 @@
   "imports": {
     "#root": null,
     "#root/index.ts": null,
-    "#root/*.ts": {
-      "types": "./declarations/*.d.ts",
-      "default": "./src/*.ts"
-    },
-    "#root/*": {
-      "types": "./declarations/*.d.ts",
-      "default": "./src/*"
-    }
+    "#root/*.ts": "./src/*.ts",
+    "#root/*": "./src/*"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
### Overview
This PR slightly adjusts the `package.json` `imports` field to not include the `declarations` folder.
As the `imports` field is only used internally while developing, it does not seem to be necessary to include the `declarations` output folder.
This also fixes an issue with auto-imports not importing with the correct `.ts` extension.


### Setup
- I tested this in vscode with the glint extension (https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode)

### How to test/reproduce
- Try to import from an internal module in the editor package
- Ensure the auto-imports it proposes have `.ts` extensions

### Challenges/uncertainties
Not sure if I'm missing something about the `declarations` folder being needed here?

