### PR TITLE
feat: add yup-based validation to backlink-editor form

### DIFF
--- a/.changeset/thirty-lemons-show.md
+++ b/.changeset/thirty-lemons-show.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add yup-based validation to backlink-editor form

--- a/packages/ember-rdfa-editor/package.json
+++ b/packages/ember-rdfa-editor/package.json
@@ -240,6 +240,8 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-focus-trap": "^1.1.0",
+    "ember-headless-form": "^1.1.1",
+    "ember-headless-form-yup": "^1.0.0",
     "ember-modifier": "^4.2.0",
     "ember-template-imports": "^4.1.1",
     "ember-truth-helpers": "^4.0.3",

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/form.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/form.gts
@@ -148,7 +148,10 @@ export default class BacklinkForm extends Component<BacklinkFormSig> {
             @searchEnabled={{true}}
             @options={{this.subjectOptions}}
             @selected={{this.formData.subject}}
-            @onChange={{this.updateField field.triggerValidation field.setValue}}
+            @onChange={{this.updateField
+              field.triggerValidation
+              field.setValue
+            }}
             @onKeydown={{this.onPowerSelectKeydown}}
             @allowClear={{true}}
             as |obj|
@@ -183,7 +186,10 @@ export default class BacklinkForm extends Component<BacklinkFormSig> {
             @searchEnabled={{true}}
             @options={{@predicateOptions}}
             @selected={{field.value}}
-            @onChange={{this.updateField field.triggerValidation field.setValue}}
+            @onChange={{this.updateField
+              field.triggerValidation
+              field.setValue
+            }}
             @onKeydown={{this.onPowerSelectKeydown}}
             @allowClear={{true}}
             as |obj|

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,12 @@ importers:
       ember-focus-trap:
         specifier: ^1.1.0
         version: 1.1.1(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))
+      ember-headless-form:
+        specifier: ^1.1.1
+        version: 1.1.1(@babel/core@7.26.9)(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))))(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))(eslint@9.21.0)
+      ember-headless-form-yup:
+        specifier: ^1.0.0
+        version: 1.0.0(ember-headless-form@1.1.1(@babel/core@7.26.9)(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))))(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))(eslint@9.21.0))(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))(yup@1.6.1)
       ember-modifier:
         specifier: ^4.2.0
         version: 4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))
@@ -1736,6 +1742,10 @@ packages:
     resolution: {integrity: sha512-wQtibrTbsTyqkF14m1pFwaLECzda7ObY9HpCPpRghYkgBcnwlD2dBpvfYtamMK1HCh59vEZ3OdrxEBU9jKLyng==}
     peerDependencies:
       ember-source: '>= 4.0.0'
+
+  '@ember/test-waiters@3.1.0':
+    resolution: {integrity: sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==}
+    engines: {node: 10.* || 12.* || >= 14.*}
 
   '@ember/test-waiters@4.0.0':
     resolution: {integrity: sha512-anqtvTCQvQh8VlHcKPJC0Fxz3aMmc7L+mZLOqvoH7+k86TUikZ/CxhytgMvgLk0x53fqOPEL1uykl2C9Ez65OA==}
@@ -3440,6 +3450,13 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  babel-eslint@10.1.0:
+    resolution: {integrity: sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==}
+    engines: {node: '>=6'}
+    deprecated: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
+    peerDependencies:
+      eslint: '>= 4.12.1'
+
   babel-import-util@0.2.0:
     resolution: {integrity: sha512-CtWYYHU/MgK88rxMrLfkD356dApswtR/kWZ/c6JifG1m10e7tBBrs/366dFzWMAoqYmG5/JSh+94tUSpIwh+ag==}
     engines: {node: '>= 12.*'}
@@ -4645,6 +4662,11 @@ packages:
     peerDependencies:
       ember-source: ^3.28.0 || ^4.0.0 || >=5.0.0
 
+  ember-async-data@1.0.3:
+    resolution: {integrity: sha512-54OtoQwNi+/ZvPOVuT4t8fcHR9xL8N7kBydzcZSo6BIEsLYeXPi3+jUR8niWjfjXXhKlJ8EWXR0lTeHleTrxbw==}
+    peerDependencies:
+      ember-source: '>=4.8.4'
+
   ember-auto-import@2.10.0:
     resolution: {integrity: sha512-bcBFDYVTFHyqyq8BNvsj6UO3pE6Uqou/cNmee0WaqBgZ+1nQqFz0UE26usrtnFAT+YaFZSkqF2H36QW84k0/cg==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -4869,6 +4891,20 @@ packages:
     engines: {node: '>= 14.0.0'}
     peerDependencies:
       ember-source: ^3.25.0 || >=4.0.0
+
+  ember-headless-form-yup@1.0.0:
+    resolution: {integrity: sha512-sdbybZJMl31DYXLDp+n2TjYrCb7+UM+lYOKOMPKzICpF06+/ajZeH7Uupw7dKvo/H/L3K7I35TvA0Ye8CpUs+Q==}
+    peerDependencies:
+      ember-headless-form: ^1.0.0
+      ember-source: '>=4.4.0'
+      yup: ^1.0.0
+
+  ember-headless-form@1.1.1:
+    resolution: {integrity: sha512-TsvamNGwVd7ewh//k4tKtZycAI0Ax1gUo1b6SMpyPGylBmcWX1aTl+zRcBX32meYzjp//KzPbxI5/Ac41mKX5A==}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2
+      '@glimmer/tracking': ^1.1.2
+      ember-source: '>=4.4.0'
 
   ember-intl@7.1.4:
     resolution: {integrity: sha512-ZCY/z0j6eC5I1zKpM4is7TjNv/AAJO0vn72sA1NbnTY1+/902sysAhSO3BQDBm2pAux/HDhxf0lck8hxKl5+nA==}
@@ -5238,6 +5274,10 @@ packages:
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
+
+  eslint-visitor-keys@1.3.0:
+    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
+    engines: {node: '>=4'}
 
   eslint-visitor-keys@2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
@@ -10648,6 +10688,15 @@ snapshots:
       - '@glint/template'
       - supports-color
 
+  '@ember/test-waiters@3.1.0':
+    dependencies:
+      calculate-cache-key-for-tree: 2.0.0
+      ember-cli-babel: 7.26.11
+      ember-cli-version-checker: 5.1.2
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@ember/test-waiters@4.0.0(@glint/template@1.5.2)':
     dependencies:
       '@embroider/addon-shim': 1.9.0
@@ -12707,6 +12756,18 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  babel-eslint@10.1.0(eslint@9.21.0):
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.9
+      '@babel/traverse': 7.26.9(supports-color@8.1.1)
+      '@babel/types': 7.26.9
+      eslint: 9.21.0
+      eslint-visitor-keys: 1.3.0
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
+
   babel-import-util@0.2.0: {}
 
   babel-import-util@2.1.1: {}
@@ -14133,6 +14194,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ember-async-data@1.0.3(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)):
+    dependencies:
+      '@ember/test-waiters': 3.1.0
+      '@embroider/addon-shim': 1.9.0
+      ember-source: 6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)
+    transitivePeerDependencies:
+      - supports-color
+
   ember-auto-import@2.10.0(@glint/template@1.5.2)(webpack@5.98.0):
     dependencies:
       '@babel/core': 7.26.9(supports-color@8.1.1)
@@ -14771,6 +14840,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ember-headless-form-yup@1.0.0(ember-headless-form@1.1.1(@babel/core@7.26.9)(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))))(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))(eslint@9.21.0))(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))(yup@1.6.1):
+    dependencies:
+      '@embroider/addon-shim': 1.9.0
+      ember-functions-as-helper-polyfill: 2.1.2(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))
+      ember-headless-form: 1.1.1(@babel/core@7.26.9)(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))))(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))(eslint@9.21.0)
+      ember-source: 6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)
+      yup: 1.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  ember-headless-form@1.1.1(@babel/core@7.26.9)(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))))(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))(eslint@9.21.0):
+    dependencies:
+      '@babel/runtime': 7.26.10
+      '@embroider/addon-shim': 1.9.0
+      '@embroider/util': 1.13.2(@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))))(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))
+      '@glimmer/component': 1.1.2(@babel/core@7.26.9)
+      '@glimmer/tracking': 1.1.2
+      babel-eslint: 10.1.0(eslint@9.21.0)
+      ember-async-data: 1.0.3(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))
+      ember-modifier: 4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))
+      ember-source: 6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)
+      tracked-built-ins: 3.4.0(@babel/core@7.26.9)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/environment-ember-loose'
+      - '@glint/template'
+      - eslint
+      - supports-color
+
   ember-intl@7.1.4(@ember/test-helpers@4.0.5(@babel/core@7.26.9)(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)))(@glint/template@1.5.2)(typescript@5.7.3)(webpack@5.98.0):
     dependencies:
       '@babel/core': 7.26.9(supports-color@8.1.1)
@@ -15390,6 +15488,8 @@ snapshots:
     dependencies:
       eslint: 9.21.0
       eslint-visitor-keys: 2.1.0
+
+  eslint-visitor-keys@1.3.0: {}
 
   eslint-visitor-keys@2.1.0: {}
 


### PR DESCRIPTION
### Overview
This PR adds validation using `yup` and `ember-headless-form` to the backlink-editor form component.

### How to test/reproduce
- Start the test-app
- Open the backlink editor
- Ensure that errors/warnings are shown when you try to submit the form without all fields filled in, or with the fields containing invalid URI's

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
