### PR TITLE
Fix article parsing

### DIFF
--- a/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/post-process-as-rdfa-nodes.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/post-process-as-rdfa-nodes.ts
@@ -136,8 +136,9 @@ export function postProcessTagAsRdfaNode<N>(args: PostProcessArgs<N>): void {
         if (
           truthyAttribute(attributes, 'about') &&
           !truthyAttribute(attributes, 'data-literal-node') &&
-          // Is this correct, an alternative solution would be to check on the presence of a `resource` attr here?
-          !truthyAttribute(attributes, 'datatype')
+          // temporary workaround for parsing bugs, needs rdfa handling rework
+          // to fully solve
+          !hackyCheckIfOldLiteralNode(node as unknown as Node, attributes, 3)
         ) {
           // same exception as above, we always interpret (property +about -content) cases as literal nodes
           markAsResourceNode(
@@ -230,6 +231,50 @@ function truthyAttribute(attrs: Record<string, string>, key: string) {
       return false;
     }
     return true;
+  }
+  return false;
+}
+/**
+ * With the current parsing logic there exists an ambiguity between
+ * resource nodes with a contentLiteral, and literal nodes. They both
+ * manifest in the same way in the html.
+ * In most cases this ambiguity is resolved by the data-literal-node
+ * attribute we add in newly created documents. However, there are still old
+ * documents where this was not added. This function attempts to solve for
+ * those specific cases we have identified, pending a rework of the rdfa
+ * system.
+ *
+ * The function attempts to find a parentnode which defines the resource
+ * the node is pointing to. If it exists, we can be reasonably certain this
+ * is intended to be a literal node.
+ *
+ * @param node The node being checked
+ * @param attributes the attributes of the node
+ * @param [searchDepthLimit=2] a safety limit for searching upwards to find
+ * a defining resource node
+ */
+function hackyCheckIfOldLiteralNode(
+  node: Node,
+  attributes: Record<string, string>,
+  searchDepthLimit = 2,
+): boolean {
+  const subject = attributes['about'];
+  if (!subject) {
+    return false;
+  }
+  let parent = node.parentElement;
+  if (!parent) {
+    return false;
+  }
+  let depth = 0;
+
+  while (parent && depth < searchDepthLimit) {
+    const parentSubject = parent.getAttribute('about');
+    if (parentSubject && parentSubject === subject) {
+      return true;
+    }
+    parent = parent.parentElement;
+    depth += 1;
   }
   return false;
 }

--- a/test-app/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/test-app/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -825,4 +825,35 @@ module('rdfa | parsing', function () {
     const actualDoc = controller.mainEditorState.doc;
     assert.propEqual(actualDoc.toJSON(), expectedDoc.toJSON());
   });
+
+  test('Resource nodes with contentLiterals should not be parsed as literalnodes', function (assert) {
+    const { doc, block_rdfa, paragraph } = testBuilders;
+    const df = new SayDataFactory();
+    const initialDocument = doc(
+      {},
+      block_rdfa(
+        {
+          rdfaNodeType: 'resource',
+          subject: 'http://test/1',
+          __rdfaId: 'test-id-1',
+          properties: [
+            {
+              predicate: 'http://example.org/contentLiteral',
+              object: df.contentLiteral(
+                df.namedNode('http://example.org/someDatatype'),
+              ),
+            },
+          ] satisfies OutgoingTriple[],
+        },
+        paragraph(),
+      ),
+    );
+    QUnit.dump.maxDepth = 10;
+    const state = EditorState.create({ schema, plugins, doc: initialDocument });
+    const { controller } = testEditor(schema, plugins, state);
+    const initialRender = controller.htmlContent;
+    controller.initialize(initialRender);
+    const resultingDocument = controller.mainEditorState.doc;
+    assert.propEqual(resultingDocument.toJSON(), initialDocument.toJSON());
+  });
 });


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

PR [#1323](https://github.com/lblod/ember-rdfa-editor/pull/1323) added a check to recognize older-style literal nodes (without a data-literal-node attribute). 
Unfortunately, this check also caught resource-nodes with a contentLiteral that also had a datatype, resulting in articles no longer being parsed correctly.

This uncovered a fatal flaw in the current parsing logic: there is no way to differentiate resource-nodes with contentLiterals from literalnodes, 
based on rdfa only (i.e. in documents not made by the editor, or older editor documents). 

I investigated what a long-term solution would look like, and I think it will involve a rethink of resource nodes and literal nodes, 
most likely dropping the idea of resource nodes altogether (and only keeping literal nodes). However, that would involve too much rewriting to do in a reasonable time.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->
[GN-5676](https://binnenland.atlassian.net/browse/GN-5676)

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

A test is added to check for the erroneous parsing. 
To test the original problem, link in the plugins using the `file:` protocol,
and check that articles now correctly survive a page reload, while also avoiding
the problems that were discovered in pr #1323

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->

It's a hack that specifically targets the failure case that was discussed  in
#1323, while the original solution attempted a more broad coverage. There is a
chance there are other failure cases that we didn't know about.



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
