### PR TITLE
tooling: add simple dev-release script

### DIFF
--- a/.woodpecker/.dev-release.yml
+++ b/.woodpecker/.dev-release.yml
@@ -3,7 +3,7 @@ steps:
     image: node:22-slim
     directory: packages/ember-rdfa-editor
     commands:
-      - npm version --no-git-tag-version $(npm pkg get version | sed 's/"//g')-dev.${CI_COMMIT_SHA}
+      - npm version --no-git-tag-version ${CI_COMMIT_TAG##@lblod/ember-rdfa-editor@}
   publish:
     image: node:22-slim
     commands:
@@ -14,9 +14,10 @@ steps:
       - pnpm config --location project set '//registry.npmjs.org/:_authToken' $NPM_ACCESS_TOKEN
       - pnpm i --frozen-lockfile
       - pnpm build
-      - pnpm publish packages/ember-rdfa-editor --access public --tag next --no-git-checks
+      - pnpm publish packages/ember-rdfa-editor --access public --tag dev --no-git-checks
     environment:
       NPM_ACCESS_TOKEN:
         from_secret: npm_access_token
 when:
-  - event: manual
+  event: tag
+  ref: refs/tags/@lblod/ember-rdfa-editor@*-dev.*

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -52,4 +52,6 @@ steps:
         from_secret: docker_password
 when:
   event: tag
-  ref: refs/tags/@lblod/ember-rdfa-editor@*
+  ref:
+    include: refs/tags/@lblod/ember-rdfa-editor@*
+    exclude: refs/tags/@lblod/ember-rdfa-editor@*-dev.*

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prettier": "prettier --write .",
     "say": "pnpm --filter @lblod/ember-rdfa-editor",
     "tapp": "pnpm --filter test-app",
-    "release": "tsx scripts/release/run.mts"
+    "release": "tsx scripts/release/run.mts",
+    "dev-release": "tsx scripts/dev-release/run.mts"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/scripts/dev-release/run.mts
+++ b/scripts/dev-release/run.mts
@@ -1,0 +1,37 @@
+import { execa } from 'execa';
+import { getRemote } from '../release/utils.mts';
+
+const PACKAGE_NAME = '@lblod/ember-rdfa-editor';
+const PACKAGE_PATH = 'packages/ember-rdfa-editor';
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+if (!GITHUB_TOKEN) {
+  console.error('\nPlease provided the GITHUB_TOKEN environment variable');
+  process.exit(1);
+}
+
+const mostRecentCommit = await execa`git rev-parse HEAD`;
+
+const currentVersion = await execa({ cwd: PACKAGE_PATH })`npm pkg get version`;
+
+const tagToCreate = `${PACKAGE_NAME}@${currentVersion.stdout.replaceAll('"', '')}-dev.${mostRecentCommit.stdout}`;
+
+const remote = await getRemote() ?? 'origin';
+
+const doesTagExistOnRemote = await execa`git ls-remote ${remote} refs/tags/${tagToCreate}`;
+
+const tagExistsOnRemote = Boolean(doesTagExistOnRemote.stdout);
+if(tagExistsOnRemote){
+  console.log(`A dev release has already been created for the latest commit with tag ${tagToCreate}`)
+  process.exit(0);
+}
+
+const doesTagExistLocally = await execa`git tag -l ${tagToCreate}`
+
+const tagExistsLocally = Boolean(doesTagExistLocally.stdout);
+if(!tagExistsLocally){
+  await execa`git tag -a ${tagToCreate} -m "dev-release"`
+}
+await execa`git push ${remote} tag ${tagToCreate}`;
+console.log(`Succesfully created and pushed a dev-release tag: ${tagToCreate}`)

--- a/scripts/release/utils.mts
+++ b/scripts/release/utils.mts
@@ -179,7 +179,7 @@ async function getRemoteForBranch(branch: string) {
   return response?.stdout;
 }
 
-async function getRemote() {
+export async function getRemote() {
   const branch = await getCurrentBranch();
   return branch ? getRemoteForBranch(branch) : null;
 }


### PR DESCRIPTION
### Overview
This PR adds a simple `dev-release` script which does the following:
- Determine the most recent commit SHA
- Construct a tag based on the commit SHA, current version and package name
- If the tag already exists on the remote, simply print it out
- Otherwise: create the tag and push it to the remote
- A woodpecker pipeline picks up the tag and creates an npm dev release based on it

### How to test/reproduce
You can check-out https://github.com/elpoelma/changesets-playground to play around with the script
