### PR TITLE
Add controller block param to editor-container to avoid undefined checks

### DIFF
--- a/.changeset/wild-humans-cry.md
+++ b/.changeset/wild-humans-cry.md
@@ -1,6 +1,7 @@
 ---
-'@lblod/ember-rdfa-editor': major
+'@lblod/ember-rdfa-editor': minor
 ---
 
-Add always defined controller block param to EditorContainer to allow cutting down on boilerplate is-not-undefined checks in editor components
-BREAKING: it is now necessary to pass a SayController to the EditorContainer component
+Add always defined controller block param to EditorContainer to allow cutting down on boilerplate is-not-undefined checks in editor components.
+This requires a SayController be passed to EditorContainer.
+For backwards compatibility, the blocks that are only shown when the controller exists are named differently to the previous blocks.

--- a/.changeset/wild-humans-cry.md
+++ b/.changeset/wild-humans-cry.md
@@ -1,0 +1,6 @@
+---
+'@lblod/ember-rdfa-editor': major
+---
+
+Add always defined controller block param to EditorContainer to allow cutting down on boilerplate is-not-undefined checks in editor components
+BREAKING: it is now necessary to pass a SayController to the EditorContainer component

--- a/packages/ember-rdfa-editor/src/components/editor-container.gts
+++ b/packages/ember-rdfa-editor/src/components/editor-container.gts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { hash } from '@ember/helper';
-import { and } from 'ember-truth-helpers';
+import { and, or } from 'ember-truth-helpers';
 import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
 import t from 'ember-intl/helpers/t';
 import type { Option } from '#root/utils/_private/option.ts';
@@ -22,8 +22,12 @@ type Signature = {
   };
   Blocks: {
     default: [];
-    top: [{ controller: SayController }];
-    aside: [{ controller: SayController }];
+    /** @deprecated Using top is deprecated. Pass a controller and use toolbar instead */
+    top: [];
+    /** @deprecated Using aside is deprecated. Pass a controller and use sidebarRight instead */
+    aside: [];
+    toolbar: [{ controller: SayController }];
+    sidebarRight: [{ controller: SayController }];
   };
 };
 
@@ -49,13 +53,20 @@ export default class EditorContainer extends Component<Signature> {
         {{if this.showPaper 'say-container--paper'}}
         {{if this.showSidebarLeft 'say-container--sidebar-left'}}
         {{if
-          (and (has-block 'aside') this.showSidebarRight)
+          (and
+            (or (has-block 'aside') (has-block 'sidebarRight'))
+            this.showSidebarRight
+          )
           'say-container--sidebar-right'
         }}
         {{if this.showToolbarBottom 'say-container--toolbar-bottom'}}"
     >
-      {{#if @controller}}
-        {{yield (hash controller=@controller) to="top"}}
+      {{#if (has-block "top")}}
+        {{yield to="top"}}
+      {{else if (has-block "toolbar")}}
+        {{#if @controller}}
+          {{yield (hash controller=@controller) to="toolbar"}}
+        {{/if}}
       {{/if}}
       <div class="say-container__main">
         {{#if @loading}}
@@ -68,10 +79,17 @@ export default class EditorContainer extends Component<Signature> {
           {{yield}}
 
         </div>
-        {{#if (and (has-block "aside") this.showSidebarRight)}}
+        {{#if
+          (and
+            (or (has-block "aside") (has-block "sidebarRight"))
+            this.showSidebarRight
+          )
+        }}
           <div class="say-container__aside">
-            {{#if @controller}}
-              {{yield (hash controller=@controller) to="aside"}}
+            {{#if (has-block "aside")}}
+              {{yield to="aside"}}
+            {{else if @controller}}
+              {{yield (hash controller=@controller) to="sidebarRight"}}
             {{/if}}
           </div>
         {{/if}}

--- a/packages/ember-rdfa-editor/src/components/editor-container.gts
+++ b/packages/ember-rdfa-editor/src/components/editor-container.gts
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
+import { hash } from '@ember/helper';
 import { and } from 'ember-truth-helpers';
 import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
 import t from 'ember-intl/helpers/t';
+import type { Option } from '#root/utils/_private/option.ts';
+import type SayController from '#root/core/say-controller.ts';
 
 type EditorOptions = {
   showPaper?: boolean;
@@ -13,15 +16,17 @@ type EditorOptions = {
 type Signature = {
   Element: HTMLDivElement;
   Args: {
+    controller: Option<SayController>;
     editorOptions?: EditorOptions;
     loading?: boolean;
   };
   Blocks: {
     default: [];
-    top: [];
-    aside: [];
+    top: [{ controller: SayController }];
+    aside: [{ controller: SayController }];
   };
 };
+
 export default class EditorContainer extends Component<Signature> {
   get showPaper() {
     return this.args.editorOptions?.showPaper ?? false;
@@ -49,7 +54,9 @@ export default class EditorContainer extends Component<Signature> {
         }}
         {{if this.showToolbarBottom 'say-container--toolbar-bottom'}}"
     >
-      {{yield to="top"}}
+      {{#if @controller}}
+        {{yield (hash controller=@controller) to="top"}}
+      {{/if}}
       <div class="say-container__main">
         {{#if @loading}}
           <AuLoader @hideMessage={{true}}>
@@ -63,7 +70,9 @@ export default class EditorContainer extends Component<Signature> {
         </div>
         {{#if (and (has-block "aside") this.showSidebarRight)}}
           <div class="say-container__aside">
-            {{yield to="aside"}}
+            {{#if @controller}}
+              {{yield (hash controller=@controller) to="aside"}}
+            {{/if}}
           </div>
         {{/if}}
       </div>

--- a/packages/ember-rdfa-editor/src/components/editor-container.gts
+++ b/packages/ember-rdfa-editor/src/components/editor-container.gts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { hash } from '@ember/helper';
+import { deprecate } from '@ember/debug';
 import { and, or } from 'ember-truth-helpers';
 import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
 import t from 'ember-intl/helpers/t';
@@ -16,7 +17,8 @@ type EditorOptions = {
 type Signature = {
   Element: HTMLDivElement;
   Args: {
-    controller: Option<SayController>;
+    // TODO in the next major release, this should become `controller: Option<SayController>`
+    controller?: Option<SayController>;
     editorOptions?: EditorOptions;
     loading?: boolean;
   };
@@ -32,6 +34,24 @@ type Signature = {
 };
 
 export default class EditorContainer extends Component<Signature> {
+  constructor(owner: unknown, args: Signature['Args']) {
+    super(owner, args);
+
+    deprecate(
+      'EditorContainer now requires a controller argument, so that it can pass this to child blocks when it exists',
+      'controller' in args,
+      {
+        id: '@lblod/ember-rdfa-editor.editor-container.controller-argument',
+        until: '13.0.0',
+        for: '@lblod/ember-rdfa-editor',
+        since: {
+          available: '12.11.0',
+          enabled: '12.11.0',
+        },
+      },
+    );
+  }
+
   get showPaper() {
     return this.args.editorOptions?.showPaper ?? false;
   }

--- a/test-app/app/templates/editable-node.hbs
+++ b/test-app/app/templates/editable-node.hbs
@@ -8,7 +8,7 @@
       @controller={{this.rdfaEditor}}
       @editorOptions={{hash showPaper="true" showToolbarBottom=null}}
     >
-      <:top as |container|>
+      <:toolbar as |container|>
         <SampleToolbarResponsive
           @controller={{container.controller}}
           @enableHierarchicalList={{true}}
@@ -19,7 +19,7 @@
             @onToggle={{this.onDevModeToggle}}
           />
         </SampleToolbarResponsive>
-      </:top>
+      </:toolbar>
       <:default>
         <Editor
           @plugins={{this.plugins}}
@@ -28,7 +28,7 @@
           @rdfaEditorInit={{this.rdfaEditorInit}}
         />
       </:default>
-      <:aside as |container|>
+      <:sidebarRight as |container|>
         <Sidebar as |Sb|>
           <Sb.Collapsible
             @title={{t "ember-rdfa-editor.insert"}}
@@ -82,7 +82,7 @@
             </div>
           {{/if}}
         </Sidebar>
-      </:aside>
+      </:sidebarRight>
     </EditorContainer>
   </:content>
 </DummyContainer>

--- a/test-app/app/templates/editable-node.hbs
+++ b/test-app/app/templates/editable-node.hbs
@@ -5,15 +5,16 @@
   </:header>
   <:content>
     <EditorContainer
+      @controller={{this.rdfaEditor}}
       @editorOptions={{hash showPaper="true" showToolbarBottom=null}}
     >
-      <:top>
+      <:top as |container|>
         <SampleToolbarResponsive
-          @controller={{this.rdfaEditor}}
+          @controller={{container.controller}}
           @enableHierarchicalList={{true}}
         >
           <this.DevModeToggle
-            @controller={{this.rdfaEditor}}
+            @controller={{container.controller}}
             @enabled={{this.devMode}}
             @onToggle={{this.onDevModeToggle}}
           />
@@ -27,7 +28,7 @@
           @rdfaEditorInit={{this.rdfaEditorInit}}
         />
       </:default>
-      <:aside>
+      <:aside as |container|>
         <Sidebar as |Sb|>
           <Sb.Collapsible
             @title={{t "ember-rdfa-editor.insert"}}
@@ -36,46 +37,46 @@
           >
             <Item>
               <this.CreateRelationshipButton
-                @controller={{this.rdfaEditor}}
+                @controller={{container.controller}}
                 @node={{this.activeNode}}
                 @optionGeneratorConfig={{this.optionGeneratorConfigTaskified}}
                 @devMode={{this.devMode}}
               />
             </Item>
           </Sb.Collapsible>
-          <Plugins::Link::LinkEditor @controller={{this.rdfaEditor}} />
+          <Plugins::Link::LinkEditor @controller={{container.controller}} />
           {{#if this.devMode}}
             <div class="au-u-flex au-u-flex--column au-u-flex--spaced-tiny">
               <this.VisualiserCard
-                @controller={{this.rdfaEditor}}
+                @controller={{container.controller}}
                 @config={{this.rdfa.visualizerConfig}}
               />
               <this.NodeControlsCard
                 @node={{this.activeNode}}
-                @controller={{this.rdfaEditor}}
+                @controller={{container.controller}}
               />
               {{#if this.activeNode}}
                 <this.RelationshipEditorCard
                   @node={{this.activeNode}}
-                  @controller={{this.rdfaEditor}}
+                  @controller={{container.controller}}
                   @optionGeneratorConfig={{this.optionGeneratorConfigTaskified}}
                 />
                 <this.DocImportedResourceEditorCard
-                  @controller={{this.rdfaEditor}}
+                  @controller={{container.controller}}
                   @optionGeneratorConfig={{this.optionGeneratorConfigTaskified}}
                 />
                 <this.ImportedResourceLinkerCard
                   @node={{this.activeNode}}
-                  @controller={{this.rdfaEditor}}
+                  @controller={{container.controller}}
                 />
                 <this.ExternalTripleEditorCard
                   @node={{this.activeNode}}
-                  @controller={{this.rdfaEditor}}
+                  @controller={{container.controller}}
                 />
                 <this.DebugInfo @node={{this.activeNode}} />
                 <this.AttributeEditor
                   @node={{this.activeNode}}
-                  @controller={{this.rdfaEditor}}
+                  @controller={{container.controller}}
                 />
               {{/if}}
             </div>

--- a/test-app/app/templates/index.hbs
+++ b/test-app/app/templates/index.hbs
@@ -30,11 +30,11 @@
           <Plugins::Table::TableTooltip @controller={{this.rdfaEditor}} />
         {{/if}}
       </:default>
-      <:aside as |container|>
+      <:sidebarRight as |container|>
         <Sidebar>
           <Plugins::Link::LinkEditor @controller={{container.controller}} />
         </Sidebar>
-      </:aside>
+      </:sidebarRight>
     </EditorContainer>
   </:content>
 </DummyContainer>

--- a/test-app/app/templates/index.hbs
+++ b/test-app/app/templates/index.hbs
@@ -5,6 +5,7 @@
   </:header>
   <:content>
     <EditorContainer
+      @controller={{this.rdfaEditor}}
       @editorOptions={{hash
         showPaper=true
         showToolbarBottom=null
@@ -12,9 +13,9 @@
         showSidebarRight=false
       }}
     >
-      <:top>
+      <:top as |container|>
         <SampleToolbarResponsive
-          @controller={{this.rdfaEditor}}
+          @controller={{container.controller}}
           @enableHierarchicalList={{true}}
         />
       </:top>
@@ -29,9 +30,9 @@
           <Plugins::Table::TableTooltip @controller={{this.rdfaEditor}} />
         {{/if}}
       </:default>
-      <:aside>
+      <:aside as |container|>
         <Sidebar>
-          <Plugins::Link::LinkEditor @controller={{this.rdfaEditor}} />
+          <Plugins::Link::LinkEditor @controller={{container.controller}} />
         </Sidebar>
       </:aside>
     </EditorContainer>

--- a/test-app/app/templates/index.hbs
+++ b/test-app/app/templates/index.hbs
@@ -13,12 +13,12 @@
         showSidebarRight=false
       }}
     >
-      <:top as |container|>
+      <:toolbar as |container|>
         <SampleToolbarResponsive
           @controller={{container.controller}}
           @enableHierarchicalList={{true}}
         />
-      </:top>
+      </:toolbar>
       <:default>
         <Editor
           @plugins={{this.plugins}}

--- a/test-app/app/templates/plugins.hbs
+++ b/test-app/app/templates/plugins.hbs
@@ -5,10 +5,11 @@
   </:header>
   <:content>
     <EditorContainer
+      @controller={{this.rdfaEditor}}
       @editorOptions={{hash showPaper=true showToolbarBottom=null}}
     >
-      <:top>
-        <SampleToolbarResponsive @controller={{this.rdfaEditor}} />
+      <:top as |container|>
+        <SampleToolbarResponsive @controller={{container.controller}} />
       </:top>
       <:default>
         <Editor
@@ -18,11 +19,11 @@
           @rdfaEditorInit={{this.rdfaEditorInit}}
         />
       </:default>
-      <:aside>
+      <:aside as |container|>
         <SampleEmberNodes::Sidebar
           @expanded={{this.sidebarExpanded}}
           @onToggle={{this.onSidebarToggle}}
-          @controller={{this.rdfaEditor}}
+          @controller={{container.controller}}
         />
       </:aside>
     </EditorContainer>

--- a/test-app/app/templates/plugins.hbs
+++ b/test-app/app/templates/plugins.hbs
@@ -8,9 +8,9 @@
       @controller={{this.rdfaEditor}}
       @editorOptions={{hash showPaper=true showToolbarBottom=null}}
     >
-      <:top as |container|>
+      <:toolbar as |container|>
         <SampleToolbarResponsive @controller={{container.controller}} />
-      </:top>
+      </:toolbar>
       <:default>
         <Editor
           @plugins={{this.plugins}}
@@ -19,13 +19,13 @@
           @rdfaEditorInit={{this.rdfaEditorInit}}
         />
       </:default>
-      <:aside as |container|>
+      <:sidebarRight as |container|>
         <SampleEmberNodes::Sidebar
           @expanded={{this.sidebarExpanded}}
           @onToggle={{this.onSidebarToggle}}
           @controller={{container.controller}}
         />
-      </:aside>
+      </:sidebarRight>
     </EditorContainer>
   </:content>
 </DummyContainer>


### PR DESCRIPTION
### Overview
This should allow editor components such as toolbar buttons and cards to rely on the controller being present, instead of needing to accept `undefined` as a possibility and handle it gracefully.

I re-named the blocks so that the change can be backwards compatible, otherwise it would be a breaking change, as failing to pass a `@controller` argument would prevent the sidebar and toolbar from being rendered. There are some components that could have their `if (this.controller)` checks removed, but I decided not to do that, also for backwards compatibility.

##### connected issues and PRs:
N/A

### Setup
To test the types it's best to test in GN as the `rdfa-editor-container.gts` file is type checked, unlike the usages of EditorContainer in the test app.

### How to test/reproduce
If you pass an undefined controller to EditorContainer, the sidebar and toolbar should not be shown. Otherwise, everything should work as before.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
