### PR TITLE
Extend `updateSubject` utility function with support for literal nodes

### DIFF
--- a/.changeset/gold-apples-like.md
+++ b/.changeset/gold-apples-like.md
@@ -1,0 +1,7 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Adjust `updateSubject` utility function:
+- accept `null` as a `targetSubject` value. If `null` is passed, the node is converted to a literal node. In this case, the `keepProperties` argument is ignored (properties are always removed in case of conversion to a literal node).
+- the function can now also be run on literal nodes. This always you to easily convert a literal node to a resource node with a certain subject.

--- a/test-app/tests/unit/rdfa/update-subject-test.ts
+++ b/test-app/tests/unit/rdfa/update-subject-test.ts
@@ -7,6 +7,7 @@ import {
 import { EditorState, PNode, type RdfaAttrs } from '@lblod/ember-rdfa-editor';
 import {
   getNodeByRdfaId,
+  getNodesBySubject,
   updateSubject,
   type UpdateSubjectArgs,
 } from '@lblod/ember-rdfa-editor/plugins/rdfa-info/utils';
@@ -1011,5 +1012,177 @@ module('rdfa | updateSubject', (hooks) => {
       const resultState = operationResult.state;
       assert.deepEqual(resultState.doc.toJSON(), expectedDoc.toJSON());
     });
+  });
+  test('change subjects to match then to literal', (assert) => {
+    const initalSubject1 = `http://example.org/1`;
+    const initalSubject2 = `http://example.org/2`;
+    const initialDoc = doc(
+      {},
+      block_rdfa(
+        {
+          rdfaNodeType: 'resource',
+          subject: initalSubject1,
+          __rdfaId: '1',
+          properties: [
+            {
+              predicate: 'http://predicates.org/1',
+              object: sayDataFactory.literalNode('5'),
+            },
+            {
+              predicate: 'http://predicates.org/2',
+              object: sayDataFactory.namedNode('http://named-nodes.org/1'),
+            },
+          ],
+          backlinks: [],
+        },
+        paragraph('content'),
+      ),
+      block_rdfa(
+        {
+          rdfaNodeType: 'resource',
+          subject: initalSubject2,
+          __rdfaId: '2',
+          properties: [
+            {
+              predicate: 'http://predicates.org/3',
+              object: sayDataFactory.literalNode('42'),
+            },
+            {
+              predicate: 'http://predicates.org/4',
+              object: sayDataFactory.namedNode('http://named-nodes.org/2'),
+            },
+          ],
+          backlinks: [],
+        },
+        paragraph('content'),
+      ),
+    );
+
+    const linkedDoc = doc(
+      {},
+      block_rdfa(
+        {
+          rdfaNodeType: 'resource',
+          subject: initalSubject1,
+          __rdfaId: '1',
+          properties: [
+            {
+              predicate: 'http://predicates.org/1',
+              object: sayDataFactory.literalNode('5'),
+            },
+            {
+              predicate: 'http://predicates.org/2',
+              object: sayDataFactory.namedNode('http://named-nodes.org/1'),
+            },
+            {
+              predicate: 'http://predicates.org/3',
+              object: sayDataFactory.literalNode('42'),
+            },
+            {
+              predicate: 'http://predicates.org/4',
+              object: sayDataFactory.namedNode('http://named-nodes.org/2'),
+            },
+          ],
+          backlinks: [],
+        },
+        paragraph('content'),
+      ),
+      block_rdfa(
+        {
+          rdfaNodeType: 'resource',
+          subject: initalSubject1,
+          __rdfaId: '2',
+          properties: [
+            {
+              predicate: 'http://predicates.org/1',
+              object: sayDataFactory.literalNode('5'),
+            },
+            {
+              predicate: 'http://predicates.org/2',
+              object: sayDataFactory.namedNode('http://named-nodes.org/1'),
+            },
+            {
+              predicate: 'http://predicates.org/3',
+              object: sayDataFactory.literalNode('42'),
+            },
+            {
+              predicate: 'http://predicates.org/4',
+              object: sayDataFactory.namedNode('http://named-nodes.org/2'),
+            },
+          ],
+          backlinks: [],
+        },
+        paragraph('content'),
+      ),
+    );
+
+    const initialState = createEditorState(initialDoc);
+
+    const node2 = unwrap(getNodesBySubject(initialState, initalSubject2))[0];
+    const operationResult = executeAndApplyUpdateSubjectOperation({
+      pos: node2.pos,
+      targetSubject: initalSubject1,
+      keepBacklinks: true,
+      keepProperties: true,
+      keepExternalTriples: true,
+    })(initialState);
+    assert.true(operationResult.success);
+
+    const resultState = operationResult.state;
+    assert.deepEqual(resultState.doc.toJSON(), linkedDoc.toJSON());
+
+    const step2Node2 = unwrap(getNodeByRdfaId(resultState, '2'));
+    const operation2Result = executeAndApplyUpdateSubjectOperation({
+      pos: step2Node2.pos,
+      targetSubject: null,
+      keepBacklinks: true,
+      keepProperties: false,
+      keepExternalTriples: true,
+    })(resultState);
+    assert.true(operationResult.success);
+
+    const afterDoc = doc(
+      {},
+      block_rdfa(
+        {
+          rdfaNodeType: 'resource',
+          subject: initalSubject1,
+          __rdfaId: '1',
+          properties: [
+            {
+              predicate: 'http://predicates.org/1',
+              object: sayDataFactory.literalNode('5'),
+            },
+            {
+              predicate: 'http://predicates.org/2',
+              object: sayDataFactory.namedNode('http://named-nodes.org/1'),
+            },
+            {
+              predicate: 'http://predicates.org/3',
+              object: sayDataFactory.literalNode('42'),
+            },
+            {
+              predicate: 'http://predicates.org/4',
+              object: sayDataFactory.namedNode('http://named-nodes.org/2'),
+            },
+          ],
+          backlinks: [],
+        },
+        paragraph('content'),
+      ),
+      block_rdfa(
+        {
+          rdfaNodeType: 'literal',
+          subject: null,
+          __rdfaId: '2',
+          properties: [],
+          backlinks: [],
+        },
+        paragraph('content'),
+      ),
+    );
+
+    const result2State = operation2Result.state;
+    assert.deepEqual(result2State.doc.toJSON(), afterDoc.toJSON());
   });
 });

--- a/test-app/tests/unit/rdfa/update-subject-test.ts
+++ b/test-app/tests/unit/rdfa/update-subject-test.ts
@@ -92,6 +92,98 @@ module('rdfa | updateSubject', (hooks) => {
       const resultState = operationResult.state;
       assert.deepEqual(resultState.doc.toJSON(), expectedDoc.toJSON());
     });
+    test('Literal node to resource node', (assert) => {
+      const initalSubject = null;
+      const targetSubject = `http://example.org/2`;
+      const initialDoc = doc(
+        {},
+        block_rdfa(
+          {
+            rdfaNodeType: 'literal',
+            subject: initalSubject,
+            __rdfaId: '1',
+            properties: [],
+            backlinks: [],
+          },
+          paragraph('content'),
+        ),
+      );
+
+      const expectedDoc = doc(
+        {},
+        block_rdfa(
+          {
+            rdfaNodeType: 'resource',
+            subject: targetSubject,
+            __rdfaId: '1',
+            properties: [],
+            backlinks: [],
+          },
+          paragraph('content'),
+        ),
+      );
+
+      const initialState = createEditorState(initialDoc);
+
+      const nodeToUpdate = unwrap(getNodeByRdfaId(initialState, '1'));
+      const operationResult = executeAndApplyUpdateSubjectOperation({
+        pos: nodeToUpdate.pos,
+        targetSubject,
+        keepBacklinks: false,
+        keepProperties: false,
+        keepExternalTriples: false,
+      })(initialState);
+      assert.true(operationResult.success);
+
+      const resultState = operationResult.state;
+      assert.deepEqual(resultState.doc.toJSON(), expectedDoc.toJSON());
+    });
+    test('Resource node to resource node', (assert) => {
+      const initalSubject = `http://example.org/1`;
+      const targetSubject = null;
+      const initialDoc = doc(
+        {},
+        block_rdfa(
+          {
+            rdfaNodeType: 'resource',
+            subject: initalSubject,
+            __rdfaId: '1',
+            properties: [],
+            backlinks: [],
+          },
+          paragraph('content'),
+        ),
+      );
+
+      const expectedDoc = doc(
+        {},
+        block_rdfa(
+          {
+            rdfaNodeType: 'literal',
+            subject: targetSubject,
+            __rdfaId: '1',
+            properties: [],
+            backlinks: [],
+          },
+          paragraph('content'),
+        ),
+      );
+
+      const initialState = createEditorState(initialDoc);
+
+      const nodeToUpdate = unwrap(getNodeByRdfaId(initialState, '1'));
+      const operationResult = executeAndApplyUpdateSubjectOperation({
+        pos: nodeToUpdate.pos,
+        targetSubject,
+        keepBacklinks: false,
+        keepProperties: false,
+        keepExternalTriples: false,
+      })(initialState);
+      assert.true(operationResult.success);
+
+      const resultState = operationResult.state;
+      assert.deepEqual(resultState.doc.toJSON(), expectedDoc.toJSON());
+    });
     module('External triples', () => {
       const initalSubject = `http://example.org/1`;
       const targetSubject = `http://example.org/2`;

--- a/test-app/tests/unit/rdfa/update-subject-test.ts
+++ b/test-app/tests/unit/rdfa/update-subject-test.ts
@@ -138,7 +138,7 @@ module('rdfa | updateSubject', (hooks) => {
       const resultState = operationResult.state;
       assert.deepEqual(resultState.doc.toJSON(), expectedDoc.toJSON());
     });
-    test('Resource node to resource node', (assert) => {
+    test('Resource node to literal node', (assert) => {
       const initalSubject = `http://example.org/1`;
       const targetSubject = null;
       const initialDoc = doc(


### PR DESCRIPTION
### Overview
This PR extends the `updateSubject` utility function with support for literal nodes:
- accept `null` as a `targetSubject` value. If `null` is passed, the node is converted to a literal node. In this case, the `keepProperties` argument is ignored (properties are always removed in case of conversion to a literal node).
- the function can now also be run on literal nodes. This always you to easily convert a literal node to a resource node with a certain subject.

This ensures that the `updateSubject` utility function can also serve as a `changeRdfaNodeType` function.

### How to test/reproduce
This PR includes two simple tests to test the functionality of converting literal nodes to resource nodes and vice versa.

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
