### PR TITLE
Feat/disable responsiveness in toolbar

### DIFF
--- a/.changeset/bumpy-paths-peel.md
+++ b/.changeset/bumpy-paths-peel.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix dropdown positioning and the argument to disable the responsiveness of the toolbar

--- a/packages/ember-rdfa-editor/package.json
+++ b/packages/ember-rdfa-editor/package.json
@@ -339,7 +339,7 @@
     "ember-concurrency": "^4.0.2",
     "ember-intl": "^6.4.0 || ^7.0.0",
     "ember-power-select": "^7.0.0 || ^8.0.0",
-    "ember-power-select-with-create": "^3.0.0",
+    "ember-power-select-with-create": "^2.0.0 || ^3.0.0",
     "ember-source": "^4.12.0 || >=5.0.0",
     "tracked-built-ins": "^3.3.0"
   },

--- a/packages/ember-rdfa-editor/package.json
+++ b/packages/ember-rdfa-editor/package.json
@@ -339,7 +339,7 @@
     "ember-concurrency": "^4.0.2",
     "ember-intl": "^6.4.0 || ^7.0.0",
     "ember-power-select": "^7.0.0 || ^8.0.0",
-    "ember-power-select-with-create": "^2.0.0 || ^3.0.0",
+    "ember-power-select-with-create": "^3.0.0",
     "ember-source": "^4.12.0 || >=5.0.0",
     "tracked-built-ins": "^3.3.0"
   },

--- a/packages/ember-rdfa-editor/src/components/_private/relationship-editor/card.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/relationship-editor/card.gts
@@ -58,7 +58,7 @@ import WithUniqueId from '#root/components/_private/utils/with-unique-id.ts';
 import type { ContentLiteralTerm } from '#root/core/say-data-factory/index.js';
 import type { OutgoingTriple } from '#root/core/rdfa-processor.js';
 import { htmlSafe } from '@ember/template';
-import { CheckIcon } from '@appuniversum/ember-appuniversum/components/icons/check.js';
+import { CheckIcon } from '@appuniversum/ember-appuniversum/components/icons/check';
 
 interface StatusMessageForNode extends StatusMessage {
   node: PNode;

--- a/packages/ember-rdfa-editor/src/components/responsive-toolbar.gts
+++ b/packages/ember-rdfa-editor/src/components/responsive-toolbar.gts
@@ -20,6 +20,9 @@ type ToolbarSection = {
 };
 
 type Signature = {
+  Args: {
+    disableResponsiveness?: boolean;
+  };
   Blocks: {
     main: [
       {
@@ -129,6 +132,7 @@ export default class ResponsiveToolbar extends Component<Signature> {
   }
 
   handleResize() {
+    if (this.args.disableResponsiveness) return;
     requestAnimationFrame(() => {
       this.main.enableDropdown = false;
       this.side.enableDropdown = false;

--- a/packages/ember-rdfa-editor/src/components/toolbar/dropdown.gts
+++ b/packages/ember-rdfa-editor/src/components/toolbar/dropdown.gts
@@ -82,7 +82,7 @@ export default class ToolbarDropdown extends Component<ToolbarDropdownSignature>
 
   <template>
     <div class="say-dropdown" ...attributes>
-      <Velcro @placement="bottom" @strategy="absolute" as |velcro|>
+      <Velcro @placement="bottom-start" @strategy="absolute" as |velcro|>
         <button
           {{this.reference}}
           class="say-dropdown__button {{if this.dropdownOpen 'is-active' ''}}"


### PR DESCRIPTION
### Overview
Fix dropdown positioning and the argument to disable the responsiveness of the toolbar

##### connected issues and PRs:
GN-4737


### Setup
None

### How to test/reproduce
Already tested in the GN PR

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
