### PR TITLE
Add context to rdfa-visualiser to say if we're at the top level

### DIFF
--- a/.changeset/mean-waves-begin.md
+++ b/.changeset/mean-waves-begin.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add context to RDFa visualiser components that says if a resource is at the top level so the display can be changed accordingly

--- a/packages/ember-rdfa-editor/src/components/_private/common/configurable-rdfa-display.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/configurable-rdfa-display.gts
@@ -7,11 +7,11 @@ import { trackedFunction } from 'reactiveweb/function';
 import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
 import AuPill from '@appuniversum/ember-appuniversum/components/au-pill';
 import { type OutgoingTriple } from '#root/core/rdfa-processor.ts';
-import type SayController from '#root/core/say-controller.ts';
 import {
   type DisplayElement,
   type DisplayGenerator,
   type DisplayMeta,
+  type GeneratorContext,
 } from '#root/plugins/rdfa-info/types.ts';
 
 interface SpanSig {
@@ -30,8 +30,7 @@ export const predicateDisplay: DisplayGenerator<OutgoingTriple> = (triple) => {
 
 interface Sig<T> {
   Args: {
-    controller: SayController;
-    isTopLevel: boolean;
+    context: GeneratorContext;
     value: T;
     generator: DisplayGenerator<T>;
     wrapper?: ComponentLike<SpanSig>;
@@ -43,10 +42,7 @@ interface Sig<T> {
 
 export default class ConfigurableRdfaDisplay<T> extends Component<Sig<T>> {
   elementConfig = trackedFunction(this, () => {
-    return this.args.generator(this.args.value, {
-      controller: this.args.controller,
-      isTopLevel: this.args.isTopLevel,
-    });
+    return this.args.generator(this.args.value, this.args.context);
   });
   get elements(): DisplayElement[] {
     const conf = this.elementConfig.value;

--- a/packages/ember-rdfa-editor/src/components/_private/common/configurable-rdfa-display.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/configurable-rdfa-display.gts
@@ -31,6 +31,7 @@ export const predicateDisplay: DisplayGenerator<OutgoingTriple> = (triple) => {
 interface Sig<T> {
   Args: {
     controller: SayController;
+    isTopLevel: boolean;
     value: T;
     generator: DisplayGenerator<T>;
     wrapper?: ComponentLike<SpanSig>;
@@ -44,6 +45,7 @@ export default class ConfigurableRdfaDisplay<T> extends Component<Sig<T>> {
   elementConfig = trackedFunction(this, () => {
     return this.args.generator(this.args.value, {
       controller: this.args.controller,
+      isTopLevel: this.args.isTopLevel,
     });
   });
   get elements(): DisplayElement[] {

--- a/packages/ember-rdfa-editor/src/components/_private/doc-imported-resource-editor/card.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/doc-imported-resource-editor/card.gts
@@ -97,12 +97,8 @@ export default class DocImportedResourceEditorCard extends Component<Sig> {
     this.args.onToggle?.(this.expanded);
   };
 
-  get controller() {
-    return this.args.controller;
-  }
-
   get documentNode() {
-    return this.controller.mainEditorState.doc;
+    return this.args.controller.mainEditorState.doc;
   }
 
   getSubjectPropertyMap(): Record<string, OutgoingTriple[]> {
@@ -352,6 +348,7 @@ export default class DocImportedResourceEditorCard extends Component<Sig> {
                               @value={{prop}}
                               @generator={{predicateDisplay}}
                               @controller={{@controller}}
+                              @isTopLevel={{false}}
                             />
                           {{/if}}
                           <PropertyDetails

--- a/packages/ember-rdfa-editor/src/components/_private/doc-imported-resource-editor/card.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/doc-imported-resource-editor/card.gts
@@ -43,6 +43,7 @@ import type { FormData } from '../relationship-editor/modals/dev-mode.gts';
 import { array } from '@ember/helper';
 import type { OptionGeneratorConfig } from '../relationship-editor/types.ts';
 import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
+import { hash } from '@ember/helper';
 
 type CreationStatus = {
   mode: 'creation';
@@ -347,8 +348,10 @@ export default class DocImportedResourceEditorCard extends Component<Sig> {
                             <ConfigurableRdfaDisplay
                               @value={{prop}}
                               @generator={{predicateDisplay}}
-                              @controller={{@controller}}
-                              @isTopLevel={{false}}
+                              @context={{hash
+                                controller=@controller
+                                isTopLevel=false
+                              }}
                             />
                           {{/if}}
                           <PropertyDetails

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-visualiser/rdfa-explorer.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-visualiser/rdfa-explorer.gts
@@ -84,6 +84,7 @@ export default class RdfaExplorer extends Component<Sig> {
             @wrapper={{Item}}
             @controller={{@controller}}
             @subject={{subject}}
+            @isTopLevel={{true}}
             @displayConfig={{@config.displayConfig}}
           />
         {{/each}}

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-visualiser/resource-info.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-visualiser/resource-info.gts
@@ -19,6 +19,7 @@ import { ExternalLinkIcon } from '@appuniversum/ember-appuniversum/components/ic
 import PropertyDetails from '#root/components/_private/common/property-details.gts';
 import type {
   DisplayGenerator,
+  GeneratorContext,
   RdfaVisualizerConfig,
 } from '#root/plugins/rdfa-info/types.ts';
 import { get } from '@ember/helper';
@@ -101,6 +102,11 @@ export default class ResourceInfo extends Component<ResourceInfoSig> {
     return (this.node?.attrs['properties'] as OutgoingTriple[]) ?? [];
   }
 
+  generatorContext = (isTopLevel: boolean): GeneratorContext => ({
+    controller: this.args.controller,
+    isTopLevel,
+  });
+
   toggleExpanded = () => {
     this.expanded = !this.expanded;
   };
@@ -117,8 +123,7 @@ export default class ResourceInfo extends Component<ResourceInfoSig> {
       <ConfigurableRdfaDisplay
         @value={{this.node}}
         @generator={{or @displayConfig.ResourceNode backupResourceDisplay}}
-        @controller={{@controller}}
-        @isTopLevel={{@isTopLevel}}
+        @context={{this.generatorContext @isTopLevel}}
         @wrapper={{component
           ResourceNodeWrapper
           expanded=this.expanded
@@ -140,8 +145,7 @@ export default class ResourceInfo extends Component<ResourceInfoSig> {
               <ConfigurableRdfaDisplay
                 @value={{prop}}
                 @generator={{or @displayConfig.predicate predicateDisplay}}
-                @controller={{@controller}}
-                @isTopLevel={{false}}
+                @context={{this.generatorContext false}}
                 @wrapper={{Item}}
               >
                 {{#if (eq prop.object.termType "ResourceNode")}}
@@ -157,7 +161,7 @@ export default class ResourceInfo extends Component<ResourceInfoSig> {
                     @value={{prop}}
                     {{! @glint-expect-error }}
                     @generator={{get @displayConfig prop.object.termType}}
-                    @controller={{@controller}}
+                    @context={{this.generatorContext false}}
                   />
                 {{else}}
                   <PropertyDetails @prop={{prop}} @controller={{@controller}} />

--- a/packages/ember-rdfa-editor/src/components/_private/rdfa-visualiser/resource-info.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/rdfa-visualiser/resource-info.gts
@@ -76,6 +76,7 @@ export interface ResourceInfoSig {
   Args: {
     controller: SayController;
     subject: string;
+    isTopLevel: boolean;
     // In theory this could be used for optimisation but currently it is not...
     node?: PNode;
     expanded?: boolean;
@@ -85,7 +86,7 @@ export interface ResourceInfoSig {
 }
 
 export default class ResourceInfo extends Component<ResourceInfoSig> {
-  @localCopy('args.localCopy') expanded = false;
+  @localCopy('args.expanded') expanded = false;
 
   get node(): PNode | undefined {
     return (
@@ -117,6 +118,7 @@ export default class ResourceInfo extends Component<ResourceInfoSig> {
         @value={{this.node}}
         @generator={{or @displayConfig.ResourceNode backupResourceDisplay}}
         @controller={{@controller}}
+        @isTopLevel={{@isTopLevel}}
         @wrapper={{component
           ResourceNodeWrapper
           expanded=this.expanded
@@ -139,12 +141,14 @@ export default class ResourceInfo extends Component<ResourceInfoSig> {
                 @value={{prop}}
                 @generator={{or @displayConfig.predicate predicateDisplay}}
                 @controller={{@controller}}
+                @isTopLevel={{false}}
                 @wrapper={{Item}}
               >
                 {{#if (eq prop.object.termType "ResourceNode")}}
                   <ResourceInfo
                     @controller={{@controller}}
                     @subject={{prop.object.value}}
+                    @isTopLevel={{false}}
                     @displayConfig={{@displayConfig}}
                   />
                 {{else if (get @displayConfig prop.object.termType)}}

--- a/packages/ember-rdfa-editor/src/components/_private/relationship-editor/card.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/relationship-editor/card.gts
@@ -25,7 +25,7 @@ import AuToolbar from '@appuniversum/ember-appuniversum/components/au-toolbar';
 import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 import { PlusIcon } from '@appuniversum/ember-appuniversum/components/icons/plus';
 import { on } from '@ember/modifier';
-import { fn } from '@ember/helper';
+import { fn, hash } from '@ember/helper';
 import AuList from '@appuniversum/ember-appuniversum/components/au-list';
 import ConfigurableRdfaDisplay, {
   predicateDisplay,
@@ -443,7 +443,10 @@ export default class RelationshipEditorCard extends Component<Args> {
                       <ConfigurableRdfaDisplay
                         @value={{prop}}
                         @generator={{predicateDisplay}}
-                        @controller={{@controller}}
+                        @context={{hash
+                          controller=@controller
+                          isTopLevel=false
+                        }}
                       />
                       <PropertyDetails
                         @controller={{@controller}}

--- a/packages/ember-rdfa-editor/src/plugins/rdfa-info/types.ts
+++ b/packages/ember-rdfa-editor/src/plugins/rdfa-info/types.ts
@@ -19,8 +19,9 @@ export type DisplayConfig =
   | { meta: DisplayMeta; elements: DisplayElement[] }
   | DisplayElement[];
 
-interface GeneratorContext {
+export interface GeneratorContext {
   controller: SayController;
+  isTopLevel: boolean;
 }
 export type DisplayGenerator<T> = (
   value: T,

--- a/test-app/app/templates/editable-node.gts
+++ b/test-app/app/templates/editable-node.gts
@@ -148,7 +148,7 @@ const RDF = namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'rdf');
 
 const humanReadableResourceName: DisplayGenerator<PNode> = (
   node,
-  { controller },
+  { controller, isTopLevel },
 ) => {
   const subject = node.attrs['subject'] as string;
   const type = optionMap(
@@ -168,6 +168,11 @@ const humanReadableResourceName: DisplayGenerator<PNode> = (
         { pill: 'Besluit' },
         titleNode?.value.textContent ?? title ?? subject,
       ];
+    } else if (
+      type === 'http://mu.semte.ch/vocabularies/ext/Snippet' &&
+      isTopLevel
+    ) {
+      return [{ hidden: true }];
     } else {
       return [{ strong: `${type.split(/[/#]/).at(-1)}:` }, subject];
     }


### PR DESCRIPTION
### Overview
Allows for hiding elements only when they are not part of a hierarchy for example, snippets.

##### connected issues and PRs:
Related to https://github.com/lblod/ember-rdfa-editor/pull/1333

### Setup
N/A

### How to test/reproduce
In the editable-nodes sample, Snippets should be hidden from the top level, so pasting in HTML with snippets should not display them in the top level (even if the nodespecs don't work for obvious reasons). Linking any resource to the snippet should allow it to appear in the visualiser in the correct place.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
