### PR TITLE
Align table tooltip design with new toolbar design

### DIFF
--- a/.changeset/loose-aliens-work.md
+++ b/.changeset/loose-aliens-work.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Align table popup menu design with new toolbar design

--- a/packages/ember-rdfa-editor/scss/_c-selection-tooltip.scss
+++ b/packages/ember-rdfa-editor/scss/_c-selection-tooltip.scss
@@ -1,6 +1,6 @@
 @use "@appuniversum/ember-appuniversum/styles/settings/s-root";
 
-$say-selection-tooltip-background: var(--au-gray-200) !default;
+$say-selection-tooltip-background: var(--au-gray-100) !default;
 
 .say-editor-selection-tooltip {
   background: $say-selection-tooltip-background;

--- a/packages/ember-rdfa-editor/scss/_c-table.scss
+++ b/packages/ember-rdfa-editor/scss/_c-table.scss
@@ -120,17 +120,19 @@ table.ProseMirror-selectednode,
   button {
     outline: none;
     border: 0;
-    color: var(--au-gray-600);
+    color: var(--au-gray-900);
     padding: au-settings.$au-unit-small;
 
     &:hover,
     &:focus {
-      color: var(--au-gray-700);
+      color: var(--au-gray-900);
+      background-color: var(--au-gray-300);
     }
 
     &:disabled {
-      color: var(--au-gray-400);
+      color: var(--au-gray-500);
       cursor: not-allowed;
+      background-color: transparent;
     }
   }
 }


### PR DESCRIPTION
### Overview
This PR aligns the table tooltip design with the new toolbar design.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor/pull/1318

### How to test/reproduce
- Start the test-app and open the 'Home' page
- Insert a table
- Click anywhere in the table to trigger the popup menu
- Ensure the popup menu design is now aligned with the new toolbar design

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
