### PR TITLE
feat: support parsing and serializing `data-say-id` (`__rdfaId`) attributes

### DIFF
--- a/.changeset/tiny-badgers-fry.md
+++ b/.changeset/tiny-badgers-fry.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add support for parsing and serializing data-say-id attributes (\_\_rdfaId)

--- a/packages/ember-rdfa-editor/src/core/rdfa-processor.ts
+++ b/packages/ember-rdfa-editor/src/core/rdfa-processor.ts
@@ -309,7 +309,7 @@ function quadToBacklink(quad: Quad): IncomingTriple {
 }
 
 function ensureId(element: HTMLElement): string {
-  const rdfaId = element.getAttribute('__rdfaId') || uuidv4();
-  element.setAttribute('__rdfaId', rdfaId);
+  const rdfaId = element.dataset['sayId'] || uuidv4();
+  element.dataset['sayId'] = rdfaId;
   return rdfaId;
 }

--- a/packages/ember-rdfa-editor/src/core/schema.ts
+++ b/packages/ember-rdfa-editor/src/core/schema.ts
@@ -103,7 +103,7 @@ function getRdfaAwareAttrs(node: HTMLElement): RdfaAttrs | false {
   if (!rdfaNodeType || !rdfaNodeTypes.includes(rdfaNodeType)) {
     return false;
   }
-  const __rdfaId = node.getAttribute('__rdfaId') ?? uuidv4();
+  const __rdfaId = node.dataset['sayId'] ?? uuidv4();
   let backlinks: IncomingTriple[] = [];
   if (node.dataset['incomingProps']) {
     backlinks = JSON.parse(
@@ -398,6 +398,7 @@ export function renderInvisibleRdfa(
 export function renderRdfaAttrs(
   rdfaAttrs: RdfaAttrs,
 ): Record<string, string | null> {
+  console.log('SayId: ', rdfaAttrs.__rdfaId);
   if (rdfaAttrs.rdfaNodeType === 'resource') {
     const contentTriple: ContentTriple | null = rdfaAttrs.properties.find(
       (prop) => prop.object.termType === 'ContentLiteral',
@@ -406,22 +407,25 @@ export function renderRdfaAttrs(
     return contentTriple
       ? {
           about: rdfaAttrs.subject,
+          'data-say-id': rdfaAttrs.__rdfaId,
           property: contentTriple.predicate,
           datatype: contentTriple.object.language.length
             ? null
             : contentTriple.object.datatype.value,
           lang: contentTriple.object.language,
-
           resource: null,
         }
       : {
           about: rdfaAttrs.subject,
+          'data-say-id': rdfaAttrs.__rdfaId,
           resource: null,
         };
   } else {
     const backlinks = rdfaAttrs.backlinks as IncomingLiteralNodeTriple[];
     if (!backlinks.length) {
-      return {};
+      return {
+        'data-say-id': rdfaAttrs.__rdfaId,
+      };
     }
 
     return {
@@ -432,6 +436,7 @@ export function renderRdfaAttrs(
         : backlinks[0].subject.datatype.value,
       lang: backlinks[0].subject.language,
       'data-literal-node': 'true',
+      'data-say-id': rdfaAttrs.__rdfaId,
     };
   }
 }

--- a/test-app/tests/integration/rdfa/blackbox-test.ts
+++ b/test-app/tests/integration/rdfa/blackbox-test.ts
@@ -12,6 +12,9 @@ import {
   SAMPLE_PLUGINS,
   SAMPLE_SCHEMA,
 } from 'test-app/tests/helpers/prosemirror';
+import { findNodesBySubject } from '@lblod/ember-rdfa-editor/utils/rdfa-utils';
+import { isSome } from '@lblod/ember-rdfa-editor/utils/_private/option';
+import type { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 
 module('Integration | RDFa blackbox test ', function () {
   for (const entry of Object.entries(TEST_CASES)) {
@@ -46,4 +49,71 @@ module('Integration | RDFa blackbox test ', function () {
       assert.true(isEqual, message);
     });
   }
+  test('__rdfaId attributes should be persisted throughout parsing and serializing steps', (assert) => {
+    const { controller } = testEditor(SAMPLE_SCHEMA, {
+      override: true,
+      plugins: SAMPLE_PLUGINS,
+    });
+    const htmlContent = `
+      <div
+        class="say-editable say-block-rdfa"
+        about="http://example.com/c3d0f3a2-1314-4686-aa30-f46fd1f988f7"
+        data-say-id="c3d0f3a2-1314-4686-aa30-f46fd1f988f7"
+      >
+        <div
+          style="display: none"
+          class="say-hidden"
+          data-rdfa-container="true"
+        >
+          <span property="ext:content" content="test" lang="nl-be"></span>
+        </div>
+        <div data-content-container="true">
+            <p class="say-paragraph"></p>
+        </div>
+      </div>
+      <div
+        class="say-editable say-block-rdfa"
+        data-label="literal"
+        about="http://example.com/c3d0f3a2-1314-4686-aa30-f46fd1f988f7"
+        property="ext:toLiteral"
+        lang="nl-be"
+        data-literal-node="true"
+        data-say-id="f6a0b16d-0b7f-4c27-8111-a7ebf12ab103"
+      >
+        <div
+          style="display: none"
+          class="say-hidden"
+          data-rdfa-container="true"
+        >
+        </div>
+        <div data-content-container="true">
+          <p class="say-paragraph">Some content</p>
+        </div>
+      </div>
+    `;
+    console.log('HTML Content: ', htmlContent);
+    // Initial parse
+    controller.initialize(htmlContent);
+    // Serialize + parse
+    controller.initialize(controller.htmlContent);
+    const { doc } = controller.mainEditorState;
+    const resourceNode = findNodesBySubject(
+      doc,
+      'http://example.com/c3d0f3a2-1314-4686-aa30-f46fd1f988f7',
+    )[0].value;
+    assert.deepEqual(
+      resourceNode.attrs['__rdfaId'],
+      'c3d0f3a2-1314-4686-aa30-f46fd1f988f7',
+    );
+    const properties = resourceNode.attrs['properties'] as OutgoingTriple[];
+    assert.strictEqual(properties.length, 2);
+    const propertyToLiteralNode = properties.find(
+      (prop) => prop.object.termType === 'LiteralNode',
+    );
+    assert.true(isSome(propertyToLiteralNode));
+    assert.strictEqual(
+      propertyToLiteralNode!.object.value,
+      'f6a0b16d-0b7f-4c27-8111-a7ebf12ab103',
+    );
+  });
 });


### PR DESCRIPTION
### Overview
This PR adds supporting for serializing and parsing __rdfaId node attributes. 
The attribute is serialized in the form of `data-say-id`.

Additionally, this PR also contains an integration test to ensure the attribute is correctly parsed and serialized.

##### connected issues and PRs:
Required for [GN-5440](https://binnenland.atlassian.net/browse/GN-5440?atlOrigin=eyJpIjoiMTE3MWMyZDk3MTMxNDc3ZGE3Zjc5NDM2ZTUwMDA2NjMiLCJwIjoiaiJ9)

### How to test/reproduce
- Create some resource and literal nodes in a document
- Serialize the document: ensure the `__rdfaId` attributes are serialized as `data-say-id`
- Reload the document, the `__rdfaId` attribute values should be persisted.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
