### PR TITLE
bugfix: remove usage of explicit `uniqueId` imports

### DIFF
--- a/.changeset/silent-spoons-hope.md
+++ b/.changeset/silent-spoons-hope.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Remove usage of explicitly imported `uniqueId` helper, as this is not supported by ember 4.x

--- a/packages/ember-rdfa-editor/src/components/_private/attribute-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/attribute-editor/index.gts
@@ -24,7 +24,8 @@ import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
 import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 import AuTextarea from '@appuniversum/ember-appuniversum/components/au-textarea';
 
-import { uniqueId } from '@ember/helper';
+import WithUniqueId from '../with-unique-id.ts';
+
 import { get } from '@ember/object';
 import { fn } from '@ember/helper';
 
@@ -163,7 +164,7 @@ export default class AttributeEditor extends Component<Signature> {
               <Item>
                 <div class="au-u-padding-tiny">
                   {{#if (and this.isEditing (this.isEditable key))}}
-                    {{#let (uniqueId) as |id|}}
+                    <WithUniqueId as |id|>
                       <AuLabel for={{id}}>
                         {{key}}
                       </AuLabel>
@@ -186,7 +187,7 @@ export default class AttributeEditor extends Component<Signature> {
                           />
                         {{/if}}
                       {{/let}}
-                    {{/let}}
+                    </WithUniqueId>
                   {{else}}
                     <p><strong>{{key}}</strong></p>
                     <pre>{{if

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/form.gts
@@ -9,12 +9,12 @@ import PowerSelect, {
   type Select,
 } from 'ember-power-select/components/power-select';
 import { type Option } from '#root/utils/_private/option.ts';
-import { uniqueId } from '@ember/helper';
 import { action } from '@ember/object';
 import type SayController from '#root/core/say-controller.ts';
 import { getSubjects } from '#root/plugins/rdfa-info/index.ts';
 import type { ModifierLike } from '@glint/template';
 import { modifier } from 'ember-modifier';
+import WithUniqueId from '../../with-unique-id.ts';
 
 interface BacklinkFormSig {
   Element: HTMLFormElement;
@@ -111,7 +111,7 @@ export default class BacklinkForm extends Component<BacklinkFormSig> {
       ...attributes
     >
       <AuFormRow>
-        {{#let (uniqueId) as |id|}}
+        <WithUniqueId as |id|>
           <AuLabel
             for={{id}}
             @required={{true}}
@@ -132,10 +132,10 @@ export default class BacklinkForm extends Component<BacklinkFormSig> {
           >
             {{obj}}
           </PowerSelect>
-        {{/let}}
+        </WithUniqueId>
       </AuFormRow>
       <AuFormRow>
-        {{#let (uniqueId) as |id|}}
+        <WithUniqueId as |id|>
           <AuLabel
             for={{id}}
             @required={{true}}
@@ -155,7 +155,7 @@ export default class BacklinkForm extends Component<BacklinkFormSig> {
           >
             {{obj}}
           </PowerSelect>
-        {{/let}}
+        </WithUniqueId>
       </AuFormRow>
     </form>
   </template>

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/doc-imported-resource-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/doc-imported-resource-editor/form.gts
@@ -7,7 +7,7 @@ import AuFormRow from '@appuniversum/ember-appuniversum/components/au-form-row';
 import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
 import AuPill from '@appuniversum/ember-appuniversum/components/au-pill';
 import AuInput from '@appuniversum/ember-appuniversum/components/au-input';
-import { uniqueId } from '@ember/helper';
+import WithUniqueId from '../../with-unique-id.ts';
 
 const resourceSchema = string().curie().required();
 
@@ -61,26 +61,28 @@ export default class PropertyEditorForm extends Component<Sig> {
   <template>
     <form ...attributes {{on "submit" this.handleSubmit}}>
       <AuFormRow>
-        {{#let (uniqueId) "resource" as |id name|}}
-          {{#let (this.findError name) as |error|}}
-            <AuLabel
-              for={{id}}
-              @required={{true}}
-              @requiredLabel="Required"
-            >Resource</AuLabel>
-            <AuInput
-              id={{id}}
-              name={{name}}
-              value={{this.resource}}
-              required={{true}}
-              @width="block"
-              {{on "input" this.handleInput}}
-            />
-            {{#if error}}
-              <AuPill>{{error}}</AuPill>
-            {{/if}}
+        <WithUniqueId as |id|>
+          {{#let "resource" as |name|}}
+            {{#let (this.findError name) as |error|}}
+              <AuLabel
+                for={{id}}
+                @required={{true}}
+                @requiredLabel="Required"
+              >Resource</AuLabel>
+              <AuInput
+                id={{id}}
+                name={{name}}
+                value={{this.resource}}
+                required={{true}}
+                @width="block"
+                {{on "input" this.handleInput}}
+              />
+              {{#if error}}
+                <AuPill>{{error}}</AuPill>
+              {{/if}}
+            {{/let}}
           {{/let}}
-        {{/let}}
+        </WithUniqueId>
       </AuFormRow>
     </form>
   </template>

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/form.gts
@@ -804,26 +804,26 @@ export default class PropertyEditorForm extends Component<Sig> {
         </AuFormRow>
         <AuFormRow>
           <WithUniqueId as |id|>
-          {{#let "object.language" as |name|}}
-            {{#let (this.findError name) as |error|}}
-              <AuLabel
-                for={{id}}
-                @required={{false}}
-                @requiredLabel="Required"
-              >Language</AuLabel>
-              <AuInput
-                id={{id}}
-                name={{name}}
-                value={{this.initialLanguageValue}}
-                required={{false}}
-                @width="block"
-                @disabled={{this.hasDatatype}}
-              />
-              {{#if error}}
-                <AuPill>{{error}}</AuPill>
-              {{/if}}
+            {{#let "object.language" as |name|}}
+              {{#let (this.findError name) as |error|}}
+                <AuLabel
+                  for={{id}}
+                  @required={{false}}
+                  @requiredLabel="Required"
+                >Language</AuLabel>
+                <AuInput
+                  id={{id}}
+                  name={{name}}
+                  value={{this.initialLanguageValue}}
+                  required={{false}}
+                  @width="block"
+                  @disabled={{this.hasDatatype}}
+                />
+                {{#if error}}
+                  <AuPill>{{error}}</AuPill>
+                {{/if}}
+              {{/let}}
             {{/let}}
-          {{/let}}
           </WithUniqueId>
         </AuFormRow>
       {{/if}}

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/form.gts
@@ -31,11 +31,11 @@ import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
 import AuPill from '@appuniversum/ember-appuniversum/components/au-pill';
 import AuInput from '@appuniversum/ember-appuniversum/components/au-input';
 import { eq } from 'ember-truth-helpers';
-import { uniqueId } from '@ember/helper';
 // eslint-disable-next-line ember/no-at-ember-render-modifiers
 import didInsert from '@ember/render-modifiers/modifiers/did-insert';
 import type { ModifierLike } from '@glint/template';
 import { modifier } from 'ember-modifier';
+import WithUniqueId from '../../with-unique-id.ts';
 
 type SupportedTermType =
   | 'NamedNode'
@@ -511,22 +511,55 @@ export default class PropertyEditorForm extends Component<Sig> {
     >
       {{#if (this.isArray @importedResources)}}
         <AuFormRow>
-          {{#let (uniqueId) "subject" as |id name|}}
+          <WithUniqueId as |id|>
+            {{#let "subject" as |name|}}
+              {{#let (this.findError name) as |error|}}
+                <AuLabel
+                  for={{id}}
+                  @required={{true}}
+                  @requiredLabel="Required"
+                >Subject</AuLabel>
+                <PowerSelect
+                  {{@initialFocus}}
+                  id={{id}}
+                  {{! For some reason need to manually set width }}
+                  class="au-u-1-1"
+                  @searchEnabled={{true}}
+                  @options={{@importedResources}}
+                  @selected={{this.subject}}
+                  @onChange={{this.setSubject}}
+                  @onKeydown={{this.onPowerSelectKeydown true}}
+                  @allowClear={{true}}
+                  as |obj|
+                >
+                  {{obj}}
+                </PowerSelect>
+                {{#if error}}
+                  <AuPill>{{error}}</AuPill>
+                {{/if}}
+              {{/let}}
+            {{/let}}
+          </WithUniqueId>
+        </AuFormRow>
+      {{/if}}
+      <AuFormRow>
+        <WithUniqueId as |id|>
+          {{#let "predicate" as |name|}}
             {{#let (this.findError name) as |error|}}
               <AuLabel
                 for={{id}}
                 @required={{true}}
                 @requiredLabel="Required"
-              >Subject</AuLabel>
+              >Predicate</AuLabel>
               <PowerSelect
-                {{@initialFocus}}
+                {{(unless (this.isArray @importedResources) @initialFocus)}}
                 id={{id}}
                 {{! For some reason need to manually set width }}
                 class="au-u-1-1"
                 @searchEnabled={{true}}
-                @options={{@importedResources}}
-                @selected={{this.subject}}
-                @onChange={{this.setSubject}}
+                @options={{@predicateOptions}}
+                @selected={{this.predicate}}
+                @onChange={{this.setPredicate}}
                 @onKeydown={{this.onPowerSelectKeydown true}}
                 @allowClear={{true}}
                 as |obj|
@@ -538,243 +571,240 @@ export default class PropertyEditorForm extends Component<Sig> {
               {{/if}}
             {{/let}}
           {{/let}}
-        </AuFormRow>
-      {{/if}}
-      <AuFormRow>
-        {{#let (uniqueId) "predicate" as |id name|}}
-          {{#let (this.findError name) as |error|}}
-            <AuLabel
-              for={{id}}
-              @required={{true}}
-              @requiredLabel="Required"
-            >Predicate</AuLabel>
-            <PowerSelect
-              {{(unless (this.isArray @importedResources) @initialFocus)}}
-              id={{id}}
-              {{! For some reason need to manually set width }}
-              class="au-u-1-1"
-              @searchEnabled={{true}}
-              @options={{@predicateOptions}}
-              @selected={{this.predicate}}
-              @onChange={{this.setPredicate}}
-              @onKeydown={{this.onPowerSelectKeydown true}}
-              @allowClear={{true}}
-              as |obj|
-            >
-              {{obj}}
-            </PowerSelect>
-            {{#if error}}
-              <AuPill>{{error}}</AuPill>
-            {{/if}}
-          {{/let}}
-        {{/let}}
+        </WithUniqueId>
+
       </AuFormRow>
       <AuFormRow>
-        {{#let (uniqueId) "object.termType" as |id name|}}
-          {{#let (this.findError name) as |error|}}
-            <AuLabel
-              for={{id}}
-              @required={{true}}
-              @requiredLabel="Required"
-            >TermType</AuLabel>
-            <PowerSelect
-              id={{id}}
-              {{! For some reason need to manually set width }}
-              class="au-u-1-1"
-              @searchEnabled={{false}}
-              @options={{this.termTypes}}
-              @selected={{this.termType}}
-              @onChange={{this.setTermType}}
-              @onKeydown={{this.onPowerSelectKeydown false}}
-              @allowClear={{true}}
-              as |obj|
-            >
-              {{obj}}
-            </PowerSelect>
-            {{#if error}}
-              <AuPill>{{error}}</AuPill>
-            {{/if}}
+        <WithUniqueId as |id|>
+          {{#let "object.termType" as |name|}}
+            {{#let (this.findError name) as |error|}}
+              <AuLabel
+                for={{id}}
+                @required={{true}}
+                @requiredLabel="Required"
+              >TermType</AuLabel>
+              <PowerSelect
+                id={{id}}
+                {{! For some reason need to manually set width }}
+                class="au-u-1-1"
+                @searchEnabled={{false}}
+                @options={{this.termTypes}}
+                @selected={{this.termType}}
+                @onChange={{this.setTermType}}
+                @onKeydown={{this.onPowerSelectKeydown false}}
+                @allowClear={{true}}
+                as |obj|
+              >
+                {{obj}}
+              </PowerSelect>
+              {{#if error}}
+                <AuPill>{{error}}</AuPill>
+              {{/if}}
+            {{/let}}
           {{/let}}
-        {{/let}}
+        </WithUniqueId>
       </AuFormRow>
       {{! I tried deduplicating these, but they all need slightly different validation so there's no point}}
       {{#if (eq this.termType "NamedNode")}}
         <AuFormRow>
-          {{#let (uniqueId) "object.value" as |id name|}}
-            {{#let (this.findError name) as |error|}}
-              <AuLabel
-                for={{id}}
-                @required={{true}}
-                @requiredLabel="Required"
-              >URI</AuLabel>
-              <PowerSelect
-                id={{id}}
-                {{! For some reason need to manually set width }}
-                class="au-u-1-1"
-                @searchEnabled={{true}}
-                @options={{this.objectOptions}}
-                @selected={{this.object}}
-                @onChange={{this.setObject}}
-                @onKeydown={{this.onPowerSelectKeydown true}}
-                @allowClear={{true}}
-                as |obj|
-              >
-                {{obj}}
-              </PowerSelect>
-              {{#if error}}
-                <AuPill>{{error}}</AuPill>
-              {{/if}}
+          <WithUniqueId as |id|>
+            {{#let "object.value" as |name|}}
+              {{#let (this.findError name) as |error|}}
+                <AuLabel
+                  for={{id}}
+                  @required={{true}}
+                  @requiredLabel="Required"
+                >URI</AuLabel>
+                <PowerSelect
+                  id={{id}}
+                  {{! For some reason need to manually set width }}
+                  class="au-u-1-1"
+                  @searchEnabled={{true}}
+                  @options={{this.objectOptions}}
+                  @selected={{this.object}}
+                  @onChange={{this.setObject}}
+                  @onKeydown={{this.onPowerSelectKeydown true}}
+                  @allowClear={{true}}
+                  as |obj|
+                >
+                  {{obj}}
+                </PowerSelect>
+                {{#if error}}
+                  <AuPill>{{error}}</AuPill>
+                {{/if}}
+              {{/let}}
             {{/let}}
-          {{/let}}
+          </WithUniqueId>
         </AuFormRow>
       {{else if (eq this.termType "Literal")}}
         <AuFormRow>
-          {{#let (uniqueId) "object.value" as |id name|}}
-            {{#let (this.findError name) as |error|}}
-              <AuLabel
-                for={{id}}
-                @required={{true}}
-                @requiredLabel="Required"
-              >Value</AuLabel>
-              <AuInput
-                id={{id}}
-                name={{name}}
-                value={{this.triple.object.value}}
-                required={{true}}
-                @width="block"
-              />
-              {{#if error}}
-                <AuPill>{{error}}</AuPill>
-              {{/if}}
+          <WithUniqueId as |id|>
+            {{#let "object.value" as |name|}}
+              {{#let (this.findError name) as |error|}}
+                <AuLabel
+                  for={{id}}
+                  @required={{true}}
+                  @requiredLabel="Required"
+                >Value</AuLabel>
+                <AuInput
+                  id={{id}}
+                  name={{name}}
+                  value={{this.triple.object.value}}
+                  required={{true}}
+                  @width="block"
+                />
+                {{#if error}}
+                  <AuPill>{{error}}</AuPill>
+                {{/if}}
+              {{/let}}
             {{/let}}
-          {{/let}}
+          </WithUniqueId>
         </AuFormRow>
         <AuFormRow>
-          {{#let (uniqueId) "object.datatype.value" as |id name|}}
-            {{#let (this.findError name) as |error|}}
-              <AuLabel
-                for={{id}}
-                @required={{false}}
-                @requiredLabel="Required"
-              >Datatype</AuLabel>
-              <AuInput
-                id={{id}}
-                name={{name}}
-                value={{this.initialDatatypeValue}}
-                required={{false}}
-                @width="block"
-                @disabled={{this.hasLanguage}}
-              />
-              {{#if error}}
-                <AuPill>{{error}}</AuPill>
-              {{/if}}
+          <WithUniqueId as |id|>
+            {{#let "object.datatype.value" as |name|}}
+              {{#let (this.findError name) as |error|}}
+                <AuLabel
+                  for={{id}}
+                  @required={{false}}
+                  @requiredLabel="Required"
+                >Datatype</AuLabel>
+                <AuInput
+                  id={{id}}
+                  name={{name}}
+                  value={{this.initialDatatypeValue}}
+                  required={{false}}
+                  @width="block"
+                  @disabled={{this.hasLanguage}}
+                />
+                {{#if error}}
+                  <AuPill>{{error}}</AuPill>
+                {{/if}}
+              {{/let}}
             {{/let}}
-          {{/let}}
+          </WithUniqueId>
         </AuFormRow>
         <AuFormRow>
-          {{#let (uniqueId) "object.language" as |id name|}}
-            {{#let (this.findError name) as |error|}}
-              <AuLabel
-                for={{id}}
-                @required={{false}}
-                @requiredLabel="Required"
-              >Language</AuLabel>
-              <AuInput
-                id={{id}}
-                name={{name}}
-                value={{this.initialLanguageValue}}
-                required={{false}}
-                @width="block"
-                @disabled={{this.hasDatatype}}
-              />
-              {{#if error}}
-                <AuPill>{{error}}</AuPill>
-              {{/if}}
+          <WithUniqueId as |id|>
+            {{#let "object.language" as |name|}}
+              {{#let (this.findError name) as |error|}}
+                <AuLabel
+                  for={{id}}
+                  @required={{false}}
+                  @requiredLabel="Required"
+                >Language</AuLabel>
+                <AuInput
+                  id={{id}}
+                  name={{name}}
+                  value={{this.initialLanguageValue}}
+                  required={{false}}
+                  @width="block"
+                  @disabled={{this.hasDatatype}}
+                />
+                {{#if error}}
+                  <AuPill>{{error}}</AuPill>
+                {{/if}}
+              {{/let}}
             {{/let}}
-          {{/let}}
+          </WithUniqueId>
         </AuFormRow>
       {{else if (eq this.termType "LiteralNode")}}
-
         <AuFormRow>
-          {{#let (uniqueId) "object.value" as |id name|}}
-            {{#let (this.findError name) as |error|}}
-              <AuLabel for={{id}} @required={{true}} @requiredLabel="Required">
-                Object
-              </AuLabel>
-              <PowerSelect
-                id={{id}}
-                {{! For some reason need to manually set width }}
-                class="au-u-1-1"
-                @searchEnabled={{false}}
-                @options={{this.literals}}
-                @selected={{this.selectedLiteralNode}}
-                @onChange={{this.setLiteralNodeLink}}
-                @onKeydown={{this.onPowerSelectKeydown false}}
-                @allowClear={{true}}
-                @placeholder="Select a literal"
-                as |obj|
-              >
-                {{this.literalNodeLabel obj}}
-              </PowerSelect>
-              {{#if error}}
-                <AuPill>{{error}}</AuPill>
-              {{/if}}
+          <WithUniqueId as |id|>
+            {{#let "object.value" as |name|}}
+              {{#let (this.findError name) as |error|}}
+                <AuLabel
+                  for={{id}}
+                  @required={{true}}
+                  @requiredLabel="Required"
+                >
+                  Object
+                </AuLabel>
+                <PowerSelect
+                  id={{id}}
+                  {{! For some reason need to manually set width }}
+                  class="au-u-1-1"
+                  @searchEnabled={{false}}
+                  @options={{this.literals}}
+                  @selected={{this.selectedLiteralNode}}
+                  @onChange={{this.setLiteralNodeLink}}
+                  @onKeydown={{this.onPowerSelectKeydown false}}
+                  @allowClear={{true}}
+                  @placeholder="Select a literal"
+                  as |obj|
+                >
+                  {{this.literalNodeLabel obj}}
+                </PowerSelect>
+                {{#if error}}
+                  <AuPill>{{error}}</AuPill>
+                {{/if}}
+              {{/let}}
             {{/let}}
-          {{/let}}
+          </WithUniqueId>
         </AuFormRow>
       {{else if (eq this.termType "ResourceNode")}}
         <AuFormRow>
-          {{#let (uniqueId) "object.value" as |id name|}}
-            {{#let (this.findError name) as |error|}}
-              <AuLabel for={{id}} @required={{true}} @requiredLabel="Required">
-                Object
-              </AuLabel>
-              <PowerSelect
-                id={{id}}
-                {{! For some reason need to manually set width }}
-                class="au-u-1-1"
-                @searchEnabled={{false}}
-                @options={{this.resources}}
-                @selected={{this.selectedResourceNode}}
-                @onChange={{this.setResourceNodeLink}}
-                @onKeydown={{this.onPowerSelectKeydown false}}
-                @allowClear={{true}}
-                @placeholder="Select a resource"
-                as |obj|
-              >
-                {{this.resourceNodeLabel obj}}
-              </PowerSelect>
-              {{#if error}}
-                <AuPill>{{error}}</AuPill>
-              {{/if}}
+          <WithUniqueId as |id|>
+            {{#let "object.value" as |name|}}
+              {{#let (this.findError name) as |error|}}
+                <AuLabel
+                  for={{id}}
+                  @required={{true}}
+                  @requiredLabel="Required"
+                >
+                  Object
+                </AuLabel>
+                <PowerSelect
+                  id={{id}}
+                  {{! For some reason need to manually set width }}
+                  class="au-u-1-1"
+                  @searchEnabled={{false}}
+                  @options={{this.resources}}
+                  @selected={{this.selectedResourceNode}}
+                  @onChange={{this.setResourceNodeLink}}
+                  @onKeydown={{this.onPowerSelectKeydown false}}
+                  @allowClear={{true}}
+                  @placeholder="Select a resource"
+                  as |obj|
+                >
+                  {{this.resourceNodeLabel obj}}
+                </PowerSelect>
+                {{#if error}}
+                  <AuPill>{{error}}</AuPill>
+                {{/if}}
+              {{/let}}
             {{/let}}
-          {{/let}}
+          </WithUniqueId>
         </AuFormRow>
       {{else if (eq this.termType "ContentLiteral")}}
         <AuFormRow>
-          {{#let (uniqueId) "object.datatype.value" as |id name|}}
-            {{#let (this.findError name) as |error|}}
-              <AuLabel
-                for={{id}}
-                @required={{false}}
-                @requiredLabel="Required"
-              >Datatype</AuLabel>
-              <AuInput
-                id={{id}}
-                name={{name}}
-                value={{this.initialDatatypeValue}}
-                required={{false}}
-                @width="block"
-                @disabled={{this.hasLanguage}}
-              />
-              {{#if error}}
-                <AuPill>{{error}}</AuPill>
-              {{/if}}
+          <WithUniqueId as |id|>
+            {{#let "object.datatype.value" as |name|}}
+              {{#let (this.findError name) as |error|}}
+                <AuLabel
+                  for={{id}}
+                  @required={{false}}
+                  @requiredLabel="Required"
+                >Datatype</AuLabel>
+                <AuInput
+                  id={{id}}
+                  name={{name}}
+                  value={{this.initialDatatypeValue}}
+                  required={{false}}
+                  @width="block"
+                  @disabled={{this.hasLanguage}}
+                />
+                {{#if error}}
+                  <AuPill>{{error}}</AuPill>
+                {{/if}}
+              {{/let}}
             {{/let}}
-          {{/let}}
+          </WithUniqueId>
+
         </AuFormRow>
         <AuFormRow>
-          {{#let (uniqueId) "object.language" as |id name|}}
+          <WithUniqueId as |id|>
+          {{#let "object.language" as |name|}}
             {{#let (this.findError name) as |error|}}
               <AuLabel
                 for={{id}}
@@ -794,6 +824,7 @@ export default class PropertyEditorForm extends Component<Sig> {
               {{/if}}
             {{/let}}
           {{/let}}
+          </WithUniqueId>
         </AuFormRow>
       {{/if}}
 


### PR DESCRIPTION
### Overview
Explicitly importing the `uniqueId` helper is not supported in ember 4.x. This PR replaces it's usage by the `WithUniqueId` component workaround.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
