### PR TITLE
Add workaround to get ember-inspector working on vite builds

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,6 +665,9 @@ importers:
       globals:
         specifier: ^15.14.0
         version: 15.15.0
+      loader.js:
+        specifier: ^4.7.0
+        version: 4.7.0
       prettier:
         specifier: ^3.4.2
         version: 3.5.2
@@ -7243,7 +7246,6 @@ packages:
     resolution: {integrity: sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
-    bundledDependencies: []
 
   jsonfile@2.4.0:
     resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}
@@ -7321,6 +7323,9 @@ packages:
   loader-utils@2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
+
+  loader.js@4.7.0:
+    resolution: {integrity: sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==}
 
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
@@ -19491,6 +19496,8 @@ snapshots:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.3
+
+  loader.js@4.7.0: {}
 
   locate-path@2.0.0:
     dependencies:

--- a/test-app/app/app.ts
+++ b/test-app/app/app.ts
@@ -2,7 +2,7 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
-
+import './inspector-support';
 import compatModules from '@embroider/virtual/compat-modules';
 import './styles/app.scss';
 

--- a/test-app/app/inspector-support.ts
+++ b/test-app/app/inspector-support.ts
@@ -1,0 +1,28 @@
+/**
+ * Workaround to get the ember-inspector working with vite applications.
+ * Once ember-inspector gets native vite support, we can remove this.
+ */
+
+import Ember from 'ember';
+import * as runtime from '@glimmer/runtime';
+import * as tracking from '@glimmer/tracking';
+import * as validator from '@glimmer/validator';
+// @ts-expect-error this dep is not installed directly
+import * as reference from '@glimmer/reference';
+// @ts-expect-error this dep is not installed directly
+import * as destroyable from '@glimmer/destroyable';
+import { RSVP } from '@ember/-internals/runtime';
+import config from './config/environment';
+
+window.define('@glimmer/tracking', () => tracking);
+window.define('@glimmer/runtime', () => runtime);
+window.define('@glimmer/validator', () => validator);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+window.define('@glimmer/reference', () => reference);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+window.define('@glimmer/destroyable', () => destroyable);
+window.define('rsvp', () => RSVP);
+window.define('ember', () => ({ default: Ember }));
+window.define('test-app/config/environment', () => ({
+  default: config,
+}));

--- a/test-app/index.html
+++ b/test-app/index.html
@@ -18,6 +18,8 @@
     {{content-for "body"}}
 
     <script src="/@embroider/virtual/vendor.js"></script>
+    <!-- Needed for ember-inspector workaround. May be removed once it gets native vite support. -->
+    <script src="/node_modules/loader.js"></script>
     <script type="module">
       import Application from './app/app';
       import environment from './app/config/environment';

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -123,6 +123,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-qunit": "^8.1.2",
     "globals": "^15.14.0",
+    "loader.js": "^4.7.0",
     "prettier": "^3.4.2",
     "prettier-plugin-ember-template-tag": "^2.0.4",
     "prosemirror-dev-tools": "^4.2.0",


### PR DESCRIPTION
### Overview
This PR adds a workaround to get the ember-inspector working on vite builds.
It installs (and includes) `loader.js`, an AMD loader and then loads the necessary modules which the ember-inspector needs.
Once https://github.com/emberjs/ember-inspector/pull/2625 is merged and released, we can remove this workaround.

I realize that this is not an ideal solution (as it adds an AMD loader back), but this currently seems to be the only option to get the ember-inspector working with vite builds.
