### PR TITLE
fix(html-input-parser): return correct htmlelement

### DIFF
--- a/.changeset/tricky-glasses-fail.md
+++ b/.changeset/tricky-glasses-fail.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+adjust `HTMLInputParser.prepareHTML` to return `HTMLElement` instead of `Document`

--- a/packages/ember-rdfa-editor/src/core/say-editor.ts
+++ b/packages/ember-rdfa-editor/src/core/say-editor.ts
@@ -157,14 +157,14 @@ export default class SayEditor {
       domParser: this.parser,
       transformPastedHTML: (html, editorView) => {
         const htmlCleaner = new HTMLInputParser();
-        const cleanedDocument = htmlCleaner.prepareHTML(html, true);
+        const cleanedHTMLNode = htmlCleaner.prepareHTML(html, true);
 
         preprocessRDFa(
-          cleanedDocument.body,
+          cleanedHTMLNode,
           editorView ? getPathFromRoot(editorView.dom, false) : [],
         );
 
-        return cleanedDocument.body.innerHTML;
+        return cleanedHTMLNode.innerHTML;
       },
       clipboardSerializer: this.serializer,
     });

--- a/packages/ember-rdfa-editor/src/utils/_private/html-input-parser.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/html-input-parser.ts
@@ -275,25 +275,25 @@ export default class HTMLInputParser {
    * @method prepareHTML
    *
    * @param htmlString {string}
-   * @param asHTMLElement {boolean}
+   * @param asHTMLNode {boolean}
    * @param doNotClean {boolean} - optionally prevent cleaning input (just sanitize it). This should
    * only be used with html that the editor understands directly, e.g. saved editor contents.
    */
   prepareHTML(
     htmlString: string,
-    asHTMLDocument?: false,
+    asHTMLNode?: false,
     doNotClean?: boolean,
   ): string;
   prepareHTML(
     htmlString: string,
-    asHTMLDocument: true,
+    asHTMLNode: true,
     doNotClean?: boolean,
-  ): Document;
+  ): HTMLElement;
   prepareHTML(
     htmlString: string,
-    asHTMLDocument?: boolean,
+    asHTMLNode?: boolean,
     doNotClean?: boolean,
-  ): string | Document {
+  ): string | HTMLElement {
     const parser = new DOMParser();
 
     const doc = parser.parseFromString(
@@ -309,11 +309,11 @@ export default class HTMLInputParser {
     }
     const sanitized = this.sanitizeHTML({ element: bodyElement });
 
-    if (asHTMLDocument) {
-      return sanitized as Document;
+    if (asHTMLNode) {
+      return sanitized;
     }
 
-    return (sanitized as HTMLElement).innerHTML;
+    return sanitized.innerHTML;
   }
 
   /**
@@ -323,14 +323,14 @@ export default class HTMLInputParser {
    * @method sanitizeHTML
    * @param element {HTMLElement}
    */
-  private sanitizeHTML({ element }: { element: HTMLElement }): Node {
+  private sanitizeHTML({ element }: { element: HTMLElement }): HTMLElement {
     return DOMPurify.sanitize(element.outerHTML, {
       ALLOWED_TAGS: this.safeTags,
       ALLOWED_ATTR: this.safeAttributes,
       ADD_URI_SAFE_ATTR: this.uriSafeAttributes,
       IN_PLACE: true,
       RETURN_DOM: true,
-    });
+    }) as HTMLElement;
   }
 
   private preCleanHtml(html: string): string {


### PR DESCRIPTION
### Overview
This PR ensures that the `HTMLInputParser.prepareHTML` method returns an `HTMLElement` object instead of a `Document` object.
A change was introduced in the `v2-addon` branch related to the usage of return values, this caused a bug in the `prepareHTML` method. See https://github.com/lblod/ember-rdfa-editor/commit/24bdc2046f3530b63beee08046823b6cb840152d for more details.

### How to test/reproduce
- Start the dummy app
- Paste any html (e.g. an inline image)
- Ensure this pasting works as expected
- Notice there's no longer an error in the console

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
