### PR TITLE
CIT-35: relationship-editor `document` config

### DIFF
--- a/.changeset/floppy-shirts-tickle.md
+++ b/.changeset/floppy-shirts-tickle.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+relationship-editor: add sample document config

--- a/packages/ember-rdfa-editor/package.json
+++ b/packages/ember-rdfa-editor/package.json
@@ -374,6 +374,7 @@
       "./components/_private/rdfa-visualiser/resource-info.js": "./dist/_app_/components/_private/rdfa-visualiser/resource-info.js",
       "./components/_private/rdfa-visualiser/visualiser-card.js": "./dist/_app_/components/_private/rdfa-visualiser/visualiser-card.js",
       "./components/_private/relationship-editor/card.js": "./dist/_app_/components/_private/relationship-editor/card.js",
+      "./components/_private/relationship-editor/configs.js": "./dist/_app_/components/_private/relationship-editor/configs.js",
       "./components/_private/relationship-editor/create-button.js": "./dist/_app_/components/_private/relationship-editor/create-button.js",
       "./components/_private/relationship-editor/modals/classic.js": "./dist/_app_/components/_private/relationship-editor/modals/classic.js",
       "./components/_private/relationship-editor/modals/dev-mode.js": "./dist/_app_/components/_private/relationship-editor/modals/dev-mode.js",

--- a/packages/ember-rdfa-editor/src/components/_private/relationship-editor/configs.ts
+++ b/packages/ember-rdfa-editor/src/components/_private/relationship-editor/configs.ts
@@ -1,0 +1,86 @@
+import type {
+  ObjectOption,
+  OptionGeneratorConfig,
+  PredicateOption,
+} from './types.ts';
+import { sayDataFactory } from '#root/core/say-data-factory/data-factory.ts';
+import type SayController from '#root/core/say-controller.ts';
+import { getSubjects } from '#root/plugins/rdfa-info/utils.ts';
+import { rdfaInfoPluginKey } from '#root/plugins/rdfa-info/plugin.ts';
+import { isRdfaAttrs } from '#root/core/rdfa-types.ts';
+import SetUtils from '#root/utils/_private/set-utils.ts';
+
+export const documentConfig: (
+  controller: SayController,
+) => OptionGeneratorConfig = (controller) => ({
+  subjects: ({ searchString = '' } = {}) => {
+    const resources = getSubjects(controller.mainEditorState);
+    return resources
+      .map((resource) => ({
+        term: sayDataFactory.resourceNode(resource),
+      }))
+      .filter(({ term }) =>
+        term.value.toLowerCase().includes(searchString.toLowerCase()),
+      );
+  },
+  predicates: ({ searchString = '', direction } = {}) => {
+    const rdfaIdMapping = rdfaInfoPluginKey.getState(
+      controller.mainEditorState,
+    )?.rdfaIdMapping;
+    if (!rdfaIdMapping) {
+      return [];
+    }
+    const predicates: Set<string> = new Set();
+    rdfaIdMapping.forEach((resolvedNode) => {
+      const node = resolvedNode.value;
+      if (isRdfaAttrs(node.attrs) && node.attrs.rdfaNodeType === 'resource') {
+        SetUtils.addMany(
+          predicates,
+          ...node.attrs.properties
+            .map((prop) => prop.predicate)
+            .filter((predicate) => predicate.includes(searchString)),
+        );
+      }
+    });
+
+    const predicateList = [...predicates];
+    let propertyPredicates: PredicateOption[] = [];
+    let backlinkPredicates: PredicateOption[] = [];
+    if (!direction || direction === 'property') {
+      propertyPredicates = predicateList.map((predicate) => ({
+        direction: 'property',
+        term: sayDataFactory.namedNode(predicate),
+      }));
+    }
+    if (!direction || direction === 'backlink') {
+      backlinkPredicates = predicateList.map((predicate) => ({
+        direction: 'backlink',
+        term: sayDataFactory.namedNode(predicate),
+      }));
+    }
+    return [...propertyPredicates, ...backlinkPredicates];
+  },
+  objects: ({ searchString = '' } = {}) => {
+    const resources = getSubjects(controller.mainEditorState);
+    const rdfaIdMapping = rdfaInfoPluginKey.getState(
+      controller.mainEditorState,
+    )?.rdfaIdMapping;
+    const literals: string[] = [];
+    if (rdfaIdMapping) {
+      rdfaIdMapping.forEach((resolvedNode, rdfaId) => {
+        if (resolvedNode.value.attrs['rdfaNodeType'] === 'literal') {
+          literals.push(rdfaId);
+        }
+      });
+    }
+    const resourceOptions: ObjectOption[] = resources.map((resource) => ({
+      term: sayDataFactory.resourceNode(resource),
+    }));
+    const literalOptions: ObjectOption[] = literals.map((rdfaId) => ({
+      term: sayDataFactory.literalNode(rdfaId),
+    }));
+    return [...resourceOptions, ...literalOptions].filter(({ term }) =>
+      term.value.toLowerCase().includes(searchString.toLowerCase()),
+    );
+  },
+});

--- a/test-app/app/controllers/editable-node.ts
+++ b/test-app/app/controllers/editable-node.ts
@@ -84,7 +84,6 @@ import {
   unwrap,
 } from '@lblod/ember-rdfa-editor/utils/_private/option';
 
-import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
 import VisualiserCard from '@lblod/ember-rdfa-editor/components/_private/rdfa-visualiser/visualiser-card';
 import type { OutgoingTriple } from '@lblod/ember-rdfa-editor/core/rdfa-processor';
 import {
@@ -98,13 +97,7 @@ import {
 } from '@lblod/ember-rdfa-editor/utils/namespace';
 import DevModeToggle from 'test-app/components/dev-mode-toggle';
 import CreateRelationshipButton from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/create-button';
-import type {
-  ObjectOption,
-  PredicateOption,
-  SubjectOption,
-} from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/types';
-import type { OptionGeneratorConfig } from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/types';
-
+import { documentConfig } from '@lblod/ember-rdfa-editor/components/_private/relationship-editor/configs';
 const humanReadablePredicateDisplay: DisplayGenerator<OutgoingTriple> = (
   triple,
 ) => {
@@ -300,90 +293,7 @@ export default class EditableBlockController extends Controller {
     console.warn('Live toggling plugins is currently not supported');
   }
 
-  optionGeneratorConfig: OptionGeneratorConfig = {
-    subjects: ({ searchString = '' } = {}) => {
-      const options: SubjectOption[] = [
-        {
-          label: '(Besluit) Kennisname van de definitieve verkiezingsuitslag',
-          term: sayDataFactory.resourceNode('http://example.org/decisions/1'),
-        },
-        {
-          label: 'Artikel 1',
-          term: sayDataFactory.resourceNode('http://example.org/articles/1'),
-        },
-      ];
-      return options.filter(
-        (option) =>
-          option.label?.toLowerCase().includes(searchString.toLowerCase()) ||
-          option.description
-            ?.toLowerCase()
-            .includes(searchString.toLowerCase()) ||
-          option.term.value.toLowerCase().includes(searchString.toLowerCase()),
-      );
-    },
-    predicates: ({ searchString = '', direction } = {}) => {
-      const options: PredicateOption[] = [
-        {
-          label: 'Titel',
-          description:
-            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-          term: sayDataFactory.namedNode('eli:title'),
-          direction: 'backlink',
-        },
-        {
-          label: 'Has Titel',
-          description:
-            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-          term: sayDataFactory.namedNode('eli:title'),
-          allowFreeTextTarget: true,
-          direction: 'property',
-        },
-        {
-          label: 'Beschrijving',
-          description:
-            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.',
-          term: sayDataFactory.namedNode('dct:description'),
-          direction: 'backlink',
-        },
-        {
-          label: 'Motivering',
-          description:
-            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.',
-          term: sayDataFactory.namedNode('besluit:motivering'),
-          direction: 'backlink',
-        },
-      ];
-      return options.filter(
-        (option) =>
-          (option.label?.toLowerCase().includes(searchString.toLowerCase()) ||
-            option.description
-              ?.toLowerCase()
-              .includes(searchString.toLowerCase()) ||
-            option.term.value
-              .toLowerCase()
-              .includes(searchString.toLowerCase())) &&
-          (!direction || option.direction === direction),
-      );
-    },
-    objects: ({ searchString = '' } = {}) => {
-      const options: ObjectOption[] = [
-        {
-          label: 'Target 1',
-          term: sayDataFactory.resourceNode('http://example.org/decisions/1'),
-        },
-        {
-          label: 'Target 2',
-          term: sayDataFactory.resourceNode('http://example.org/articles/1'),
-        },
-      ];
-      return options.filter(
-        (option) =>
-          option.label?.toLowerCase().includes(searchString.toLowerCase()) ||
-          option.description
-            ?.toLowerCase()
-            .includes(searchString.toLowerCase()) ||
-          option.term.value.toLowerCase().includes(searchString.toLowerCase()),
-      );
-    },
-  };
+  get optionGeneratorConfig() {
+    return this.rdfaEditor && documentConfig(this.rdfaEditor);
+  }
 }


### PR DESCRIPTION
### Overview
This PR adds a sample `documentConfig` `OptionGeneratorConfig` for the relationship-editor components. This config is now also used in the test-app.
The specific config:
- suggests subjects used in the document
- suggests predicates used in the document
- suggests objects used in the document

### How to test/reproduce
- Start the test-app
- Open the relationship-editor modal
- You should be able to select from a list of subjects/predicates/objects

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
