### PR TITLE
GN-5607: correctly parse older-style literal nodes

### DIFF
--- a/.changeset/twelve-experts-pick.md
+++ b/.changeset/twelve-experts-pick.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Add extra check to `postProcessTagAsRdfaNode` function to correctly parse older style literal nodes

--- a/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/post-process-as-rdfa-nodes.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/post-process-as-rdfa-nodes.ts
@@ -5,6 +5,7 @@ export interface PostProcessArgs<N> {
   activeTag: IActiveTag<N>;
   attributes: Record<string, string>;
   isRootTag: boolean;
+  isExternalTriple: boolean;
   typedResource: true | ModelBlankNode<N> | ModelNamedNode<N> | null;
   markAsLiteralNode: (
     node: N,
@@ -76,15 +77,13 @@ export function postProcessTagAsRdfaNode<N>(args: PostProcessArgs<N>): void {
     activeTag,
     attributes,
     isRootTag,
+    isExternalTriple,
     typedResource,
     markAsLiteralNode,
     markAsResourceNode,
   } = args;
   const node = activeTag.node;
-  const representsExternalTriple =
-    node instanceof Node &&
-    node.parentElement?.dataset['externalTripleContainer'];
-  if (representsExternalTriple) {
+  if (node && isExternalTriple) {
     markAsResourceNode(
       node,
       unwrap(activeTag.subject),

--- a/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/post-process-as-rdfa-nodes.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/post-process-as-rdfa-nodes.ts
@@ -81,6 +81,22 @@ export function postProcessTagAsRdfaNode<N>(args: PostProcessArgs<N>): void {
     markAsResourceNode,
   } = args;
   const node = activeTag.node;
+  const representsExternalTriple =
+    node instanceof Node &&
+    node.parentElement?.dataset['externalTripleContainer'];
+  if (representsExternalTriple) {
+    markAsResourceNode(
+      node,
+      unwrap(activeTag.subject),
+      activeTag,
+      activeTag.predicates?.find(
+        (pred) => pred.value === attributes['property'],
+      ),
+      activeTag.datatype,
+      activeTag.language,
+    );
+    return;
+  }
   if (!activeTag.skipElement && node) {
     // no rel or rev
     if (

--- a/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/post-process-as-rdfa-nodes.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/post-process-as-rdfa-nodes.ts
@@ -120,7 +120,9 @@ export function postProcessTagAsRdfaNode<N>(args: PostProcessArgs<N>): void {
       } else {
         if (
           truthyAttribute(attributes, 'about') &&
-          !truthyAttribute(attributes, 'data-literal-node')
+          !truthyAttribute(attributes, 'data-literal-node') &&
+          // Is this correct, an alternative solution would be to check on the presence of a `resource` attr here?
+          !truthyAttribute(attributes, 'datatype')
         ) {
           // same exception as above, we always interpret (property +about -content) cases as literal nodes
           markAsResourceNode(

--- a/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/rdfa-parser.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/rdfa-parser.ts
@@ -1204,10 +1204,12 @@ export class RdfaParser<N> {
       }
     }
     const isRootTag: boolean = this.activeTagStack.length === 1;
+    const isExternalTriple = Boolean(parentTag?.attributes['data-external-triple-container']);
     postProcessTagAsRdfaNode({
       activeTag,
       attributes: activeTag.attributes,
       isRootTag,
+      isExternalTriple,
       typedResource: activeTag.typedResource ?? null,
       markAsLiteralNode: this.markAsLiteralNode,
       markAsResourceNode: this.markAsResourceNode,

--- a/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/rdfa-parser.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/rdfa-parser.ts
@@ -1204,7 +1204,9 @@ export class RdfaParser<N> {
       }
     }
     const isRootTag: boolean = this.activeTagStack.length === 1;
-    const isExternalTriple = Boolean(parentTag?.attributes['data-external-triple-container']);
+    const isExternalTriple = Boolean(
+      parentTag?.attributes['data-external-triple-container'],
+    );
     postProcessTagAsRdfaNode({
       activeTag,
       attributes: activeTag.attributes,


### PR DESCRIPTION
### Overview
This PR ensures that older-style literal nodes (which are not per se rdfa-aware) are more or less correctly parsed.
The example used to test this PR are older decision templates with non rdfa-aware titles.

##### connected issues and PRs:
[GN-5607](https://binnenland.atlassian.net/browse/GN-5607?atlOrigin=eyJpIjoiNThkNTg2NTc0NGJkNDU1Y2E5YTNjYjY4ZWRjMmQwNGMiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the test-app
- Insert an older decision template, e.g.:
```html
<div
    lang="nl-BE"
    data-say-document="true"
    data-literal-node="true"
>
    <div
        style="display: none"
        class="say-hidden"
        data-rdfa-container="true"
    ></div>
    <div data-content-container="true">
        <div
            class="say-editable say-block-rdfa"
            about="http://data.lblod.info/id/besluiten/000f9360-2fcc-11f0-ad19-fbd5cd20271e"
            data-say-id="30e2d215-a8b6-4bab-9d8b-aaab634589ea"
        >
            <div
                style="display: none"
                class="say-hidden"
                data-rdfa-container="true"
            ><span
                    about="http://data.lblod.info/id/besluiten/000f9360-2fcc-11f0-ad19-fbd5cd20271e"
                    property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
                    resource="http://data.vlaanderen.be/ns/besluit#Besluit"
                ></span><span
                    about="http://data.lblod.info/id/besluiten/000f9360-2fcc-11f0-ad19-fbd5cd20271e"
                    property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
                    resource="http://mu.semte.ch/vocabularies/ext/BesluitKlassiekeStijl"
                ></span><span
                    about="http://data.lblod.info/id/besluiten/000f9360-2fcc-11f0-ad19-fbd5cd20271e"
                    property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
                    resource="https://data.vlaanderen.be/id/concept/BesluitType/e96ec8af-6480-4b32-876a-fefe5f0a3793"
                ></span><span
                    property="http://data.europa.eu/eli/ontology#title"
                    content="Decision title"
                    datatype="http://www.w3.org/2001/XMLSchema#string"
                ></span><span
                    property="http://data.europa.eu/eli/ontology#title"
                    content="Decision title edit"
                    datatype="http://www.w3.org/2001/XMLSchema#string"
                ></span><span
                    rev="http://www.w3.org/ns/prov#generated"
                    resource="http://example.org#"
                ></span></div>
            <div data-content-container="true">
                <h4
                    data-indentation-level="0"
                    style=""
                    level="4"
                    indentationlevel="0"
                    alignment="left"
                    property="http://data.europa.eu/eli/ontology#title"
                    about="http://data.lblod.info/id/besluiten/000f9360-2fcc-11f0-ad19-fbd5cd20271e"
                    datatype="http://www.w3.org/2001/XMLSchema#string"
                    lang=""
                    class="say-heading"
                >Decision title edit</h4>
            </div>
        </div>
    </div>
</div>
```
- Notice that the title included in this sample decision is not rdfa-aware (rdfa-attrs are define on the header tag itself, there is not `data-literal-node` attribute...)
- Insert this html in the editor
- The relationship to the title is parsed as a relationship to a literal node
- As the `heading` node itself is not rdfa-aware, it does not have backlinks defined
- Changing the content of the `heading` node works and results in the correct changes in the RDF output

### Challenges/uncertainties
This is not a perfect solution, as heading nodes are (no longer) rdfa-aware.
An alternative solution would be to convert these type of headings to a div node (`block_rdfa`) with a plain `heading` node inside.
AFAIK, resource nodes may not have a `datatype` attribute, while literal nodes always have one.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
