### PR TITLE
rdfa-tools: disable add-property button when doc-node is selected

### DIFF
--- a/.changeset/eight-memes-occur.md
+++ b/.changeset/eight-memes-occur.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+rdfa-tools: disable `Add property` button when doc node is selected, as this functionality is now covered by the imported-resource editor


### PR DESCRIPTION
### Overview
This PR adjusts the rdfa `property-editor` to ensure the 'Add property' button is disabled when the doc node is selected. Imported resources can be added through the new imported-resources editor.

### How to test/reproduce
- Start the test-app
- Ensure that the 'Add property' button is now disabled when the doc node is selected

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
