### PR TITLE
Convert release-commit pipeline to manual pipeline

### DIFF
--- a/.woodpecker/.release-commit.yml
+++ b/.woodpecker/.release-commit.yml
@@ -19,4 +19,4 @@ steps:
       NPM_ACCESS_TOKEN:
         from_secret: npm_access_token
 when:
-  - event: push
+  - event: manual


### PR DESCRIPTION
### Overview
This PR adjusts the `release-commit`  pipeline to only be triggered by `manual` events. This simply means you can run the pipeline by going into the woodpecker interface and running it manually. The other pipelines should now be run automatically.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
