### PR TITLE
Update `@embroider/addon-dev` to 7.1.4

### DIFF
--- a/.changeset/major-shrimps-yell.md
+++ b/.changeset/major-shrimps-yell.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Update `@embroider/addon-dev` to version [7.1.4](https://github.com/embroider-build/embroider/releases/tag/v7.1.4-%40embroider%2Faddon-dev)

--- a/packages/ember-rdfa-editor/package.json
+++ b/packages/ember-rdfa-editor/package.json
@@ -273,7 +273,7 @@
     "@babel/eslint-parser": "^7.25.1",
     "@babel/plugin-transform-typescript": "^7.25.2",
     "@babel/runtime": "^7.26.10",
-    "@embroider/addon-dev": "^7.1.2",
+    "@embroider/addon-dev": "^7.1.4",
     "@eslint/js": "^9.17.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,8 +243,8 @@ importers:
         specifier: ^7.26.10
         version: 7.26.10
       '@embroider/addon-dev':
-        specifier: ^7.1.2
-        version: 7.1.2(patch_hash=53e2d1aced0efe02a771b310e047e987d526d2e698413f3ed74efa9d963bc9a8)(@glint/template@1.5.2)(rollup@4.34.8)
+        specifier: ^7.1.4
+        version: 7.1.4(@glint/template@1.5.2)(rollup@4.34.8)
       '@eslint/js':
         specifier: ^9.17.0
         version: 9.21.0
@@ -1737,8 +1737,8 @@ packages:
   '@ember/test-waiters@4.0.0':
     resolution: {integrity: sha512-anqtvTCQvQh8VlHcKPJC0Fxz3aMmc7L+mZLOqvoH7+k86TUikZ/CxhytgMvgLk0x53fqOPEL1uykl2C9Ez65OA==}
 
-  '@embroider/addon-dev@7.1.2':
-    resolution: {integrity: sha512-hR1NTjoQ3BR3OGH0Ldl8I6N9YX59e4dFmFapUTi3ZNrKSp0WMIeFTThyGKDmMOzjLZZRAi1VUWAF5qUQ+xbkDA==}
+  '@embroider/addon-dev@7.1.4':
+    resolution: {integrity: sha512-HoyU9CyY8bTi44nshqx8L2w6A1cQ2l+3W4gIFszWJt2wGn1iVSLs9dfozSCrC51FKWJk+tAMs5Y1Epfx4u/o/Q==}
     engines: {node: 12.* || 14.* || >= 16}
     hasBin: true
     peerDependencies:
@@ -1767,12 +1767,12 @@ packages:
     peerDependencies:
       '@embroider/core': ^3.5.4
 
-  '@embroider/core@3.5.2':
-    resolution: {integrity: sha512-VRHhVgswkTul7a05+QeMgrYjC7ybzPQkNGkad2abdy8a+rJg8/j/QEdmnPf4gG7a12gr88gMT0nAL60O3JbLCQ==}
-    engines: {node: 12.* || 14.* || >= 16}
-
   '@embroider/core@3.5.4':
     resolution: {integrity: sha512-tUSR6sjK4xdO+EqBbuYz1NNlKIhxFZ7U1ixoBFZF+CEB/vL7Hq7zFMXq4JtaBncbrKIObOuQJJf6QhfT8B2gvg==}
+    engines: {node: 12.* || 14.* || >= 16}
+
+  '@embroider/core@3.5.6':
+    resolution: {integrity: sha512-yCTed4fjX4ZK3baFN4qay8zvER6MB75peCHN0WxfxX4esK/Lgjh8aANLYPsZ/7kmSlKcq4qYnBmBD7peIMh6dA==}
     engines: {node: 12.* || 14.* || >= 16}
 
   '@embroider/hbs-loader@3.0.3':
@@ -1784,6 +1784,15 @@ packages:
 
   '@embroider/macros@1.16.11':
     resolution: {integrity: sha512-TUm/74oBr+tWto0IPAht1g6zjpP7UK0aQdnFHHqGvDPc+tAROQb9jKI/ePEuKAdBCV3L7XvvC4Rlf0DNvT4qmw==}
+    engines: {node: 12.* || 14.* || >= 16}
+    peerDependencies:
+      '@glint/template': ^1.0.0
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
+
+  '@embroider/macros@1.16.13':
+    resolution: {integrity: sha512-2oGZh0m1byBYQFWEa8b2cvHJB2LzaF3DdMCLCqcRAccABMROt1G3sultnNCT30NhfdGWMEsJOT3Jm4nFxXmTRw==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
       '@glint/template': ^1.0.0
@@ -10645,9 +10654,9 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@embroider/addon-dev@7.1.2(patch_hash=53e2d1aced0efe02a771b310e047e987d526d2e698413f3ed74efa9d963bc9a8)(@glint/template@1.5.2)(rollup@4.34.8)':
+  '@embroider/addon-dev@7.1.4(@glint/template@1.5.2)(rollup@4.34.8)':
     dependencies:
-      '@embroider/core': 3.5.2(@glint/template@1.5.2)
+      '@embroider/core': 3.5.6(@glint/template@1.5.2)
       '@rollup/pluginutils': 4.2.1
       content-tag: 3.1.1
       execa: 5.1.1
@@ -10746,40 +10755,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/core@3.5.2(@glint/template@1.5.2)':
-    dependencies:
-      '@babel/core': 7.26.9(supports-color@8.1.1)
-      '@babel/parser': 7.26.9
-      '@babel/traverse': 7.26.9(supports-color@8.1.1)
-      '@embroider/macros': 1.16.11(@glint/template@1.5.2)
-      '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
-      assert-never: 1.4.0
-      babel-plugin-ember-template-compilation: 2.3.0
-      broccoli-node-api: 1.7.0
-      broccoli-persistent-filter: 3.1.3
-      broccoli-plugin: 4.0.7
-      broccoli-source: 3.0.1
-      debug: 4.4.0(supports-color@8.1.1)
-      fast-sourcemap-concat: 2.1.1
-      filesize: 10.1.6
-      fs-extra: 9.1.0
-      fs-tree-diff: 2.0.1
-      handlebars: 4.7.8
-      js-string-escape: 1.0.1
-      jsdom: 25.0.1(supports-color@8.1.1)
-      lodash: 4.17.21
-      resolve: 1.22.10
-      resolve-package-path: 4.0.3
-      semver: 7.7.1
-      typescript-memoize: 1.1.1
-      walk-sync: 3.0.0
-    transitivePeerDependencies:
-      - '@glint/template'
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
-
   '@embroider/core@3.5.4(@glint/template@1.5.2)':
     dependencies:
       '@babel/core': 7.26.9(supports-color@8.1.1)
@@ -10814,12 +10789,61 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@embroider/core@3.5.6(@glint/template@1.5.2)':
+    dependencies:
+      '@babel/core': 7.26.9(supports-color@8.1.1)
+      '@babel/parser': 7.26.9
+      '@babel/traverse': 7.26.9(supports-color@8.1.1)
+      '@embroider/macros': 1.16.13(@glint/template@1.5.2)
+      '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
+      assert-never: 1.4.0
+      babel-plugin-ember-template-compilation: 2.3.0
+      broccoli-node-api: 1.7.0
+      broccoli-persistent-filter: 3.1.3
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      debug: 4.4.0(supports-color@8.1.1)
+      fast-sourcemap-concat: 2.1.1
+      filesize: 10.1.6
+      fs-extra: 9.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.8
+      js-string-escape: 1.0.1
+      jsdom: 25.0.1(supports-color@8.1.1)
+      lodash: 4.17.21
+      resolve: 1.22.10
+      resolve-package-path: 4.0.3
+      semver: 7.7.1
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+
   '@embroider/hbs-loader@3.0.3(@embroider/core@3.5.4(@glint/template@1.5.2))(webpack@5.98.0)':
     dependencies:
       '@embroider/core': 3.5.4(@glint/template@1.5.2)
       webpack: 5.98.0
 
   '@embroider/macros@1.16.11(@glint/template@1.5.2)':
+    dependencies:
+      '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
+      assert-never: 1.4.0
+      babel-import-util: 2.1.1
+      ember-cli-babel: 7.26.11
+      find-up: 5.0.0
+      lodash: 4.17.21
+      resolve: 1.22.10
+      semver: 7.7.1
+    optionalDependencies:
+      '@glint/template': 1.5.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@embroider/macros@1.16.13(@glint/template@1.5.2)':
     dependencies:
       '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
       assert-never: 1.4.0


### PR DESCRIPTION
### Overview
Update `@embroider/addon-dev` to version [7.1.4](https://github.com/embroider-build/embroider/releases/tag/v7.1.4-%40embroider%2Faddon-dev)

This package bump should (hopefully) solve the issues with the crashing watch/dev builds when an error is found in the source files (another change to the `declarations` plugin was made).

### How to test/reproduce
- Run the `start` script in the package folder
- Make an error in any source file, e.g. a syntax error, type error
- None of these errors should cause the dev build to crash

### Challenges/uncertainties
I did not yet include an update to version 8, as that one causes an issue with the sass build.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
