### PR TITLE
GN-5592: fix firefox cursor bug

### DIFF
--- a/.changeset/shy-days-wash.md
+++ b/.changeset/shy-days-wash.md
@@ -1,0 +1,7 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Introduction of two new ember-node options:
+- `domClassNames`: classnames to apply to the nodeview which is created
+- `contentDomClassNames`: classnames to apply to the content node within the nodeview

--- a/.changeset/whole-bats-scream.md
+++ b/.changeset/whole-bats-scream.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Remove obsolete firefox fake cursor styling. The fake cursor is no longer needed, the native browser cursor can now be used without issues.

--- a/packages/ember-rdfa-editor/ember-rdfa-editor.scss
+++ b/packages/ember-rdfa-editor/ember-rdfa-editor.scss
@@ -26,12 +26,6 @@
   width: 20px;
 }
 
-.ProseMirror-firefox-fake-cursor {
-  pointer-events: none;
-  border-left: 0.08em solid black;
-  animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
-}
-
 @keyframes ProseMirror-cursor-blink {
   to {
     visibility: hidden;

--- a/packages/ember-rdfa-editor/src/plugins/firefox-cursor-fix/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/firefox-cursor-fix/index.ts
@@ -89,7 +89,6 @@ export function firefoxCursorFix(): ProsePlugin {
               from,
               () => {
                 const fakeCursor = document.createElement('span');
-                fakeCursor.classList.add('ProseMirror-firefox-fake-cursor');
                 return fakeCursor;
               },
               { side: 1 },

--- a/packages/ember-rdfa-editor/src/utils/_private/ember-node.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/ember-node.ts
@@ -220,6 +220,13 @@ class EmberNodeView implements NodeView {
       },
     );
     this.dom = node;
+    if (this.config.domClassNames) {
+      this.dom.classList.add(...this.config.domClassNames);
+    }
+    if (this.config.contentDomClassNames && this.contentDOM) {
+      this.contentDOM.classList.add(...this.config.contentDomClassNames);
+    }
+
     this.emberComponent = component;
   }
 
@@ -372,6 +379,8 @@ export type EmberNodeConfig = {
    * @param event The event to check
    */
   stopEvent?: (event: Event) => boolean;
+  domClassNames?: string[];
+  contentDomClassNames?: string[];
   /**
    * Determines whether a DOM mutation should be ignored by prosemirror.
    * Use this to avoid rerendering a component for every change.

--- a/test-app/app/components/sample-ember-nodes/sample-block.gts
+++ b/test-app/app/components/sample-ember-nodes/sample-block.gts
@@ -1,0 +1,17 @@
+import type { TOC } from '@ember/component/template-only';
+
+interface Signature {
+  Blocks: {
+    default: [];
+  };
+}
+
+const SampleBlock: TOC<Signature> = <template>
+  <div class="say-dummy-sample-block">
+    <div>
+      {{yield}}
+    </div>
+  </div>
+</template>;
+
+export default SampleBlock;

--- a/test-app/app/components/sample-ember-nodes/sidebar.gts
+++ b/test-app/app/components/sample-ember-nodes/sidebar.gts
@@ -38,10 +38,14 @@ export default class SampleEmberNodesSidebar extends Component<Signature> {
     this.insert(this.schema.nodes['dropdown']);
   }
 
+  @action
+  insertBlock() {
+    this.insert(this.schema.nodes['sample_block']);
+  }
   insert(type?: NodeType) {
     if (type) {
       this.controller.withTransaction((tr) => {
-        return tr.replaceSelectionWith(type.create()).scrollIntoView();
+        return tr.replaceSelectionWith(type.createAndFill()!).scrollIntoView();
       });
     }
   }
@@ -81,6 +85,16 @@ export default class SampleEmberNodesSidebar extends Component<Signature> {
             {{on "click" this.insertDropdown}}
           >
             Insert Dropdown
+          </AuButton>
+        </Item>
+        <Item>
+          <AuButton
+            @icon="add"
+            @iconAlignment="left"
+            @skin="link"
+            {{on "click" this.insertBlock}}
+          >
+            Insert Sample block
           </AuButton>
         </Item>
       </sidebar.Collapsible>

--- a/test-app/app/controllers/plugins.ts
+++ b/test-app/app/controllers/plugins.ts
@@ -71,6 +71,10 @@ import { heading } from '@lblod/ember-rdfa-editor/plugins/heading/nodes/heading'
 import { getOwner } from '@ember/owner';
 import { unwrap } from '@lblod/ember-rdfa-editor/utils/_private/option';
 import { modifier } from 'ember-modifier';
+import {
+  sample_block,
+  sampleBlockView,
+} from 'test-app/dummy-nodes/sample-block';
 
 const DEFAULT_SIDEBAR_EXPANDED = true;
 const SIDEBAR_EXPANDED_LOCAL_STORAGE_KEY = 'editor-sidebar-expanded';
@@ -132,6 +136,7 @@ export default class IndexController extends Controller {
       card,
       counter,
       dropdown,
+      sample_block,
       link: link(this.linkOptions),
     },
     marks: {
@@ -163,6 +168,7 @@ export default class IndexController extends Controller {
       dropdown: dropdownView(proseController),
       link: linkView(this.linkOptions)(proseController),
       image: imageView(proseController),
+      sample_block: sampleBlockView(proseController),
     };
   };
   @tracked plugins: PluginConfig = [

--- a/test-app/app/dummy-nodes/sample-block.ts
+++ b/test-app/app/dummy-nodes/sample-block.ts
@@ -1,0 +1,24 @@
+import type { ComponentLike } from '@glint/template';
+import {
+  createEmberNodeSpec,
+  createEmberNodeView,
+  type EmberNodeConfig,
+} from '@lblod/ember-rdfa-editor/utils/_private/ember-node';
+import SampleBlock from 'test-app/components/sample-ember-nodes/sample-block';
+
+const emberNodeConfig: EmberNodeConfig = {
+  name: 'sample_block',
+  component: SampleBlock as unknown as ComponentLike,
+  inline: false,
+  group: 'block',
+  content: 'block+',
+  contentDomClassNames: ['say-dummy-sample-block__content'],
+  atom: false,
+  draggable: false,
+  selectable: true,
+  isolating: true,
+};
+
+export const sample_block = createEmberNodeSpec(emberNodeConfig);
+
+export const sampleBlockView = createEmberNodeView(emberNodeConfig);

--- a/test-app/app/styles/_c-dummy.scss
+++ b/test-app/app/styles/_c-dummy.scss
@@ -107,3 +107,11 @@ input.uri {
 input[type="number"] {
   width: 100px;
 }
+
+.say-dummy-sample-block {
+  outline: 1px solid black;
+}
+
+.say-dummy-sample-block__content {
+  padding: 10px;
+}


### PR DESCRIPTION
### Overview
This PR contains two adjustments to improve cursor behaviour around inline, non-editable nodes:

**The addition of two new ember-node options:**
- `domClassNames`: classnames to apply to the nodeview which is created
- `contentDomClassNames`: classnames to apply to the content node within the nodeview
These are needed/useful to workaround the `stopEvent` problem: we want prosemirror to ignore most events occuring inside the custom ember nodeview itself (e.g. button presses). This does mean that e.g. clicks before the content of such a node are not  handled by prosemirror => cursor is not correctly set. Events inside the `contentDOM` _are_ handled correctly, so the `contentDomClassNames` can allow custom styling on that node (e.g. spacing/padding which makes it easier to click before the content).

Aside from that, I still think it's a sensible default for prosemirror to ignore most events on the nodeview itself (except for maybe drag events).

**Removal of the obsolete firefox fake-cursor decoration**
The custom click handler is still needed, but it seems firefox now correctly handles displaying a native cursor (where before we needed a fake cursor).

##### connected issues and PRs:
[GN-5592](https://binnenland.atlassian.net/browse/GN-5592?atlOrigin=eyJpIjoiOWQwNjUyNjVhMzVmNDQ5MWI4NmQxNTZmMzhhZTNkMTEiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the test-app and open the 'Dummy plugins' page
- Insert the following two dummy nodes: `Card` and `Sample Block`
  * `Card` has no styling/padding on its content dom
  * `Sample Block` has padding on its content dom
- Insert a simple hyperlink at the start of each dummy node
- Observe the difference in click/cursor handling:
  * In `Card`, you can seemingly set a cursor before the link by clicking before it, but it will not work (the click handler of the `firefoxCursorFix` plugin is not called as we are clicking inside the nodeview)
  * In `Sample Block`, you can correctly set a cursor (which works) when clicking before the link (the click handler of the `firefoxCursorFix` plugin is correctly called as we are clicking inside the contentDOM)

### Challenges/uncertainties
- You'll notice some small visual bugs (like the cursor jumping around a second before setting the correct/fixed one). I have not yet found a solution for this, but I already consider this a large improvement upon the current situation.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
