### PR TITLE
CIT-31: rdfa tools tab behaviour/submit shortcuts

### DIFF
--- a/.changeset/legal-fans-push.md
+++ b/.changeset/legal-fans-push.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Rdfa-tool components: add `Ctrl+Enter`/`Cmd+Enter` handler to submit creation/edit forms inside modals.

--- a/.changeset/slow-rules-teach.md
+++ b/.changeset/slow-rules-teach.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+RDFa tool forms/modals: initially focus relevant form inputs

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/form.gts
@@ -13,10 +13,12 @@ import { uniqueId } from '@ember/helper';
 import { action } from '@ember/object';
 import type SayController from '#root/core/say-controller.ts';
 import { getSubjects } from '#root/plugins/rdfa-info/index.ts';
+import type { ModifierLike } from '@glint/template';
 
 interface BacklinkFormSig {
   Element: HTMLFormElement;
   Args: {
+    initialFocus?: ModifierLike<{ Element: HTMLElement }>;
     controller: SayController;
     onSubmit: (backlink: IncomingTriple) => void;
     backlink?: Option<IncomingTriple>;
@@ -103,6 +105,7 @@ export default class BacklinkForm extends Component<BacklinkFormSig> {
           >Subject</AuLabel>
           <PowerSelect
             id={{id}}
+            {{@initialFocus}}
             {{! For some reason need to manually set width }}
             class="au-u-1-1"
             @searchEnabled={{true}}

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/index.gts
@@ -257,15 +257,13 @@ interface BacklinkEditorModalSig {
 }
 
 class Modal extends Component<BacklinkEditorModalSig> {
-  setupFormSubmitShortcut = modifier((formElement: HTMLFormElement) => {
-    const ctrlEnterHandler = (event: KeyboardEvent) => {
-      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
-        formElement.requestSubmit();
-      }
-    };
-    window.addEventListener('keydown', ctrlEnterHandler);
-    return () => window.removeEventListener('keydown', ctrlEnterHandler);
-  });
+  @action
+  onFormKeyDown(formElement: HTMLFormElement, event: KeyboardEvent) {
+    if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+      formElement.requestSubmit();
+    }
+    return true;
+  }
 
   @tracked initiallyFocusedElement?: HTMLElement;
 
@@ -301,7 +299,7 @@ class Modal extends Component<BacklinkEditorModalSig> {
             @controller={{@controller}}
             @backlink={{@backlink}}
             @predicateOptions={{@predicateOptions}}
-            {{this.setupFormSubmitShortcut}}
+            @onKeyDown={{this.onFormKeyDown}}
           />
         </:body>
         <:footer>

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/index.gts
@@ -257,6 +257,16 @@ interface BacklinkEditorModalSig {
 }
 
 class Modal extends Component<BacklinkEditorModalSig> {
+  setupFormSubmitShortcut = modifier((formElement: HTMLFormElement) => {
+    const ctrlEnterHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+        formElement.requestSubmit();
+      }
+    };
+    window.addEventListener('keydown', ctrlEnterHandler);
+    return () => window.removeEventListener('keydown', ctrlEnterHandler);
+  });
+
   @action
   cancel() {
     this.args.onCancel();
@@ -282,6 +292,7 @@ class Modal extends Component<BacklinkEditorModalSig> {
             @controller={{@controller}}
             @backlink={{@backlink}}
             @predicateOptions={{@predicateOptions}}
+            {{this.setupFormSubmitShortcut}}
           />
         </:body>
         <:footer>

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/index.gts
@@ -267,6 +267,12 @@ class Modal extends Component<BacklinkEditorModalSig> {
     return () => window.removeEventListener('keydown', ctrlEnterHandler);
   });
 
+  @tracked initiallyFocusedElement?: HTMLElement;
+
+  initialFocus = modifier((element: HTMLElement) => {
+    this.initiallyFocusedElement = element;
+  });
+
   @action
   cancel() {
     this.args.onCancel();
@@ -283,11 +289,14 @@ class Modal extends Component<BacklinkEditorModalSig> {
         @modalOpen={{@modalOpen}}
         @closable={{true}}
         @closeModal={{this.cancel}}
+        {{! @glint-expect-error appuniversum types should be adapted to accept an html element here }}
+        @initialFocus={{this.initiallyFocusedElement}}
       >
         <:title>{{@title}}</:title>
         <:body>
           <BacklinkForm
             id={{formId}}
+            @initialFocus={{this.initialFocus}}
             @onSubmit={{this.save}}
             @controller={{@controller}}
             @backlink={{@backlink}}

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/form.gts
@@ -8,10 +8,11 @@ import {
   literalTermSchema,
   namedNodeTermSchema,
 } from '../object-term-schemas.ts';
-import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
+import AuFormRow, {
+} from '@appuniversum/ember-appuniversum/components/au-form-row';
 import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
 import AuPill from '@appuniversum/ember-appuniversum/components/au-label';
-import AuInput from '@appuniversum/ember-appuniversum/components/au-input';
+import AuInput, { type AuInputSignature } from '@appuniversum/ember-appuniversum/components/au-input';
 import {
   languageOrDataType,
   sayDataFactory,
@@ -23,6 +24,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { modifier } from 'ember-modifier';
 import type { Select } from 'ember-power-select/components/power-select';
 import WithUniqueId from '../../with-unique-id.ts';
+import type { ModifierLike } from '@glint/template';
 const predicateSchema = string().curie().required();
 
 const literalTripleSchema = object({
@@ -47,6 +49,7 @@ type ValidationResult = ValidResult | InvalidResult;
 interface ExternalTripleFormSig {
   Element: HTMLFormElement;
   Args: {
+    initialFocus?: ModifierLike<{ Element: HTMLElement }>;
     onSubmit: (trip: FullTriple) => void;
     triple?: Option<FullTriple>;
   };
@@ -219,6 +222,7 @@ export default class ExternalTripleForm extends Component<ExternalTripleFormSig>
     >
 
       <StringField
+        {{@initialFocus}}
         @name="subject.value"
         @required={{true}}
         @errors={{this.errors}}
@@ -276,6 +280,7 @@ interface StringFieldSig {
     default: [];
   };
   Args: FieldArgs & { value: string; disabled?: boolean };
+  Element: AuInputSignature['Element'];
 }
 
 const StringField: TemplateOnlyComponent<StringFieldSig> = <template>
@@ -292,6 +297,7 @@ const StringField: TemplateOnlyComponent<StringFieldSig> = <template>
         required={{@required}}
         @disabled={{@disabled}}
         @width="block"
+        ...attributes
       />
     </:default>
   </FormField>
@@ -305,6 +311,7 @@ interface SelectFieldArgs<T> extends FieldArgs {
 interface SelectFieldSig<T> {
   Args: SelectFieldArgs<T>;
   Blocks: { default: [] };
+  Element: HTMLElement;
 }
 
 // TOCs can't have a generic argument, so in this case we have to make a backing
@@ -330,6 +337,7 @@ class SelectField<T> extends Component<SelectFieldSig<T>> {
           @options={{@options}}
           @selected={{@selected}}
           @onChange={{this.onChange}}
+          ...attributes
           as |obj|
         >
           {{obj}}

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/form.gts
@@ -8,11 +8,12 @@ import {
   literalTermSchema,
   namedNodeTermSchema,
 } from '../object-term-schemas.ts';
-import AuFormRow, {
-} from '@appuniversum/ember-appuniversum/components/au-form-row';
+import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
 import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
 import AuPill from '@appuniversum/ember-appuniversum/components/au-label';
-import AuInput, { type AuInputSignature } from '@appuniversum/ember-appuniversum/components/au-input';
+import AuInput, {
+  type AuInputSignature,
+} from '@appuniversum/ember-appuniversum/components/au-input';
 import {
   languageOrDataType,
   sayDataFactory,

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/form.gts
@@ -212,10 +212,10 @@ export default class ExternalTripleForm extends Component<ExternalTripleFormSig>
   });
   <template>
     <form
-      ...attributes
       {{on "submit" this.handleSubmit}}
       {{on "input" this.handleInput}}
       {{this.initAfterInsert}}
+      ...attributes
     >
 
       <StringField

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/index.gts
@@ -20,8 +20,8 @@ import { BinIcon } from '@appuniversum/ember-appuniversum/components/icons/bin';
 import { fn } from '@ember/helper';
 import AuList from '@appuniversum/ember-appuniversum/components/au-list';
 import { isSome, type Option } from '#root/utils/_private/option.ts';
-import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import WithUniqueId from '../../with-unique-id.ts';
+import { modifier } from 'ember-modifier';
 
 interface EditModalSig {
   Args: {
@@ -32,30 +32,46 @@ interface EditModalSig {
   };
 }
 
-const EditModal: TemplateOnlyComponent<EditModalSig> = <template>
-  <WithUniqueId as |formId|>
-    <AuModal
-      @modalOpen={{@modalOpen}}
-      @closable={{true}}
-      @closeModal={{@onCancel}}
-    >
-      <:title>Edit external triples</:title>
-      <:body>
-        <ExternalTripleForm
-          @onSubmit={{@onSubmit}}
-          id={{formId}}
-          @triple={{@triple}}
-        />
-      </:body>
-      <:footer>
-        <AuButtonGroup>
-          <AuButton form={{formId}} type="submit">Save</AuButton>
-          <AuButton @skin="secondary" {{on "click" @onCancel}}>Cancel</AuButton>
-        </AuButtonGroup>
-      </:footer>
-    </AuModal>
-  </WithUniqueId>
-</template>;
+class EditModal extends Component<EditModalSig> {
+  setupFormSubmitShortcut = modifier((formElement: HTMLFormElement) => {
+    const ctrlEnterHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+        formElement.requestSubmit();
+      }
+    };
+    window.addEventListener('keydown', ctrlEnterHandler);
+    return () => window.removeEventListener('keydown', ctrlEnterHandler);
+  });
+
+  <template>
+    <WithUniqueId as |formId|>
+      <AuModal
+        @modalOpen={{@modalOpen}}
+        @closable={{true}}
+        @closeModal={{@onCancel}}
+      >
+        <:title>Edit external triples</:title>
+        <:body>
+          <ExternalTripleForm
+            @onSubmit={{@onSubmit}}
+            id={{formId}}
+            @triple={{@triple}}
+            {{this.setupFormSubmitShortcut}}
+          />
+        </:body>
+        <:footer>
+          <AuButtonGroup>
+            <AuButton form={{formId}} type="submit">Save</AuButton>
+            <AuButton
+              @skin="secondary"
+              {{on "click" @onCancel}}
+            >Cancel</AuButton>
+          </AuButtonGroup>
+        </:footer>
+      </AuModal>
+    </WithUniqueId>
+  </template>
+}
 
 interface ExternalTripleItemSig {
   Args: {

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/index.gts
@@ -22,6 +22,7 @@ import AuList from '@appuniversum/ember-appuniversum/components/au-list';
 import { isSome, type Option } from '#root/utils/_private/option.ts';
 import WithUniqueId from '../../with-unique-id.ts';
 import { modifier } from 'ember-modifier';
+import { action } from '@ember/object';
 
 interface EditModalSig {
   Args: {
@@ -33,15 +34,14 @@ interface EditModalSig {
 }
 
 class EditModal extends Component<EditModalSig> {
-  setupFormSubmitShortcut = modifier((formElement: HTMLFormElement) => {
-    const ctrlEnterHandler = (event: KeyboardEvent) => {
-      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
-        formElement.requestSubmit();
-      }
-    };
-    window.addEventListener('keydown', ctrlEnterHandler);
-    return () => window.removeEventListener('keydown', ctrlEnterHandler);
-  });
+
+  @action
+  onFormKeyDown(formElement: HTMLFormElement, event: KeyboardEvent) {
+    if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+      formElement.requestSubmit();
+    }
+    return true;
+  }
 
   @tracked initiallyFocusedElement?: HTMLElement;
 
@@ -65,7 +65,7 @@ class EditModal extends Component<EditModalSig> {
             @onSubmit={{@onSubmit}}
             id={{formId}}
             @triple={{@triple}}
-            {{this.setupFormSubmitShortcut}}
+            @onKeyDown={{this.onFormKeyDown}}
           />
         </:body>
         <:footer>

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/index.gts
@@ -43,16 +43,25 @@ class EditModal extends Component<EditModalSig> {
     return () => window.removeEventListener('keydown', ctrlEnterHandler);
   });
 
+  @tracked initiallyFocusedElement?: HTMLElement;
+
+  initialFocus = modifier((element: HTMLElement) => {
+    this.initiallyFocusedElement = element;
+  });
+
   <template>
     <WithUniqueId as |formId|>
       <AuModal
         @modalOpen={{@modalOpen}}
         @closable={{true}}
         @closeModal={{@onCancel}}
+        {{! @glint-expect-error appuniversum types should be adapted to accept an html element here }}
+        @initialFocus={{this.initiallyFocusedElement}}
       >
         <:title>Edit external triples</:title>
         <:body>
           <ExternalTripleForm
+            @initialFocus={{this.initialFocus}}
             @onSubmit={{@onSubmit}}
             id={{formId}}
             @triple={{@triple}}

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/index.gts
@@ -34,7 +34,6 @@ interface EditModalSig {
 }
 
 class EditModal extends Component<EditModalSig> {
-
   @action
   onFormKeyDown(formElement: HTMLFormElement, event: KeyboardEvent) {
     if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/form.gts
@@ -34,6 +34,7 @@ import { eq } from 'ember-truth-helpers';
 import { uniqueId } from '@ember/helper';
 // eslint-disable-next-line ember/no-at-ember-render-modifiers
 import didInsert from '@ember/render-modifiers/modifiers/did-insert';
+import type { ModifierLike } from '@glint/template';
 
 type SupportedTermType =
   | 'NamedNode'
@@ -52,6 +53,7 @@ const allTermTypes: SupportedTermType[] = [
 interface Sig {
   Args: {
     subject?: string;
+    initialFocus?: ModifierLike<{ Element: HTMLElement }>;
     triple?: OutgoingTriple;
     termTypes?: SupportedTermType[];
     defaultTermType?: SupportedTermType;
@@ -491,6 +493,7 @@ export default class PropertyEditorForm extends Component<Sig> {
                 @requiredLabel="Required"
               >Subject</AuLabel>
               <PowerSelect
+                {{@initialFocus}}
                 id={{id}}
                 {{! For some reason need to manually set width }}
                 class="au-u-1-1"
@@ -520,6 +523,7 @@ export default class PropertyEditorForm extends Component<Sig> {
               @requiredLabel="Required"
             >Predicate</AuLabel>
             <PowerSelect
+              {{(unless (this.isArray @importedResources) @initialFocus)}}
               id={{id}}
               {{! For some reason need to manually set width }}
               class="au-u-1-1"

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/form.gts
@@ -476,10 +476,10 @@ export default class PropertyEditorForm extends Component<Sig> {
 
   <template>
     <form
-      ...attributes
       {{on "submit" this.handleSubmit}}
       {{on "input" this.handleInput}}
       {{didInsert this.afterInsert}}
+      ...attributes
     >
       {{#if (this.isArray @importedResources)}}
         <AuFormRow>

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/form.gts
@@ -35,6 +35,7 @@ import { uniqueId } from '@ember/helper';
 // eslint-disable-next-line ember/no-at-ember-render-modifiers
 import didInsert from '@ember/render-modifiers/modifiers/did-insert';
 import type { ModifierLike } from '@glint/template';
+import { modifier } from 'ember-modifier';
 
 type SupportedTermType =
   | 'NamedNode'
@@ -60,6 +61,10 @@ interface Sig {
     controller?: SayController;
     onInput?(newTriple: Partial<OutgoingTriple>): void;
     onSubmit?(newTriple: OutgoingTriple, subject?: string): void;
+    onKeyDown?: (
+      form: HTMLFormElement,
+      event: KeyboardEvent,
+    ) => boolean | undefined;
     importedResources?: string[] | false;
     predicateOptions?: string[];
     objectOptions?: string[];
@@ -92,6 +97,18 @@ const DEFAULT_TRIPLE: OutgoingTriple = {
   object: sayDataFactory.namedNode(''),
 };
 export default class PropertyEditorForm extends Component<Sig> {
+  formElement?: HTMLFormElement;
+  setupFormElement = modifier((element: HTMLFormElement) => {
+    this.formElement = element;
+    const keyDownHandler = (event: KeyboardEvent) => {
+      if (this.args.onKeyDown) {
+        this.args.onKeyDown(element, event);
+      }
+    };
+    window.addEventListener('keydown', keyDownHandler);
+    return () => window.removeEventListener('keydown', keyDownHandler);
+  });
+
   @localCopy('args.triple.object.termType')
   selectedTermType?: SayTermType;
 
@@ -422,20 +439,28 @@ export default class PropertyEditorForm extends Component<Sig> {
   setObject(object: string) {
     this.object = object;
   }
-  @action
-  allowCustomSelection(select: Select, event: KeyboardEvent) {
-    // Based on example from ember-power-select docs, allows for selecting a previously non-existent
-    // entry by typing in the power-select 'search' and hitting 'enter'
-    if (
-      event.key === 'Enter' &&
-      select.isOpen &&
-      !select.highlighted &&
-      !!select.searchText
-    ) {
-      select.actions.choose(select.searchText);
-    }
-    return true;
-  }
+
+  onPowerSelectKeydown = (allowCustom: boolean) => {
+    return (select: Select, event: KeyboardEvent) => {
+      if (this.formElement && this.args.onKeyDown) {
+        this.args.onKeyDown(this.formElement, event);
+      }
+      // Based on example from ember-power-select docs, allows for selecting a previously non-existent
+      // entry by typing in the power-select 'search' and hitting 'enter'
+      if (
+        allowCustom &&
+        event.key === 'Enter' &&
+        select.isOpen &&
+        !select.highlighted &&
+        !!select.searchText
+      ) {
+        select.actions.choose(select.searchText);
+        return false;
+      }
+      return;
+    };
+  };
+
   @action
   setTermType(termType: SayTermType) {
     this.selectedTermType = termType;
@@ -481,6 +506,7 @@ export default class PropertyEditorForm extends Component<Sig> {
       {{on "submit" this.handleSubmit}}
       {{on "input" this.handleInput}}
       {{didInsert this.afterInsert}}
+      {{this.setupFormElement}}
       ...attributes
     >
       {{#if (this.isArray @importedResources)}}
@@ -501,7 +527,7 @@ export default class PropertyEditorForm extends Component<Sig> {
                 @options={{@importedResources}}
                 @selected={{this.subject}}
                 @onChange={{this.setSubject}}
-                @onKeydown={{this.allowCustomSelection}}
+                @onKeydown={{this.onPowerSelectKeydown true}}
                 @allowClear={{true}}
                 as |obj|
               >
@@ -531,7 +557,7 @@ export default class PropertyEditorForm extends Component<Sig> {
               @options={{@predicateOptions}}
               @selected={{this.predicate}}
               @onChange={{this.setPredicate}}
-              @onKeydown={{this.allowCustomSelection}}
+              @onKeydown={{this.onPowerSelectKeydown true}}
               @allowClear={{true}}
               as |obj|
             >
@@ -559,6 +585,7 @@ export default class PropertyEditorForm extends Component<Sig> {
               @options={{this.termTypes}}
               @selected={{this.termType}}
               @onChange={{this.setTermType}}
+              @onKeydown={{this.onPowerSelectKeydown false}}
               @allowClear={{true}}
               as |obj|
             >
@@ -588,7 +615,7 @@ export default class PropertyEditorForm extends Component<Sig> {
                 @options={{this.objectOptions}}
                 @selected={{this.object}}
                 @onChange={{this.setObject}}
-                @onKeydown={{this.allowCustomSelection}}
+                @onKeydown={{this.onPowerSelectKeydown true}}
                 @allowClear={{true}}
                 as |obj|
               >
@@ -682,6 +709,7 @@ export default class PropertyEditorForm extends Component<Sig> {
                 @options={{this.literals}}
                 @selected={{this.selectedLiteralNode}}
                 @onChange={{this.setLiteralNodeLink}}
+                @onKeydown={{this.onPowerSelectKeydown false}}
                 @allowClear={{true}}
                 @placeholder="Select a literal"
                 as |obj|
@@ -709,6 +737,7 @@ export default class PropertyEditorForm extends Component<Sig> {
                 @options={{this.resources}}
                 @selected={{this.selectedResourceNode}}
                 @onChange={{this.setResourceNodeLink}}
+                @onKeydown={{this.onPowerSelectKeydown false}}
                 @allowClear={{true}}
                 @placeholder="Select a resource"
                 as |obj|

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/index.gts
@@ -39,6 +39,7 @@ import { isResourceNode } from '#root/utils/node-utils.ts';
 import { type Status, type StatusMessage } from '../types.ts';
 import PropertyDetails from '../property-details.gts';
 import { modifier } from 'ember-modifier';
+import { action } from '@ember/object';
 
 interface StatusMessageForNode extends StatusMessage {
   node: PNode;
@@ -407,15 +408,13 @@ interface Sig {
 }
 
 class Modal extends Component<Sig> {
-  setupFormSubmitShortcut = modifier((formElement: HTMLFormElement) => {
-    const ctrlEnterHandler = (event: KeyboardEvent) => {
-      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
-        formElement.requestSubmit();
-      }
-    };
-    window.addEventListener('keydown', ctrlEnterHandler);
-    return () => window.removeEventListener('keydown', ctrlEnterHandler);
-  });
+  @action
+  onFormKeyDown(formElement: HTMLFormElement, event: KeyboardEvent) {
+    if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+      formElement.requestSubmit();
+    }
+    return true;
+  }
 
   @tracked initiallyFocusedElement?: HTMLElement;
 
@@ -460,7 +459,7 @@ class Modal extends Component<Sig> {
             @importedResources={{@importedResources}}
             @predicateOptions={{@predicateOptions}}
             @objectOptions={{@objectOptions}}
-            {{this.setupFormSubmitShortcut}}
+            @onKeyDown={{this.onFormKeyDown}}
           />
         </:body>
         <:footer>

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/index.gts
@@ -407,6 +407,16 @@ interface Sig {
 }
 
 class Modal extends Component<Sig> {
+  setupFormSubmitShortcut = modifier((formElement: HTMLFormElement) => {
+    const ctrlEnterHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+        formElement.requestSubmit();
+      }
+    };
+    window.addEventListener('keydown', ctrlEnterHandler);
+    return () => window.removeEventListener('keydown', ctrlEnterHandler);
+  });
+
   cancel = () => {
     this.args.onCancel();
   };
@@ -441,6 +451,7 @@ class Modal extends Component<Sig> {
             @importedResources={{@importedResources}}
             @predicateOptions={{@predicateOptions}}
             @objectOptions={{@objectOptions}}
+            {{this.setupFormSubmitShortcut}}
           />
         </:body>
         <:footer>

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/index.gts
@@ -417,6 +417,12 @@ class Modal extends Component<Sig> {
     return () => window.removeEventListener('keydown', ctrlEnterHandler);
   });
 
+  @tracked initiallyFocusedElement?: HTMLElement;
+
+  initialFocus = modifier((element: HTMLElement) => {
+    this.initiallyFocusedElement = element;
+  });
+
   cancel = () => {
     this.args.onCancel();
   };
@@ -433,11 +439,14 @@ class Modal extends Component<Sig> {
         @modalOpen={{@modalOpen}}
         @closable={{true}}
         @closeModal={{this.cancel}}
+        {{! @glint-expect-error appuniversum types should be adapted to accept an html element here }}
+        @initialFocus={{this.initiallyFocusedElement}}
       >
         <:title>{{this.title}}</:title>
         <:body>
           <PropertyEditorForm
             id={{formId}}
+            @initialFocus={{this.initialFocus}}
             @onSubmit={{this.save}}
             @termTypes={{array
               "NamedNode"

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/wrapping-utils/modal.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/wrapping-utils/modal.gts
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import type RdfaWrappingUtils from './index.ts';
 import AuModal from '@appuniversum/ember-appuniversum/components/au-modal';
-import { uniqueId } from '@ember/helper';
 import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
 import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
 import AuInput from '@appuniversum/ember-appuniversum/components/au-input';
@@ -12,6 +11,7 @@ import AuRadioGroup from '@appuniversum/ember-appuniversum/components/au-radio-g
 import { not } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import { modifier } from 'ember-modifier';
+import WithUniqueId from '../../with-unique-id.ts';
 
 type Args = {
   closeModal: () => void;
@@ -20,6 +20,8 @@ type Args = {
 };
 
 export default class RelationshipEditorModal extends Component<Args> {
+  @tracked initiallyFocusedElement?: HTMLElement;
+
   setupFormSubmitShortcut = modifier((formElement: HTMLFormElement) => {
     const ctrlEnterHandler = (event: KeyboardEvent) => {
       if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
@@ -28,6 +30,10 @@ export default class RelationshipEditorModal extends Component<Args> {
     };
     window.addEventListener('keydown', ctrlEnterHandler);
     return () => window.removeEventListener('keydown', ctrlEnterHandler);
+  });
+
+  initialFocus = modifier((element: HTMLElement) => {
+    this.initiallyFocusedElement = element;
   });
 
   @tracked generateNewUri = 'yes';
@@ -57,11 +63,13 @@ export default class RelationshipEditorModal extends Component<Args> {
   }
 
   <template>
-    {{#let (uniqueId) as |formId|}}
+    <WithUniqueId as |formId|>
       <AuModal
         @modalOpen={{@modalOpen}}
         @closable={{true}}
         @closeModal={{@closeModal}}
+        {{! @glint-expect-error appuniversum types should be adapted to accept an html element here }}
+        @initialFocus={{this.initiallyFocusedElement}}
       >
         <:title>Wrap selection</:title>
         <:body>
@@ -72,7 +80,7 @@ export default class RelationshipEditorModal extends Component<Args> {
             {{this.setupFormSubmitShortcut}}
           >
             <AuFormRow>
-              {{#let (uniqueId) as |id|}}
+              <WithUniqueId as |id|>
                 <AuLabel
                   for={{id}}
                   @required={{true}}
@@ -92,10 +100,10 @@ export default class RelationshipEditorModal extends Component<Args> {
                   <Group.Radio @value="yes">Yes</Group.Radio>
                   <Group.Radio @value="no">No</Group.Radio>
                 </AuRadioGroup>
-              {{/let}}
+              </WithUniqueId>
             </AuFormRow>
             <AuFormRow>
-              {{#let (uniqueId) as |id|}}
+              <WithUniqueId as |id|>
                 <AuLabel
                   for={{id}}
                   @required={{true}}
@@ -104,6 +112,7 @@ export default class RelationshipEditorModal extends Component<Args> {
                   {{#if this.isNewUri}}URI base{{else}}Existing URI{{/if}}
                 </AuLabel>
                 <AuInput
+                  {{this.initialFocus}}
                   id={{id}}
                   required={{true}}
                   value={{this.resourceUriBase}}
@@ -111,7 +120,7 @@ export default class RelationshipEditorModal extends Component<Args> {
                   placeholder="http://example.com/resource/"
                   {{on "input" this.updateUriBase}}
                 />
-              {{/let}}
+              </WithUniqueId>
             </AuFormRow>
           </form>
         </:body>
@@ -131,6 +140,6 @@ export default class RelationshipEditorModal extends Component<Args> {
           </AuButtonGroup>
         </:footer>
       </AuModal>
-    {{/let}}
+    </WithUniqueId>
   </template>
 }

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/wrapping-utils/modal.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/wrapping-utils/modal.gts
@@ -11,6 +11,7 @@ import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 import AuRadioGroup from '@appuniversum/ember-appuniversum/components/au-radio-group';
 import { not } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
+import { modifier } from 'ember-modifier';
 
 type Args = {
   closeModal: () => void;
@@ -19,6 +20,16 @@ type Args = {
 };
 
 export default class RelationshipEditorModal extends Component<Args> {
+  setupFormSubmitShortcut = modifier((formElement: HTMLFormElement) => {
+    const ctrlEnterHandler = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+        formElement.requestSubmit();
+      }
+    };
+    window.addEventListener('keydown', ctrlEnterHandler);
+    return () => window.removeEventListener('keydown', ctrlEnterHandler);
+  });
+
   @tracked generateNewUri = 'yes';
   @tracked resourceUriBase = '';
 
@@ -54,7 +65,12 @@ export default class RelationshipEditorModal extends Component<Args> {
       >
         <:title>Wrap selection</:title>
         <:body>
-          <form class="au-c-form" id={{formId}} {{on "submit" this.save}}>
+          <form
+            class="au-c-form"
+            id={{formId}}
+            {{on "submit" this.save}}
+            {{this.setupFormSubmitShortcut}}
+          >
             <AuFormRow>
               {{#let (uniqueId) as |id|}}
                 <AuLabel


### PR DESCRIPTION
### Overview
This PR improves the behaviour of the forms included in the rdfa-tool modals:
- Addition of `Ctrl+Enter`/`Cmd+Enter` handlers to submit creation/edit forms inside modals of the rdfa-tool components.
- Set up modifiers to initially focus first inputs of the forms (in combination with `focus-trap`)

##### connected issues and PRs:
[CIT-31](https://binnenland.atlassian.net/browse/CIT-31)

### How to test/reproduce
- Start the test-app and open the 'editable node' page
- Open any of the rdfa-tool modals containing a form
- The first focuseable input of the form should be focused by default
- Ensure you can traverse between the different form fields. There should be a focus trap on the modal
- Pressing `Ctrl+Enter`/`Cmd+Enter` should submit the form as expected. Note: 

### Challenges/uncertainties
When a power-select is focused, the `Ctrl+Enter` key is not propagated correctly. I am still looking into this.

I opted for modifiers (in combination with `focus-trap.initialFocus`) to implement the autofocussing of the first form element. Another option would be to use the id's of the elements to focus initially (instead of the elements themselves).
Another option (maybe to be used in the future) is to use the native `dialog` element, in combination with the `autofocus` attribute, check-out https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#usage_notes.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
