### PR TITLE
feat(literal-node): add support for `defaultLanguage` and `defaultDatatype`

### DIFF
--- a/.changeset/proud-pigs-hug.md
+++ b/.changeset/proud-pigs-hug.md
@@ -1,0 +1,13 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Literal nodes: introduce concept of `defaultLanguage` and `defaultDatatype`:
+
+(loose) literal nodes may define their `defaultLanguage` and `defaultDatatype`.
+These attributes are (at the moment) editable through the attribute-editor.
+
+`defaultLanguage` and `defaultDatatype` define what the prefilled values are for `datatype` and `language` in the relationship creation form.
+
+The `defaultLanguage` attribute is serialized as `data-default-language`.
+The `defaultDatatype` attribute is serialized as `data-default-datatype`.

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/outgoing-triple-form.hbs
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/outgoing-triple-form.hbs
@@ -161,7 +161,7 @@
           <AuInput
             id={{id}}
             name={{name}}
-            value={{this.triple.object.language}}
+            value={{this.initialLanguageValue}}
             required={{false}}
             @width="block"
             @disabled={{this.hasDatatype}}
@@ -233,7 +233,7 @@
           <AuInput
             id={{id}}
             name={{name}}
-            value={{this.triple.object.language}}
+            value={{this.initialLanguageValue}}
             required={{false}}
             @width="block"
             @disabled={{this.hasDatatype}}
@@ -305,7 +305,7 @@
           <AuInput
             id={{id}}
             name={{name}}
-            value={{this.triple.object.language}}
+            value={{this.initialLanguageValue}}
             required={{false}}
             @width="block"
             @disabled={{this.hasDatatype}}

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/outgoing-triple-form.ts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/outgoing-triple-form.ts
@@ -151,11 +151,29 @@ export default class OutgoingTripleFormComponent extends Component<Sig> {
   }
 
   get initialDatatypeValue(): string {
-    const termType = this.triple.object.termType;
+    console.log('Get datatype');
+    if (!this.controller) {
+      return '';
+    }
+    if (this.termType === 'LiteralNode') {
+      const selectedLiteralNodeId = this.selectedLiteralNode;
+      if (!selectedLiteralNodeId) {
+        return '';
+      }
+      const literalNode = getNodeByRdfaId(
+        this.controller.mainEditorState,
+        selectedLiteralNodeId,
+      );
+      if (!literalNode) {
+        return '';
+      }
+      return (
+        (literalNode.value.attrs['defaultDatatype'] as string | null) ?? ''
+      );
+    }
     if (
-      termType === 'Literal' ||
-      termType === 'ContentLiteral' ||
-      termType === 'LiteralNode'
+      this.triple.object.termType === 'Literal' ||
+      this.triple.object.termType === 'ContentLiteral'
     ) {
       const { language, datatype } = this.triple.object;
       if (language.length) {
@@ -163,6 +181,37 @@ export default class OutgoingTripleFormComponent extends Component<Sig> {
       } else {
         return datatype.value;
       }
+    }
+    return '';
+  }
+
+  get initialLanguageValue(): string {
+    console.log('get initial lang');
+    if (!this.controller) {
+      return '';
+    }
+    if (this.termType === 'LiteralNode') {
+      const selectedLiteralNodeId = this.selectedLiteralNode;
+      if (!selectedLiteralNodeId) {
+        return '';
+      }
+      const literalNode = getNodeByRdfaId(
+        this.controller.mainEditorState,
+        selectedLiteralNodeId,
+      );
+      if (!literalNode) {
+        return '';
+      }
+      return (
+        (literalNode.value.attrs['defaultLanguage'] as string | null) ?? ''
+      );
+    }
+    if (
+      this.triple.object.termType === 'Literal' ||
+      this.triple.object.termType === 'ContentLiteral'
+    ) {
+      const { language } = this.triple.object;
+      return language;
     }
     return '';
   }

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/outgoing-triple-form.ts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/outgoing-triple-form.ts
@@ -151,7 +151,6 @@ export default class OutgoingTripleFormComponent extends Component<Sig> {
   }
 
   get initialDatatypeValue(): string {
-    console.log('Get datatype');
     if (!this.controller) {
       return '';
     }
@@ -186,7 +185,6 @@ export default class OutgoingTripleFormComponent extends Component<Sig> {
   }
 
   get initialLanguageValue(): string {
-    console.log('get initial lang');
     if (!this.controller) {
       return '';
     }

--- a/packages/ember-rdfa-editor/src/core/schema.ts
+++ b/packages/ember-rdfa-editor/src/core/schema.ts
@@ -61,6 +61,8 @@ const rdfaAwareAttrSpec = {
   rdfaNodeType: { default: undefined },
   subject: { default: null },
   content: { default: null, editable: true },
+  defaultLanguage: { default: null, editable: true },
+  defaultDatatype: { default: null, editable: true },
 };
 
 /** @deprecated `rdfaAttrs` is deprecated, use the `rdfaAttrSpec` function instead */
@@ -121,6 +123,8 @@ function getRdfaAwareAttrs(node: HTMLElement): RdfaAttrs | false {
     return {
       rdfaNodeType: 'literal',
       content: node.getAttribute('content'),
+      defaultDatatype: node.dataset['defaultDatatype'] ?? null,
+      defaultLanguage: node.dataset['defaultLanguage'] ?? null,
       __rdfaId,
       backlinks,
     };
@@ -259,6 +263,8 @@ export interface RdfaAwareAttrs {
 export interface RdfaLiteralAttrs extends RdfaAwareAttrs {
   rdfaNodeType: 'literal';
   content: string | null;
+  defaultDatatype: string | null;
+  defaultLanguage: string | null;
 }
 export interface RdfaResourceAttrs extends RdfaAwareAttrs {
   rdfaNodeType: 'resource';
@@ -460,6 +466,8 @@ export function renderRdfaAttrs(
         content: rdfaAttrs.content ?? null,
         'data-say-id': rdfaAttrs.__rdfaId,
         'data-literal-node': 'true',
+        'data-default-datatype': rdfaAttrs.defaultDatatype,
+        'data-default-language': rdfaAttrs.defaultLanguage,
       };
     }
 
@@ -473,6 +481,8 @@ export function renderRdfaAttrs(
       content: rdfaAttrs.content ?? null,
       'data-literal-node': 'true',
       'data-say-id': rdfaAttrs.__rdfaId,
+      'data-default-datatype': rdfaAttrs.defaultDatatype,
+      'data-default-language': rdfaAttrs.defaultLanguage,
     };
   }
 }


### PR DESCRIPTION
### Overview
Introduces concept of `defaultLanguage` and `defaultDatatype`:

(loose) literal nodes may define their `defaultLanguage` and `defaultDatatype`.
These attributes are (at the moment) editable through the attribute-editor.

`defaultLanguage` and `defaultDatatype` define what the prefilled values are for `datatype` and `language` in the relationship creation form.

The `defaultLanguage` attribute is serialized as `data-default-language`.
The `defaultDatatype` attribute is serialized as `data-default-datatype`.

### How to test/reproduce
- Start the test-app
- Insert a literal node
- Adjust its `defaultLanguage` and `defaultDatatype` through the attribute-editor
- Reload the doc, the attributes should be correctly preserved
j Add a relationship to a resource node and select the literal node as a target
- Ensure the `language` and `datatype` fields are prefilled

### Challenges/uncertainties
- We might want to revisit the `outgoing-triple-form` component to make the form a bit more reactive
- The attributes can currently only be added programmatically or through the attribute-editor. We might want to add a seperate UI for this.
- This approach ensures that this PR is not breaking (we are still supporting the `language` and `datatype` on the triples themselves). In a later (breaking) PR, we might still revisit the approach of moving the `language` and `datatype` to the literal-nodes altogether.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations