### PR TITLE
Add width rules to dynamic editor toolbar dropdowns

### DIFF
--- a/.changeset/all-streets-pick.md
+++ b/.changeset/all-streets-pick.md
@@ -1,0 +1,6 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Toolbar main and side dropdowns: add `width: max-content` and `max-width: 100%` rules.
+Essentially this means that these dropdowns take the space they need to show the content, but with a limit of 100% of the editor width.

--- a/packages/ember-rdfa-editor/scss/_c-toolbar.scss
+++ b/packages/ember-rdfa-editor/scss/_c-toolbar.scss
@@ -54,6 +54,8 @@ $say-toolbar-height: 44px !default;
   padding: 0.1rem au-settings.$au-unit-tiny 0; // Visually center the text in the pill
   background-color: $say-toolbar-background;
   z-index: 1;
+  width: max-content;
+  max-width: 100%; // should we use 100vh here?
 }
 
 .say-toolbar__main-dropdown {


### PR DESCRIPTION
### Overview
This PR adds `width`rules to the dynamic editor toolbar dropdowns.
Specifically it adds:
- `width: max-content`
- `max-width: 100%` (relative to the editor container)

### How to test/reproduce
- Start the test-app
- Resize the page
- The dropdowns should never exceed the editor width (but can clip out of it!).
- If the editor is wide enough, all main dropdown items are positioned on a single row

### Challenges/uncertainties
- This prevents issues with floating UI determining the position/size of the dropdowns in embeddable
- We could also limit the width of the dropdowns to `100vh` instead of 100% of the editor

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
