### PR TITLE
Add ability to change subject in attribute editor

### DIFF
--- a/.changeset/tender-teams-win.md
+++ b/.changeset/tender-teams-win.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add ability to change subject uris of resource nodes

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
     },
     "allowNonAppliedPatches": true,
     "onlyBuiltDependencies": [
-      "core-js",
       "@parcel/watcher",
-      "ember-source"
+      "core-js",
+      "ember-source",
+      "esbuild"
     ]
   },
   "packageManager": "pnpm@10.5.2",

--- a/packages/ember-rdfa-editor/package.json
+++ b/packages/ember-rdfa-editor/package.json
@@ -277,6 +277,7 @@
     "@eslint/js": "^9.17.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@glint/core": "^1.5.2",
     "@glint/environment-ember-loose": "^1.5.2",
     "@glint/environment-ember-template-imports": "1.5.2",
     "@glint/template": "^1.5.2",

--- a/packages/ember-rdfa-editor/src/core/schema.ts
+++ b/packages/ember-rdfa-editor/src/core/schema.ts
@@ -69,7 +69,7 @@ const rdfaAwareAttrSpec = {
   externalTriples: { default: [] },
   __rdfaId: { default: undefined },
   rdfaNodeType: { default: undefined },
-  subject: { default: null },
+  subject: { default: null, editable: true },
   content: { default: null, editable: true },
   datatype: { default: null },
   language: { default: null, editable: true },

--- a/packages/ember-rdfa-editor/src/core/schema.ts
+++ b/packages/ember-rdfa-editor/src/core/schema.ts
@@ -26,6 +26,7 @@ import {
 import { IllegalArgumentError } from '../utils/_private/errors.ts';
 import type { NamedNode } from '@rdfjs/types';
 import { rdfaNodeTypes, type RdfaAttrs } from '#root/core/rdfa-types.ts';
+import { updateSubject } from '#root/plugins/rdfa-info/utils.ts';
 
 // const logger = createLogger('core/schema');
 
@@ -69,7 +70,18 @@ const rdfaAwareAttrSpec = {
   externalTriples: { default: [] },
   __rdfaId: { default: undefined },
   rdfaNodeType: { default: undefined },
-  subject: { default: null, editable: true },
+  subject: {
+    default: null,
+    editable: true,
+    editHandler: (pos: number, value: string) =>
+      updateSubject({
+        pos,
+        targetSubject: value,
+        keepBacklinks: true,
+        keepExternalTriples: true,
+        keepProperties: true,
+      }),
+  },
   content: { default: null, editable: true },
   datatype: { default: null },
   language: { default: null, editable: true },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2
+      '@glint/core':
+        specifier: ^1.5.2
+        version: 1.5.2(typescript@5.7.3)
       '@glint/environment-ember-loose':
         specifier: ^1.5.2
         version: 1.5.2(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)))
@@ -6501,7 +6504,6 @@ packages:
     resolution: {integrity: sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
-    bundledDependencies: []
 
   jsonfile@2.4.0:
     resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->
Uses the updateSubject monad to allow editing the subject attribute of a node while maintaining all the links.

Also extends the attrspec to allow each attribute to define an updateHandler next to the `editable` property.
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

Make a resource node
give it a few relationships
change the subject using the attribute editor
observe all backlinks have been updated and links are intact after reloading

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness

- [x] changelog
- [x] npm lint
- [x] no new deprecations
