### PR TITLE
Add support for `content` attribute in rdfa-aware literal nodes

### DIFF
--- a/.changeset/khaki-months-poke.md
+++ b/.changeset/khaki-months-poke.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Literal nodes: add support for `content` attribute, which may contain alternative content representation

--- a/packages/ember-rdfa-editor/src/core/schema.ts
+++ b/packages/ember-rdfa-editor/src/core/schema.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Mark, type Attrs, type DOMOutputSpec } from 'prosemirror-model';
 import { PNode } from '#root/prosemirror-aliases.ts';
-import { isSome, unwrap } from '../utils/_private/option.ts';
+import { isSome, unwrap, type Option } from '../utils/_private/option.ts';
 import type {
   ContentTriple,
   FullTriple,
@@ -60,6 +60,7 @@ const rdfaAwareAttrSpec = {
   __rdfaId: { default: undefined },
   rdfaNodeType: { default: undefined },
   subject: { default: null },
+  content: { default: null, editable: true },
 };
 
 /** @deprecated `rdfaAttrs` is deprecated, use the `rdfaAttrSpec` function instead */
@@ -119,6 +120,7 @@ function getRdfaAwareAttrs(node: HTMLElement): RdfaAttrs | false {
   if (rdfaNodeType === 'literal') {
     return {
       rdfaNodeType: 'literal',
+      content: node.getAttribute('content'),
       __rdfaId,
       backlinks,
     };
@@ -255,6 +257,7 @@ export interface RdfaAwareAttrs {
 }
 export interface RdfaLiteralAttrs extends RdfaAwareAttrs {
   rdfaNodeType: 'literal';
+  content: string | null;
 }
 export interface RdfaResourceAttrs extends RdfaAwareAttrs {
   rdfaNodeType: 'resource';
@@ -401,7 +404,8 @@ export function renderInvisibleRdfa(
                 subject.value,
                 predicate,
                 sayDataFactory.literal(
-                  nodeOrMark.textContent,
+                  (nodeOrMark.attrs['content'] as Option<string>) ??
+                    nodeOrMark.textContent,
                   languageOrDataType(subject.language, subject.datatype),
                 ),
                 literalNodeId,
@@ -452,6 +456,7 @@ export function renderRdfaAttrs(
     const backlinks = rdfaAttrs.backlinks as IncomingLiteralNodeTriple[];
     if (!backlinks.length) {
       return {
+        content: rdfaAttrs.content ?? null,
         'data-say-id': rdfaAttrs.__rdfaId,
         'data-literal-node': 'true',
       };
@@ -464,6 +469,7 @@ export function renderRdfaAttrs(
         ? null
         : backlinks[0].subject.datatype.value,
       lang: backlinks[0].subject.language,
+      content: rdfaAttrs.content ?? null,
       'data-literal-node': 'true',
       'data-say-id': rdfaAttrs.__rdfaId,
     };

--- a/test-app/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/test-app/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -487,4 +487,28 @@ module('rdfa | parsing', function () {
     const secondState = controller.mainEditorState.doc;
     assert.propEqual(secondState.toJSON(), initialState.toJSON());
   });
+  test('literal node with content attribute should be serialized and parsed correctly', function (assert) {
+    const { doc, block_rdfa, paragraph } = testBuilders;
+    const initialDoc = doc(
+      {},
+      block_rdfa(
+        {
+          rdfaNodeType: 'literal',
+          __rdfaId: 'test-id',
+          content: 'alternative-value',
+        },
+        paragraph('value'),
+      ),
+    );
+    assert.strictEqual(
+      initialDoc.child(0).attrs['content'],
+      'alternative-value',
+    );
+    const state = EditorState.create({ schema, plugins, doc: initialDoc });
+    const { controller } = testEditor(schema, plugins, state);
+    const initialRender = controller.htmlContent;
+    controller.initialize(initialRender);
+    const secondState = controller.mainEditorState.doc;
+    assert.propEqual(secondState.toJSON(), initialDoc.toJSON());
+  });
 });


### PR DESCRIPTION
### Overview
This PR adds support for the `content` attribute in rdfa-aware literal nodes. This attribute may contain an alternative representation of the literal (e.g. a machine-readable version).

The attribute is currently editable through the attribute-editor.

### How to test/reproduce
- Start the test-app
- Insert a loose literal node
- Edit its `content` attr
- Reload the doc
- The `content` attr should be preserved
- Add links to the literal node from two different resource nodes
- Inspect the RDFa output: ensure the relations are linked to the `content` attribute value
- Reload the doc
- Ensure the relations and `content` attr remain preserved.

### Challenges/uncertainties
I still need to add a test.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
