### PR TITLE
pin prosemirror-history package to 1.4.1

### DIFF
--- a/.changeset/shiny-scissors-complain.md
+++ b/.changeset/shiny-scissors-complain.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Pin `prosemirror-history` version to 1.4.1

--- a/packages/ember-rdfa-editor/package.json
+++ b/packages/ember-rdfa-editor/package.json
@@ -247,7 +247,7 @@
     "process": "0.11.10",
     "prosemirror-commands": "^1.5.2",
     "prosemirror-dropcursor": "^1.8.1",
-    "prosemirror-history": "^1.4.0",
+    "prosemirror-history": "1.4.1",
     "prosemirror-inputrules": "^1.4.0",
     "prosemirror-keymap": "^1.2.2",
     "prosemirror-model": "^1.21.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
         specifier: ^1.8.1
         version: 1.8.1
       prosemirror-history:
-        specifier: ^1.4.0
+        specifier: 1.4.1
         version: 1.4.1
       prosemirror-inputrules:
         specifier: ^1.4.0


### PR DESCRIPTION
### Overview
This PR pins the `prosemirror-history` package version to 1.4.1.
Since we are now using the private `composition` API, it is preferable to update/manage the `prosemirror-history` package in a more controlled way.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/541
