### PR TITLE
Actually do the responsive-toolbar types properly...

### DIFF
--- a/packages/ember-rdfa-editor/src/components/responsive-toolbar.gts
+++ b/packages/ember-rdfa-editor/src/components/responsive-toolbar.gts
@@ -11,7 +11,6 @@ import { NavDownIcon } from '@appuniversum/ember-appuniversum/components/icons/n
 import ToolbarGroup from '#root/components/toolbar/group.gts';
 import ToolbarButton from '#root/components/toolbar/button.ts';
 import ToolbarDivider from '#root/components/toolbar/divider.gts';
-import type { ComponentLike } from '@glint/template';
 
 type ToolbarSection = {
   reference?: HTMLElement;
@@ -21,8 +20,8 @@ type ToolbarSection = {
 };
 interface Sig {
   Blocks: {
-    main: [{ Group: ComponentLike; Divider: ComponentLike }];
-    side: [{ Group: ComponentLike; Divider: ComponentLike }];
+    main: [{ Group: typeof ToolbarGroup; Divider: typeof ToolbarDivider }];
+    side: [{ Group: typeof ToolbarGroup; Divider: typeof ToolbarDivider }];
   };
 }
 


### PR DESCRIPTION
### Overview
This time with types that don't error when you use them...

##### connected issues and PRs:
Fixes https://github.com/lblod/ember-rdfa-editor/pull/1313

### Setup
N/A

### How to test/reproduce
To test, it's easiest to do so within GN or another app where the use of ResponsiveToolbar is in a typechecked component.

### Challenges/uncertainties
Still hard to know when to stop converting...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [x] npm lint
- [x] no new deprecations
