### PR TITLE
relationship-editor: improve UX of entering custom predicate/target option

### DIFF
--- a/.changeset/free-eagles-happen.md
+++ b/.changeset/free-eagles-happen.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Improve UX when entering a custom predicate/target option in the relationship-editor

--- a/packages/ember-rdfa-editor/package.json
+++ b/packages/ember-rdfa-editor/package.json
@@ -306,6 +306,7 @@
     "ember-intl": "^7.1.4",
     "ember-modifier": "^4.2.0",
     "ember-power-select": "^8.6.2",
+    "ember-power-select-with-create": "^3.0.0",
     "ember-source": "^6.1.0",
     "ember-template-lint": "^6.0.0",
     "eslint": "^9.17.0",
@@ -338,6 +339,7 @@
     "ember-concurrency": "^4.0.2",
     "ember-intl": "^6.4.0 || ^7.0.0",
     "ember-power-select": "^7.0.0 || ^8.0.0",
+    "ember-power-select-with-create": "^2.0.0 || ^3.0.0",
     "ember-source": "^4.12.0 || >=5.0.0",
     "tracked-built-ins": "^3.3.0"
   },

--- a/packages/ember-rdfa-editor/src/components/_private/relationship-editor/modals/dev-mode.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/relationship-editor/modals/dev-mode.gts
@@ -8,6 +8,7 @@ import WithUniqueId from '#root/components/_private/utils/with-unique-id.ts';
 import PowerSelect, {
   type Select,
 } from 'ember-power-select/components/power-select';
+import PowerSelectWithCreate from 'ember-power-select-with-create/components/power-select-with-create';
 import { tracked, TrackedObject } from 'tracked-built-ins';
 import { not } from 'ember-truth-helpers';
 import AuButtonGroup from '@appuniversum/ember-appuniversum/components/au-button-group';
@@ -150,74 +151,61 @@ export default class RelationshipEditorDevModeModal extends Component<Relationsh
 
   setPredicate = (
     validationFn: () => void,
-    predicateOption?: PredicateOption,
+    predicateOption?: PredicateOption | string,
   ) => {
     if (!this.data.direction) {
       return;
     }
-    // @ts-expect-error fix PredicateOption types
-    this.data.predicate = predicateOption && {
-      ...predicateOption,
-      direction: this.data.direction,
-    };
+    if (typeof predicateOption === 'string') {
+      const isUri =
+        isFullUri(predicateOption) || isPrefixedUri(predicateOption);
+      if (isUri) {
+        this.data.predicate = {
+          direction: this.data.direction,
+          term: sayDataFactory.namedNode(predicateOption),
+        };
+      }
+    } else {
+      // @ts-expect-error fix PredicateOption types
+      this.data.predicate = predicateOption && {
+        ...predicateOption,
+        direction: this.data.direction,
+      };
+    }
     this.data.target = undefined;
     validationFn();
   };
 
   setTarget = (
     validationFn: () => void,
-    targetOption?: ObjectOption | SubjectOption,
+    targetOption?: ObjectOption | SubjectOption | string,
   ) => {
-    this.data.target = targetOption;
-    validationFn();
-  };
-
-  onPredicateSelectKeydown = (select: Select, event: KeyboardEvent) => {
-    if (this.formElement) {
-      onFormKeyDown(this.formElement, event);
-    }
-    if (
-      event.key === 'Enter' &&
-      select.isOpen &&
-      !select.highlighted &&
-      !!select.searchText
-    ) {
-      const { searchText } = select;
-      const isUri = isFullUri(searchText) || isPrefixedUri(searchText);
-      if (isUri) {
-        select.actions.choose({
-          direction: this.data.direction,
-          term: sayDataFactory.namedNode(searchText),
-        });
-      }
-      return false;
-    }
-    return;
-  };
-
-  onTargetSelectKeydown = (select: Select, event: KeyboardEvent) => {
-    if (this.formElement) {
-      onFormKeyDown(this.formElement, event);
-    }
-    if (
-      event.key === 'Enter' &&
-      select.isOpen &&
-      !select.highlighted &&
-      !!select.searchText
-    ) {
-      const { searchText } = select;
-      const isUri = isFullUri(searchText) || isPrefixedUri(searchText);
+    if (typeof targetOption === 'string') {
+      const isUri = isFullUri(targetOption) || isPrefixedUri(targetOption);
       if (
         this.data.direction === 'property' ||
         (this.data.direction === 'backlink' && isUri)
       ) {
         const term = isUri
-          ? sayDataFactory.namedNode(searchText)
-          : sayDataFactory.literal(searchText);
-        select.actions.choose({ term });
+          ? sayDataFactory.namedNode(targetOption)
+          : sayDataFactory.literal(targetOption);
+        this.data.target = {
+          term,
+        };
       }
-      return false;
+    } else {
+      this.data.target = targetOption;
     }
+    validationFn();
+  };
+
+  buildPowerSelectWithCreateSuggestion = (term: string) => term;
+
+  onPowerSelectKeyDown = (_select: Select, event: KeyboardEvent) => {
+    if (this.formElement) {
+      onFormKeyDown(this.formElement, event);
+    }
+    return true;
   };
 
   get showTargetTermTypeSelector() {
@@ -392,12 +380,14 @@ export default class RelationshipEditorDevModeModal extends Component<Relationsh
                 <AuLabel for={{field.id}}>
                   Predicate
                 </AuLabel>
-                <PowerSelect
+                <PowerSelectWithCreate
                   id={{field.id}}
                   {{this.initialFocus}}
                   @selected={{field.value}}
-                  @onKeydown={{this.onPredicateSelectKeydown}}
+                  @onKeydown={{this.onPowerSelectKeyDown}}
                   @onChange={{fn this.setPredicate field.triggerValidation}}
+                  @onCreate={{fn this.setPredicate field.triggerValidation}}
+                  @buildSuggestion={{this.buildPowerSelectWithCreateSuggestion}}
                   @allowClear={{true}}
                   @options={{this.searchPredicates ""}}
                   @search={{this.searchPredicates}}
@@ -413,7 +403,7 @@ export default class RelationshipEditorDevModeModal extends Component<Relationsh
                   {{#if option.description}}
                     <p>{{option.description}}</p>
                   {{/if}}
-                </PowerSelect>
+                </PowerSelectWithCreate>
                 <field.Errors class="au-u-1-1 au-u-margin-top-tiny" as |errors|>
                   <AuAlert
                     class="au-u-margin-none"
@@ -433,11 +423,13 @@ export default class RelationshipEditorDevModeModal extends Component<Relationsh
                 <AuLabel for={{field.id}}>
                   {{this.targetLabel}}
                 </AuLabel>
-                <PowerSelect
+                <PowerSelectWithCreate
                   id={{field.id}}
                   @selected={{field.value}}
-                  @onKeydown={{this.onTargetSelectKeydown}}
+                  @onKeydown={{this.onPowerSelectKeyDown}}
                   @onChange={{fn this.setTarget field.triggerValidation}}
+                  @onCreate={{fn this.setTarget field.triggerValidation}}
+                  @buildSuggestion={{this.buildPowerSelectWithCreateSuggestion}}
                   @allowClear={{true}}
                   @disabled={{not this.data.predicate}}
                   @options={{this.searchTargets ""}}
@@ -454,7 +446,7 @@ export default class RelationshipEditorDevModeModal extends Component<Relationsh
                   {{#if option.description}}
                     <p>{{option.description}}</p>
                   {{/if}}
-                </PowerSelect>
+                </PowerSelectWithCreate>
                 <field.Errors class="au-u-1-1 au-u-margin-top-tiny" as |errors|>
                   <AuAlert
                     class="au-u-margin-none"

--- a/packages/ember-rdfa-editor/src/components/_private/relationship-editor/modals/dev-mode.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/relationship-editor/modals/dev-mode.gts
@@ -149,6 +149,14 @@ export default class RelationshipEditorDevModeModal extends Component<Relationsh
     this.data.target = undefined;
   };
 
+  isValidPredicate = (term: string) => {
+    if (!term) {
+      return false;
+    }
+    const isUri = isFullUri(term) || isPrefixedUri(term);
+    return isUri;
+  };
+
   setPredicate = (
     validationFn: () => void,
     predicateOption?: PredicateOption | string,
@@ -174,6 +182,17 @@ export default class RelationshipEditorDevModeModal extends Component<Relationsh
     }
     this.data.target = undefined;
     validationFn();
+  };
+
+  isValidTarget = (term: string) => {
+    if (!term) {
+      return false;
+    }
+    const isUri = isFullUri(term) || isPrefixedUri(term);
+    return (
+      this.data.direction === 'property' ||
+      (this.data.direction === 'backlink' && isUri)
+    );
   };
 
   setTarget = (
@@ -387,6 +406,7 @@ export default class RelationshipEditorDevModeModal extends Component<Relationsh
                   @onKeydown={{this.onPowerSelectKeyDown}}
                   @onChange={{fn this.setPredicate field.triggerValidation}}
                   @onCreate={{fn this.setPredicate field.triggerValidation}}
+                  @showCreateWhen={{this.isValidPredicate}}
                   @buildSuggestion={{this.buildPowerSelectWithCreateSuggestion}}
                   @allowClear={{true}}
                   @options={{this.searchPredicates ""}}
@@ -429,6 +449,7 @@ export default class RelationshipEditorDevModeModal extends Component<Relationsh
                   @onKeydown={{this.onPowerSelectKeyDown}}
                   @onChange={{fn this.setTarget field.triggerValidation}}
                   @onCreate={{fn this.setTarget field.triggerValidation}}
+                  @showCreateWhen={{this.isValidTarget}}
                   @buildSuggestion={{this.buildPowerSelectWithCreateSuggestion}}
                   @allowClear={{true}}
                   @disabled={{not this.data.predicate}}

--- a/packages/ember-rdfa-editor/unpublished-development-types/ember-power-select-with-create/components/power-select-with-create.d.ts
+++ b/packages/ember-rdfa-editor/unpublished-development-types/ember-power-select-with-create/components/power-select-with-create.d.ts
@@ -1,0 +1,26 @@
+// Types for ember-power-select-with-create
+declare module 'ember-power-select-with-create/components/power-select-with-create' {
+  import Component from '@glimmer/component';
+  import type {
+    PowerSelectArgs,
+    Select,
+  } from 'ember-power-select/components/power-select';
+
+  export interface PowerSelectWithCreateArgs extends PowerSelectArgs {
+    onCreate: (term: string) => unknown;
+    powerSelectComponent?: Component;
+    showCreateWhen?: (term: string, options: unknown[]) => boolean;
+    showCreatePosition?: 'bottom' | 'top';
+    buildSuggestion?: (term: string) => string;
+  }
+  // Copied from PS 8.0 types
+  type PowerSelectWithCreateSig = {
+    Element: HTMLElement;
+    Args: PowerSelectWithCreateArgs;
+    Blocks: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      default: [option: any, select: Select];
+    };
+  };
+  export default class PowerSelectWithCreateComponent extends Component<PowerSelectWithCreateSig> {}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,9 @@ importers:
       ember-power-select:
         specifier: ^8.6.2
         version: 8.7.0(cb2c0d618287fa9ef2cd07bd37da1082)
+      ember-power-select-with-create:
+        specifier: ^3.0.0
+        version: 3.0.1(09b1686bdff68629992e1c5df944d7c1)
       ember-source:
         specifier: ^6.1.0
         version: 6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)
@@ -584,6 +587,9 @@ importers:
       ember-power-select:
         specifier: ^8.7.0
         version: 8.7.0(cb2c0d618287fa9ef2cd07bd37da1082)
+      ember-power-select-with-create:
+        specifier: ^3.0.0
+        version: 3.0.1(09b1686bdff68629992e1c5df944d7c1)
       ember-qunit:
         specifier: ^9.0.0
         version: 9.0.2(@ember/test-helpers@4.0.5(@babel/core@7.26.9)(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)))(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))(qunit@2.24.1)
@@ -1630,6 +1636,10 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
+
+  '@embroider/addon-shim@1.10.0':
+    resolution: {integrity: sha512-gcJuHiXgnrzaU8NyU+2bMbtS6PNOr5v5B8OXBqaBvTCsMpXLvKo8OBOQFCoUN0rPX2J6VaFqrbi/371sMvzZug==}
+    engines: {node: 12.* || 14.* || >= 16}
 
   '@embroider/addon-shim@1.9.0':
     resolution: {integrity: sha512-fMzayl/licUL8VRAy4qXROKcYvHwUbV8aTh4m97L5/MRuVpxbcAy92DGGTqx5OBKCSQN3gMg+sUKeE6AviefpQ==}
@@ -5263,6 +5273,13 @@ packages:
     peerDependencies:
       ember-source: '>= 3.28.0'
 
+  ember-power-select-with-create@3.0.1:
+    resolution: {integrity: sha512-Jq+/5LleUWpHRBOKzvz0URrhzRlpE451R0AHg4z7bMSYZCLtPXcSUBR8/5qKelp01ACzpY1kTZu6iOBQwVALiQ==}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2 || ^2.0.0
+      ember-basic-dropdown: ^8.6.1
+      ember-power-select: ^8.7.1
+
   ember-power-select@8.7.0:
     resolution: {integrity: sha512-9T9M5QqgmAYORxxwiz4A9Hm8cZPWFsliIM8X2UVnQpO8Zd+oU/grIIF5MFkv2xTa9HGWCEvwnVRRUSPqFRBW7Q==}
     peerDependencies:
@@ -6973,6 +6990,7 @@ packages:
     resolution: {integrity: sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
+    bundledDependencies: []
 
   jsonfile@2.4.0:
     resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}
@@ -11817,6 +11835,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@embroider/addon-shim@1.10.0':
+    dependencies:
+      '@embroider/shared-internals': 3.0.0
+      broccoli-funnel: 3.0.8
+      common-ancestor-path: 1.0.1
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@embroider/addon-shim@1.9.0':
     dependencies:
       '@embroider/shared-internals': 2.9.0
@@ -16582,6 +16609,21 @@ snapshots:
       '@simple-dom/document': 1.4.0
       ember-source: 6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)
     transitivePeerDependencies:
+      - supports-color
+
+  ember-power-select-with-create@3.0.1(09b1686bdff68629992e1c5df944d7c1):
+    dependencies:
+      '@embroider/addon-shim': 1.10.0
+      '@embroider/util': 1.13.2(@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))))(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))
+      '@glimmer/component': 1.1.2(@babel/core@7.26.9)
+      decorator-transforms: 2.3.0(@babel/core@7.26.9)
+      ember-basic-dropdown: 8.6.0(@babel/core@7.26.9)(@ember/string@4.0.1)(@ember/test-helpers@4.0.5(@babel/core@7.26.9)(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)))(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.5.2(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.2.0(@babel/core@7.26.9)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))))(@glint/template@1.5.2)(ember-source@6.2.0(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))
+      ember-power-select: 8.7.0(cb2c0d618287fa9ef2cd07bd37da1082)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/environment-ember-loose'
+      - '@glint/template'
+      - ember-source
       - supports-color
 
   ember-power-select@8.7.0(cb2c0d618287fa9ef2cd07bd37da1082):

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -96,6 +96,7 @@
     "ember-modifier": "^4.2.0",
     "ember-page-title": "^8.2.3",
     "ember-power-select": "^8.7.0",
+    "ember-power-select-with-create": "^3.0.0",
     "ember-qunit": "^9.0.0",
     "ember-resolver": "^13.1.0",
     "ember-source": "^6.1.0",


### PR DESCRIPTION
### Overview
This PR adds the `ember-power-select-with-create` (https://github.com/cibernox/ember-power-select-with-create) dependency to improve the UX of entering custom predicate/target option in the dev-mode version of the relationship editor.

### How to test/reproduce
- Start the test-app and open the editable nodes page
- Open the relationship-editor modal in dev-mode
- Enter a valid term in the search field
- Ensure an additional option in the list of options (on top) now appears corresponding with your current search query

### Challenges/uncertainties
- The main caveat here is that we need to wait for the `options` promise to resolve before showing the custom option.
- We might also want to apply the same UX to the user-facing relationship-editor modal.


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
