### PR TITLE
bugfix: incorrect JSON serialization of `properties`/`backlinks`

### DIFF
--- a/.changeset/flat-donkeys-cross.md
+++ b/.changeset/flat-donkeys-cross.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix issue related to JSON serialization of RDF terms

--- a/packages/ember-rdfa-editor/src/core/say-data-factory/blank-node.ts
+++ b/packages/ember-rdfa-editor/src/core/say-data-factory/blank-node.ts
@@ -18,4 +18,11 @@ export class SayBlankNode implements RDF.BlankNode {
       !!other && other.termType === 'BlankNode' && other.value === this.value
     );
   };
+
+  toJSON(){
+    return {
+      termType: this.termType,
+      value: this.value,
+    }
+  }
 }

--- a/packages/ember-rdfa-editor/src/core/say-data-factory/data-factory.ts
+++ b/packages/ember-rdfa-editor/src/core/say-data-factory/data-factory.ts
@@ -92,7 +92,7 @@ export class SayDataFactory<Q extends BaseQuad = Quad>
       case 'BlankNode':
         return this.blankNode(original.value);
       case 'Literal': {
-        const { datatype, language } = original as WithoutEquals<SayLiteral>;
+        const { datatype, language } = original as unknown as WithoutEquals<SayLiteral>;
         return this.literal(
           original.value,
           languageOrDataType(language, this.fromTerm(datatype) as SayNamedNode),

--- a/packages/ember-rdfa-editor/src/core/say-data-factory/literal.ts
+++ b/packages/ember-rdfa-editor/src/core/say-data-factory/literal.ts
@@ -46,4 +46,16 @@ export class SayLiteral implements RDF.Literal {
       this.datatype.equals(other.datatype)
     );
   };
+
+  toJSON(){
+    return {
+      termType: this.termType,
+      value: this.value,
+      language: this.language,
+      datatype: {
+        termType: this.datatype.termType,
+        value: this.datatype.value,
+      }
+    }
+  }
 }

--- a/packages/ember-rdfa-editor/src/core/say-data-factory/named-node.ts
+++ b/packages/ember-rdfa-editor/src/core/say-data-factory/named-node.ts
@@ -20,4 +20,11 @@ export class SayNamedNode<Iri extends string = string>
       !!other && other.termType === 'NamedNode' && other.value === this.value
     );
   };
+
+  toJSON(){
+    return {
+      termType: this.termType,
+      value: this.value,
+    }
+  }
 }

--- a/packages/ember-rdfa-editor/src/core/say-data-factory/prosemirror-terms/content-literal.ts
+++ b/packages/ember-rdfa-editor/src/core/say-data-factory/prosemirror-terms/content-literal.ts
@@ -41,4 +41,16 @@ export class ContentLiteralTerm {
       this.datatype.equals(other.datatype)
     );
   };
+
+  toJSON(){
+    return {
+      termType: this.termType,
+      value: this.value,
+      language: this.language,
+      datatype: {
+        termType: this.datatype.termType,
+        value: this.datatype.value,
+      }
+    }
+  }
 }

--- a/packages/ember-rdfa-editor/src/core/say-data-factory/prosemirror-terms/literal-node.ts
+++ b/packages/ember-rdfa-editor/src/core/say-data-factory/prosemirror-terms/literal-node.ts
@@ -46,4 +46,16 @@ export class LiteralNodeTerm {
       this.datatype.equals(other.datatype)
     );
   };
+
+  toJSON(){
+    return {
+      termType: this.termType,
+      value: this.value,
+      language: this.language,
+      datatype: {
+        termType: this.datatype.termType,
+        value: this.datatype.value,
+      }
+    }
+  }
 }

--- a/packages/ember-rdfa-editor/src/core/say-data-factory/prosemirror-terms/resource-node.ts
+++ b/packages/ember-rdfa-editor/src/core/say-data-factory/prosemirror-terms/resource-node.ts
@@ -17,4 +17,11 @@ export class ResourceNodeTerm<Iri extends string = string> {
       !!other && other.termType === 'ResourceNode' && other.value === this.value
     );
   };
+
+  toJSON(){
+    return {
+      termType: this.termType,
+      value: this.value,
+    }
+  }
 }

--- a/packages/ember-rdfa-editor/src/core/say-data-factory/variable.ts
+++ b/packages/ember-rdfa-editor/src/core/say-data-factory/variable.ts
@@ -18,4 +18,11 @@ export class SayVariable implements RDF.Variable {
       !!other && other.termType === 'Variable' && other.value === this.value
     );
   };
+
+  toJSON(){
+    return {
+      termType: this.termType,
+      value: this.value,
+    }
+  }
 }

--- a/packages/ember-rdfa-editor/src/core/schema.ts
+++ b/packages/ember-rdfa-editor/src/core/schema.ts
@@ -164,6 +164,7 @@ function jsonToTerm(key: string, value: WithoutEquals<SayTerm>) {
     return value;
   }
 }
+
 export function getRdfaAwareDocAttrs(
   node: HTMLElement,
   { hasResourceImports = false } = {},


### PR DESCRIPTION
### Overview
This PR solves the bug where the datatype of the object of an outgoing triple was not correctly parsed when loading in a document.
The issue lied with incorrect JSON serialization when serializing the `outgoingProps` and `incomingProps`.
The `datatype` RDF terms where not fully correctly serialized, as the `termType` was not being serialized.
So why was the `termType` not being serialized?
- For the `dataset` term, we are using the graphy term implementations
- Graphy does not store the `termType` as a property of the object itself, but rather on its prototype
- Prototypes do not get serialized by default when calling `JSON.stringify`

### How to test/reproduce
- I added a small test with an example
- Open the test-app
- Create a resource node and literal node
- Add a relationship with a custom datatype
- Reload the document
- Ensure the correct datatype is loaded in again

### Challenges/uncertainties
I opted for using `toJSON` methods as that seemed the cleanest solution.



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
