### PR TITLE
Update the compatibility information in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,10 +423,9 @@ Afterwards if you need to update the snapshots you can run `npm run e2e:run:vrt:
 > Playwright is run in Docker to ensure consistent snapshot comparison results, as it guarantees the same environment for each run.
 
 ## Compatibility
-
-* Ember.js v3.28 or above
-* Ember CLI v3.28 or above
-* Node.js v18 or above
+  
+* Ember.js v4.12 or above
+* Embroider or ember-auto-import v2
 
 
 ## Contributing


### PR DESCRIPTION
v3.28 support was dropped already so the readme was a bit out of date.

It now matches the [`@embroider/addon-blueprint` version](https://github.com/embroider-build/addon-blueprint/blob/be089ee2ee9c7a5c72540cfd004226d3bff0ca4d/files/README.md?plain=1#L7-L8).