### PR TITLE
Example: integrate LOV api

### DIFF
--- a/packages/ember-rdfa-editor/src/components/_private/link-rdfa-node-poc/modal.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/link-rdfa-node-poc/modal.gts
@@ -22,10 +22,10 @@ import { HeadlessForm } from 'ember-headless-form';
 import { fn } from '@ember/helper';
 import * as yup from 'yup';
 import { validateYup } from 'ember-headless-form-yup';
-import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
-import { get } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import { unwrap } from '#root/utils/_private/option.ts';
+import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert.js';
+import { get } from '@ember/helper';
 
 type TermOptionGeneratorResult<TermType extends SayTerm> =
   | TermOption<TermType>[]

--- a/test-app/app/templates/editable-node.hbs
+++ b/test-app/app/templates/editable-node.hbs
@@ -32,7 +32,7 @@
               <this.LinkRdfaNodeButton
                 @controller={{this.rdfaEditor}}
                 @node={{this.activeNode}}
-                @predicateOptionGenerator={{this.predicateOptionGenerator}}
+                @predicateOptionGenerator={{this.predicateOptionsTask.perform}}
                 @subjectOptionGenerator={{this.subjectOptionGenerator}}
               />
             </Item>

--- a/test-app/app/utils/types.ts
+++ b/test-app/app/utils/types.ts
@@ -1,0 +1,5 @@
+// from https://stackoverflow.com/a/52731696
+type UnpackedPromise<T> = T extends Promise<infer U> ? U : T;
+export type Promisify<F> = F extends (...args: infer Args) => infer Result
+  ? (...args: Args) => Promise<UnpackedPromise<Result>>
+  : never;


### PR DESCRIPTION
### Overview
This PR contains an example on how to integrate the LOV (https://lov.linkeddata.es/dataset/lov) API into the node-linker-poc component.
It is quite fast and I can already see the advantages of integrating it.

Using the LOV api we can also query for labels and descriptions of different terms, so that might also be interesting.

### How to test/reproduce
- Start the test-app
- Open the editable-node page and click on the 'Add relationship' button
- Notice that when typing in the 'relationship-type' field, it now autocompletes
