### PR TITLE
Standardize/reduce size of rdfa-tool cards

### DIFF
--- a/.changeset/afraid-bushes-stand.md
+++ b/.changeset/afraid-bushes-stand.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+rdfa-tools: reduce size and standardize rdfa-tool cards

--- a/packages/ember-rdfa-editor/src/components/_private/attribute-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/attribute-editor/index.gts
@@ -9,13 +9,10 @@ import { and } from 'ember-truth-helpers';
 import type { Attrs } from 'prosemirror-model';
 import { CheckIcon } from '@appuniversum/ember-appuniversum/components/icons/check';
 import { PencilIcon } from '@appuniversum/ember-appuniversum/components/icons/pencil';
-import { ChevronDownIcon } from '@appuniversum/ember-appuniversum/components/icons/chevron-down';
-import { ChevronUpIcon } from '@appuniversum/ember-appuniversum/components/icons/chevron-up';
 import AuButtonGroup from '@appuniversum/ember-appuniversum/components/au-button-group';
 import AuToolbar from '@appuniversum/ember-appuniversum/components/au-toolbar';
 import AuList from '@appuniversum/ember-appuniversum/components/au-list';
 import AuLabel from '@appuniversum/ember-appuniversum/components/au-label';
-import AuPanel from '@appuniversum/ember-appuniversum/components/au-panel';
 import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
 import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 import AuTextarea from '@appuniversum/ember-appuniversum/components/au-textarea';
@@ -28,6 +25,7 @@ import {
   type TransactionMonad,
 } from '#root/utils/transaction-utils.ts';
 import WithUniqueId from '../with-unique-id.ts';
+import AuCard from '@appuniversum/ember-appuniversum/components/au-card.js';
 
 type Signature = {
   Args: {
@@ -132,18 +130,25 @@ export default class AttributeEditor extends Component<Signature> {
 
   <template>
     <WithUniqueId as |formId|>
-      <AuPanel class="au-u-margin-bottom-tiny" as |Section|>
-        <HeadlessForm
-          id={{formId}}
-          @data={{this.nodeAttrs}}
-          @onSubmit={{this.saveChanges}}
-          as |form|
+      <HeadlessForm
+        id={{formId}}
+        @data={{this.nodeAttrs}}
+        @onSubmit={{this.saveChanges}}
+        as |form|
+      >
+        <AuCard
+          @size="small"
+          @expandable={{true}}
+          @manualControl={{true}}
+          @openSection={{this.toggleSection}}
+          @isExpanded={{this.expanded}}
+          as |c|
         >
-          <Section>
-            <AuToolbar as |Group|>
-              <Group>
-                <AuHeading @level="5" @skin="5">Node attributes</AuHeading>
-              </Group>
+          <c.header>
+            <AuHeading @level="5" @skin="5">Node attributes</AuHeading>
+          </c.header>
+          <c.content class="au-c-content--tiny">
+            <AuToolbar @border="bottom" as |Group|>
               <Group>
                 <AuButtonGroup>
                   {{#if this.isEditing}}
@@ -171,68 +176,54 @@ export default class AttributeEditor extends Component<Signature> {
                       Edit
                     </AuButton>
                   {{/if}}
-                  <AuButton
-                    @skin="naked"
-                    @icon={{if this.expanded ChevronUpIcon ChevronDownIcon}}
-                    {{on "click" this.toggleSection}}
-                  />
                 </AuButtonGroup>
               </Group>
             </AuToolbar>
-          </Section>
-          {{#if this.expanded}}
-            <Section>
-              <AuList @divider={{true}} as |Item|>
-                {{#each-in this.nodeAttrs as |key value|}}
-                  <Item>
-                    <div class="au-u-padding-tiny">
-                      {{#if (and this.isEditing (this.isEditable key))}}
-                        <form.Field @name={{key}} as |field|>
-                          <AuLabel for={{field.id}}>
-                            {{key}}
-                          </AuLabel>
-                          {{#let
-                            (this.editorComponent key)
-                            as |EditorComponent|
-                          }}
-                            {{#if EditorComponent}}
-                              {{! @glint-expect-error fix types of dynamic element }}
-                              <EditorComponent
-                                id={{field.id}}
-                                value={{field.value}}
-                                name={{key}}
-                                {{! @glint-expect-error glint has no Signature for the component}}
-                                {{on "change" (fn this.setField field)}}
-                              />
-                            {{else}}
-                              <AuTextarea
-                                @width="block"
-                                id={{field.id}}
-                                value={{field.value}}
-                                name={{key}}
-                                {{on "change" (fn this.setField field)}}
-                              />
-                            {{/if}}
-                          {{/let}}
-                        </form.Field>
-                      {{else}}
-                        <p><strong>{{key}}</strong></p>
-                        <pre
-                          class="say-attribute-editor__formatted-content"
-                        >{{if
-                            value
-                            (this.formatValue value)
-                            "<No value>"
-                          }}</pre>
-                      {{/if}}
-                    </div>
-                  </Item>
-                {{/each-in}}
-              </AuList>
-            </Section>
-          {{/if}}
-        </HeadlessForm>
-      </AuPanel>
+            <AuList @divider={{true}} as |Item|>
+              {{#each-in this.nodeAttrs as |key value|}}
+                <Item>
+                  <div class="au-u-padding-tiny">
+                    {{#if (and this.isEditing (this.isEditable key))}}
+                      <form.Field @name={{key}} as |field|>
+                        <AuLabel for={{field.id}}>
+                          {{key}}
+                        </AuLabel>
+                        {{#let (this.editorComponent key) as |EditorComponent|}}
+                          {{#if EditorComponent}}
+                            {{! @glint-expect-error fix types of dynamic element }}
+                            <EditorComponent
+                              id={{field.id}}
+                              value={{field.value}}
+                              name={{key}}
+                              {{! @glint-expect-error glint has no Signature for the component}}
+                              {{on "change" (fn this.setField field)}}
+                            />
+                          {{else}}
+                            <AuTextarea
+                              @width="block"
+                              id={{field.id}}
+                              value={{field.value}}
+                              name={{key}}
+                              {{on "change" (fn this.setField field)}}
+                            />
+                          {{/if}}
+                        {{/let}}
+                      </form.Field>
+                    {{else}}
+                      <p><strong>{{key}}</strong></p>
+                      <pre class="say-attribute-editor__formatted-content">{{if
+                          value
+                          (this.formatValue value)
+                          "<No value>"
+                        }}</pre>
+                    {{/if}}
+                  </div>
+                </Item>
+              {{/each-in}}
+            </AuList>
+          </c.content>
+        </AuCard>
+      </HeadlessForm>
     </WithUniqueId>
   </template>
 }

--- a/packages/ember-rdfa-editor/src/components/_private/debug-info/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/debug-info/index.gts
@@ -1,13 +1,8 @@
 import Component from '@glimmer/component';
 import type { ResolvedPNode } from '#root/utils/_private/types.ts';
-import { ChevronDownIcon } from '@appuniversum/ember-appuniversum/components/icons/chevron-down';
-import { ChevronUpIcon } from '@appuniversum/ember-appuniversum/components/icons/chevron-up';
-import AuPanel from '@appuniversum/ember-appuniversum/components/au-panel';
-import AuToolbar from '@appuniversum/ember-appuniversum/components/au-toolbar';
 import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
-import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
-import { on } from '@ember/modifier';
 import { localCopy } from 'tracked-toolbox';
+import AuCard from '@appuniversum/ember-appuniversum/components/au-card';
 
 type Signature = {
   Args: {
@@ -34,27 +29,21 @@ export default class DebugInfo extends Component<Signature> {
   };
 
   <template>
-    <AuPanel class="au-u-margin-bottom-tiny" as |Section|>
-      <Section>
-        <AuToolbar as |Group|>
-          <Group>
-            <AuHeading @level="5" @skin="5">Debug Info</AuHeading>
-          </Group>
-          <Group>
-            <AuButton
-              @skin="naked"
-              @icon={{if this.expanded ChevronUpIcon ChevronDownIcon}}
-              {{on "click" this.toggleSection}}
-            />
-          </Group>
-        </AuToolbar>
-      </Section>
-      {{#if this.expanded}}
-        <Section>
-          <p><strong>Position: </strong>{{this.pos}}</p>
-          <p><strong>Nodetype: </strong>{{this.nodeType}}</p>
-        </Section>
-      {{/if}}
-    </AuPanel>
+    <AuCard
+      @size="small"
+      @expandable={{true}}
+      @manualControl={{true}}
+      @openSection={{this.toggleSection}}
+      @isExpanded={{this.expanded}}
+      as |c|
+    >
+      <c.header>
+        <AuHeading @level="5" @skin="5">Debug Info</AuHeading>
+      </c.header>
+      <c.content class="au-c-content--small">
+        <p><strong>Position: </strong>{{this.pos}}</p>
+        <p><strong>Nodetype: </strong>{{this.nodeType}}</p>
+      </c.content>
+    </AuCard>
   </template>
 }

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/backlink-editor/index.gts
@@ -166,7 +166,7 @@ export default class BacklinkEditor extends Component<Args> {
     <AuContent @skin="tiny" {{this.setUpListeners}}>
       <AuToolbar as |Group|>
         <Group>
-          <AuHeading @level="5" @skin="5">Backlinks</AuHeading>
+          <AuHeading @level="6" @skin="6">Backlinks</AuHeading>
         </Group>
         <Group>
           <AuButton

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/doc-imported-resource-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/doc-imported-resource-editor/index.gts
@@ -215,7 +215,7 @@ export default class DocImportedResourceEditor extends Component<Sig> {
     <AuContent @skin="tiny" ...attributes>
       <AuToolbar as |Group|>
         <Group>
-          <AuHeading @level="5" @skin="5">Imported Resources</AuHeading>
+          <AuHeading @level="6" @skin="6">Imported Resources</AuHeading>
         </Group>
         <Group>
           <AuButton

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/external-triple-editor/index.gts
@@ -208,7 +208,7 @@ export default class ExternalTripleEditor extends Component<Sig> {
     <AuContent @skin="tiny">
       <AuToolbar as |Group|>
         <Group>
-          <AuHeading @level="5" @skin="5">External Triples</AuHeading>
+          <AuHeading @level="6" @skin="6">External Triples</AuHeading>
         </Group>
         <Group>
           <AuButton

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/index.gts
@@ -1,27 +1,22 @@
 import Component from '@glimmer/component';
 import { NodeSelection } from 'prosemirror-state';
 import { localCopy } from 'tracked-toolbox';
-import { on } from '@ember/modifier';
 import { isResourceNode } from '#root/utils/node-utils.ts';
 import RdfaPropertyEditor from './property-editor/index.gts';
 import RdfaWrappingUtils from './wrapping-utils/index.gts';
 import RemoveNode from './remove-node/index.gts';
 import type { ResolvedPNode } from '#root/utils/_private/types.ts';
-import { ChevronDownIcon } from '@appuniversum/ember-appuniversum/components/icons/chevron-down';
-import { ChevronUpIcon } from '@appuniversum/ember-appuniversum/components/icons/chevron-up';
-import AuPanel from '@appuniversum/ember-appuniversum/components/au-panel';
-import AuToolbar from '@appuniversum/ember-appuniversum/components/au-toolbar';
 import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
 import AuPill from '@appuniversum/ember-appuniversum/components/au-pill';
-import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 import type SayController from '#root/core/say-controller.ts';
 import ExternalTripleEditor from './external-triple-editor/index.gts';
 import BacklinkEditor from './backlink-editor/index.gts';
 import { IMPORTED_RESOURCES_ATTR } from '#root/plugins/imported-resources/index.ts';
 import DocImportedResourceEditor from './doc-imported-resource-editor/index.gts';
+import AuCard from '@appuniversum/ember-appuniversum/components/au-card';
 
 type Args = {
-  controller?: SayController;
+  controller: SayController;
   node: ResolvedPNode;
   additionalImportedResources?: string[];
   expanded?: boolean;
@@ -93,74 +88,50 @@ export default class RdfaEditor extends Component<Args> {
     }
   };
   <template>
-    <AuPanel class="au-u-margin-top-tiny au-u-margin-bottom-tiny" as |Section|>
-      <Section>
-        <AuToolbar as |Group|>
-          <Group>
-            <AuHeading @level="4" @skin="4">RDFa</AuHeading>
-          </Group>
-          {{#if @node}}
-            <Group>
-              <AuPill>{{this.type}}</AuPill>
-              <AuButton
-                @skin="naked"
-                @icon={{if this.expanded ChevronUpIcon ChevronDownIcon}}
-                {{on "click" this.toggleSection}}
-              />
-            </Group>
-          {{/if}}
-        </AuToolbar>
-      </Section>
-      {{#if this.controller}}
-        {{#if @node}}
-          {{#if this.expanded}}
-            {{#if this.isDocWithImportedResources}}
-              <Section>
-                <DocImportedResourceEditor
-                  @controller={{@controller}}
-                  @node={{@node}}
-                />
-              </Section>
-            {{/if}}
-            {{#if this.showPropertiesSection}}
-              <Section>
-                <ExternalTripleEditor
-                  @controller={{this.controller}}
-                  @node={{@node}}
-                />
-              </Section>
-              <Section>
-                <RdfaPropertyEditor
-                  @node={{@node}}
-                  @controller={{this.controller}}
-                  @additionalImportedResources={{@additionalImportedResources}}
-                  @predicateOptions={{@propertyPredicates}}
-                  @objectOptions={{@propertyObjects}}
-                />
-              </Section>
-            {{/if}}
-            <Section>
-              <BacklinkEditor
-                @controller={{this.controller}}
-                @node={{@node}}
-                @predicateOptions={{@backlinkPredicates}}
-              />
-            </Section>
-            <Section>
-              <RdfaWrappingUtils @node={{@node}} @controller={{@controller}} />
-            </Section>
-            <Section>
-              {{#if @controller}}
-                <RemoveNode @node={{@node}} @controller={{@controller}} />
-              {{/if}}
-            </Section>
-          {{/if}}
-        {{else}}
-          <Section>
-            <RdfaWrappingUtils @node={{@node}} @controller={{@controller}} />
-          </Section>
+    <AuCard
+      @size="small"
+      @expandable={{true}}
+      @manualControl={{true}}
+      @openSection={{this.toggleSection}}
+      @isExpanded={{this.expanded}}
+      as |c|
+    >
+      <c.header>
+        <div
+          class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex--spaced-small"
+        >
+          <AuHeading @level="5" @skin="5">RDFa</AuHeading>
+          <AuPill>{{this.type}}</AuPill>
+        </div>
+      </c.header>
+      <c.content>
+        {{#if this.isDocWithImportedResources}}
+          <DocImportedResourceEditor
+            @controller={{@controller}}
+            @node={{@node}}
+          />
         {{/if}}
-      {{/if}}
-    </AuPanel>
+        {{#if this.showPropertiesSection}}
+          <ExternalTripleEditor
+            @controller={{this.controller}}
+            @node={{@node}}
+          />
+          <RdfaPropertyEditor
+            @node={{@node}}
+            @controller={{this.controller}}
+            @additionalImportedResources={{@additionalImportedResources}}
+            @predicateOptions={{@propertyPredicates}}
+            @objectOptions={{@propertyObjects}}
+          />
+        {{/if}}
+        <BacklinkEditor
+          @controller={{this.controller}}
+          @node={{@node}}
+          @predicateOptions={{@backlinkPredicates}}
+        />
+        <RdfaWrappingUtils @node={{@node}} @controller={{@controller}} />
+        <RemoveNode @node={{@node}} @controller={{@controller}} />
+      </c.content>
+    </AuCard>
   </template>
 }

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/index.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-editor/property-editor/index.gts
@@ -202,7 +202,7 @@ export default class RdfaPropertyEditor extends Component<Args> {
     <AuContent @skin="tiny" {{this.setUpListeners}}>
       <AuToolbar as |Group|>
         <Group>
-          <AuHeading @level="5" @skin="5">Properties</AuHeading>
+          <AuHeading @level="6" @skin="6">Properties</AuHeading>
         </Group>
         <Group>
           <AuButton

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-visualiser/rdfa-explorer.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-visualiser/rdfa-explorer.gts
@@ -11,7 +11,6 @@ import {
   rdfaInfoPluginKey,
   type RdfaVisualizerConfig,
 } from '#root/plugins/rdfa-info/index.ts';
-import { type ResolvedPNode } from '#root/utils/_private/types.ts';
 import { type RdfaInfo } from '#root/plugins/rdfa-info/plugin.ts';
 import { selectNodeBySubject } from '#root/commands/_private/rdfa-commands/index.ts';
 import ResourceInfo from '#root/components/_private/rdfa-visualiser/resource-info.gts';
@@ -19,7 +18,6 @@ import ResourceInfo from '#root/components/_private/rdfa-visualiser/resource-inf
 interface Sig {
   Args: {
     controller: SayController;
-    node?: ResolvedPNode;
     config: RdfaVisualizerConfig;
   };
 }

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-visualiser/visualiser-card.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-visualiser/visualiser-card.gts
@@ -1,21 +1,14 @@
 import Component from '@glimmer/component';
-import { on } from '@ember/modifier';
 import { localCopy } from 'tracked-toolbox';
-import { ChevronDownIcon } from '@appuniversum/ember-appuniversum/components/icons/chevron-down';
-import { ChevronUpIcon } from '@appuniversum/ember-appuniversum/components/icons/chevron-up';
-import AuPanel from '@appuniversum/ember-appuniversum/components/au-panel';
-import AuToolbar from '@appuniversum/ember-appuniversum/components/au-toolbar';
 import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
-import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 import type SayController from '#root/core/say-controller.ts';
-import { type ResolvedPNode } from '#root/utils/_private/types.ts';
 import { type RdfaVisualizerConfig } from '#root/plugins/rdfa-info/types.ts';
 import RdfaExplorer from './rdfa-explorer.gts';
+import AuCard from '@appuniversum/ember-appuniversum/components/au-card';
 
 interface Sig {
   Args: {
     controller?: SayController;
-    node?: ResolvedPNode;
     expanded?: boolean;
     onToggle?: (expanded: boolean) => void;
     config: RdfaVisualizerConfig;
@@ -31,34 +24,21 @@ export default class VisualiserCard extends Component<Sig> {
 
   <template>
     {{#if @controller}}
-      <AuPanel
-        class="au-u-margin-top-tiny au-u-margin-bottom-tiny"
-        as |Section|
+      <AuCard
+        @size="small"
+        @expandable={{true}}
+        @manualControl={{true}}
+        @openSection={{this.toggleSection}}
+        @isExpanded={{this.expanded}}
+        as |c|
       >
-        <Section>
-          <AuToolbar as |Group|>
-            <Group>
-              <AuHeading @level="4" @skin="4">RDFa visualiser</AuHeading>
-            </Group>
-            <Group>
-              <AuButton
-                @skin="naked"
-                @icon={{if this.expanded ChevronUpIcon ChevronDownIcon}}
-                {{on "click" this.toggleSection}}
-              />
-            </Group>
-          </AuToolbar>
-        </Section>
-        {{#if this.expanded}}
-          <Section>
-            <RdfaExplorer
-              @controller={{@controller}}
-              @node={{@node}}
-              @config={{@config}}
-            />
-          </Section>
-        {{/if}}
-      </AuPanel>
+        <c.header>
+          <AuHeading @level="5" @skin="5">RDFa visualiser</AuHeading>
+        </c.header>
+        <c.content class="au-c-content--tiny">
+          <RdfaExplorer @controller={{@controller}} @config={{@config}} />
+        </c.content>
+      </AuCard>
     {{/if}}
   </template>
 }

--- a/test-app/app/templates/editable-node.hbs
+++ b/test-app/app/templates/editable-node.hbs
@@ -39,25 +39,26 @@
             </Item>
           </Sb.Collapsible>
           <Plugins::Link::LinkEditor @controller={{this.rdfaEditor}} />
-          <this.VisualiserCard
-            @controller={{this.rdfaEditor}}
-            @node={{this.activeNode}}
-            @config={{this.rdfa.visualizerConfig}}
-          />
-          <this.RdfaEditor
-            @node={{this.activeNode}}
-            @controller={{this.rdfaEditor}}
-            @propertyPredicates={{this.rdfa.propertyPredicates}}
-            @propertyObjects={{this.rdfa.propertyObjects}}
-            @backlinkPredicates={{this.rdfa.backlinkPredicates}}
-          />
-          {{#if this.activeNode}}
-            <this.DebugInfo @node={{this.activeNode}} />
-            <this.AttributeEditor
-              @node={{this.activeNode}}
+          <div class="au-u-flex au-u-flex--column au-u-flex--spaced-tiny">
+            <this.VisualiserCard
               @controller={{this.rdfaEditor}}
+              @config={{this.rdfa.visualizerConfig}}
             />
-          {{/if}}
+            {{#if this.activeNode}}
+              <this.RdfaEditor
+                @node={{this.activeNode}}
+                @controller={{this.rdfaEditor}}
+                @propertyPredicates={{this.rdfa.propertyPredicates}}
+                @propertyObjects={{this.rdfa.propertyObjects}}
+                @backlinkPredicates={{this.rdfa.backlinkPredicates}}
+              />
+              <this.DebugInfo @node={{this.activeNode}} />
+              <this.AttributeEditor
+                @node={{this.activeNode}}
+                @controller={{this.rdfaEditor}}
+              />
+            {{/if}}
+          </div>
         </Sidebar>
       </:aside>
     </EditorContainer>


### PR DESCRIPTION
### Overview
This PR replaces the usage of `AuPanel` components by collapsible `AuCard` components in the rdfa-tools. Additionally, this PR also standardizes the font-sizes/card sizes across these components.

##### connected issues and PRs:
None

### How to test/reproduce
- Start the test-app
- Open the editable-node page
- Ensure the rdfa-tool cards are now smaller
- You can expand/collapse the cards by clicking anywhere on their header
- Spacing between cards should now be more consistent

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
