### PR TITLE
fix(tooling): run build script before start scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "pnpm --filter '*' lint",
     "lint:fix": "pnpm --filter '*' lint:fix",
     "prepack": "pnpm build",
-    "start": "concurrently 'pnpm:start:* {@}' --passthrough-arguments --restart-after 5000 --prefixColors auto",
+    "start": "pnpm build; concurrently 'pnpm:start:* {@}' --passthrough-arguments --restart-after 5000 --prefixColors auto",
     "start:addon": "pnpm --filter @lblod/ember-rdfa-editor start --no-watch.clearScreen",
     "start:test-app": "pnpm --filter test-app start",
     "test": "pnpm --filter '*' test",


### PR DESCRIPTION
### Overview
This PR ensures that the `build` script is run before running the `start` scripts of the package and test-app.
This ensures that running the test-app does not result in build errors.

This does mean a slower startup time of course...

### How to test/reproduce
- Run the start script at the root of the repo
- Ensure that the package and test-app build before running the start scripts
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

