### PR TITLE
Fix dropdown bug

### DIFF
--- a/.changeset/rich-sheep-teach.md
+++ b/.changeset/rich-sheep-teach.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix bug with toolbar dropdown

--- a/packages/ember-rdfa-editor/src/components/toolbar/dropdown.gts
+++ b/packages/ember-rdfa-editor/src/components/toolbar/dropdown.gts
@@ -38,9 +38,14 @@ export type ToolbarDropdownSignature = {
 export default class ToolbarDropdown extends Component<ToolbarDropdownSignature> {
   @tracked referenceElement?: Element = undefined;
   @tracked dropdownOpen = false;
+  @tracked dropdownMenu?: Element = undefined;
 
   reference = modifier((element) => {
     this.referenceElement = element;
+  });
+
+  dropdownMenuReference = modifier((element) => {
+    this.dropdownMenu = element;
   });
 
   @action
@@ -102,6 +107,7 @@ export default class ToolbarDropdown extends Component<ToolbarDropdownSignature>
               shouldSelfFocus=true
               focusTrapOptions=(hash
                 clickOutsideDeactivates=this.clickOutsideDeactivates
+                fallbackFocus=this.dropdownMenu
               )
             }}
             class="say-dropdown__menu is-visible
@@ -110,12 +116,14 @@ export default class ToolbarDropdown extends Component<ToolbarDropdownSignature>
             tabindex="-1"
             {{velcro.loop}}
           >
-            {{yield
-              (hash
-                Item=(component DropdownItem onActivate=this.closeDropdown)
-                closeDropdown=this.closeDropdown
-              )
-            }}
+            <div tabindex="-1" {{this.dropdownMenuReference}}>
+              {{yield
+                (hash
+                  Item=(component DropdownItem onActivate=this.closeDropdown)
+                  closeDropdown=this.closeDropdown
+                )
+              }}
+            </div>
           </div>
         {{/if}}
       </Velcro>

--- a/packages/ember-rdfa-editor/src/components/toolbar/dropdown.gts
+++ b/packages/ember-rdfa-editor/src/components/toolbar/dropdown.gts
@@ -103,6 +103,7 @@ export default class ToolbarDropdown extends Component<ToolbarDropdownSignature>
         </button>
         {{#if this.dropdownOpen}}
           <div
+            {{this.dropdownMenuReference}}
             {{focusTrap
               shouldSelfFocus=true
               focusTrapOptions=(hash
@@ -116,14 +117,12 @@ export default class ToolbarDropdown extends Component<ToolbarDropdownSignature>
             tabindex="-1"
             {{velcro.loop}}
           >
-            <div tabindex="-1" {{this.dropdownMenuReference}}>
-              {{yield
-                (hash
-                  Item=(component DropdownItem onActivate=this.closeDropdown)
-                  closeDropdown=this.closeDropdown
-                )
-              }}
-            </div>
+            {{yield
+              (hash
+                Item=(component DropdownItem onActivate=this.closeDropdown)
+                closeDropdown=this.closeDropdown
+              )
+            }}
           </div>
         {{/if}}
       </Velcro>


### PR DESCRIPTION
### Overview
Added a fallback focus so the focus trap doesn't fail anymore

##### connected issues and PRs:
GN-4737


### Setup
None

### How to test/reproduce
Try to get in a gap cursor position where none of the text formatting is enabled, then check that the dropdown still works

### Challenges/uncertainties
Non a keyboard user, the focus seems good to me, but not sure if I broke something weird



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
