### PR TITLE
Add preliminary support for data model migrations to inline-rdfa nodes

### DIFF
--- a/.changeset/famous-squids-swim.md
+++ b/.changeset/famous-squids-swim.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add preliminary support for data model migrations when parsing documents

--- a/packages/ember-rdfa-editor/src/core/rdfa-types.ts
+++ b/packages/ember-rdfa-editor/src/core/rdfa-types.ts
@@ -43,3 +43,10 @@ export function isResourceAttrs(attrs: RdfaAttrs): attrs is RdfaResourceAttrs {
 export function isLiteralAttrs(attrs: RdfaAttrs): attrs is RdfaLiteralAttrs {
   return attrs.rdfaNodeType === 'literal';
 }
+
+export type ModelMigration = {
+  /** A modified contentElement function to allow for nested structures to be modified **/
+  contentElement?: (element: HTMLElement) => HTMLElement;
+  /** A modified getAttrs that returns attrs matching the new model **/
+  getAttrs?: (element: HTMLElement) => RdfaAttrs;
+};

--- a/packages/ember-rdfa-editor/src/core/rdfa-types.ts
+++ b/packages/ember-rdfa-editor/src/core/rdfa-types.ts
@@ -36,3 +36,10 @@ export function isRdfaAttrs(attrs: Attrs): attrs is RdfaAttrs {
     rdfaNodeTypes.includes(attrs['rdfaNodeType'] as 'resource' | 'literal')
   );
 }
+
+export function isResourceAttrs(attrs: RdfaAttrs): attrs is RdfaResourceAttrs {
+  return attrs.rdfaNodeType === 'resource';
+}
+export function isLiteralAttrs(attrs: RdfaAttrs): attrs is RdfaLiteralAttrs {
+  return attrs.rdfaNodeType === 'literal';
+}

--- a/packages/ember-rdfa-editor/src/core/rdfa-types.ts
+++ b/packages/ember-rdfa-editor/src/core/rdfa-types.ts
@@ -50,3 +50,6 @@ export type ModelMigration = {
   /** A modified getAttrs that returns attrs matching the new model **/
   getAttrs?: (element: HTMLElement) => RdfaAttrs;
 };
+export type ModelMigrationGenerator = (
+  attrs: RdfaAttrs,
+) => false | ModelMigration;

--- a/packages/ember-rdfa-editor/src/nodes/inline-rdfa.ts
+++ b/packages/ember-rdfa-editor/src/nodes/inline-rdfa.ts
@@ -13,7 +13,7 @@ import {
 import InlineRdfaComponent from '../components/ember-node/inline-rdfa.ts';
 import type { ComponentLike } from '@glint/template';
 import getClassnamesFromNode from '../utils/get-classnames-from-node.ts';
-import type { RdfaAttrs } from '#root/core/rdfa-types.js';
+import type { ModelMigration, RdfaAttrs } from '#root/core/rdfa-types.ts';
 
 type Options = {
   rdfaAware?: boolean;
@@ -21,14 +21,7 @@ type Options = {
    * Migrations to apply to nodes parsed as inline-rdfa, to modify the data model.
    * @returns false to use the default parsing or an object to define overrides
    **/
-  modelMigrations?: (attrs: RdfaAttrs) =>
-    | false
-    | {
-        /** A modified contentElement function to allow for nested structures to be modified **/
-        contentElement?: (element: HTMLElement) => HTMLElement;
-        /** A modified getAttrs that returns attrs matching the new model **/
-        getAttrs?: (element: HTMLElement) => RdfaAttrs;
-      };
+  modelMigrations?: (attrs: RdfaAttrs) => false | ModelMigration;
 };
 
 const emberNodeConfig: (options?: Options) => EmberNodeConfig = ({

--- a/packages/ember-rdfa-editor/src/nodes/inline-rdfa.ts
+++ b/packages/ember-rdfa-editor/src/nodes/inline-rdfa.ts
@@ -13,13 +13,27 @@ import {
 import InlineRdfaComponent from '../components/ember-node/inline-rdfa.ts';
 import type { ComponentLike } from '@glint/template';
 import getClassnamesFromNode from '../utils/get-classnames-from-node.ts';
+import type { RdfaAttrs } from '#root/core/rdfa-types.js';
 
 type Options = {
   rdfaAware?: boolean;
+  /**
+   * Migrations to apply to nodes parsed as inline-rdfa, to modify the data model.
+   * @returns false to use the default parsing or an object to define overrides
+   **/
+  modelMigrations?: (attrs: RdfaAttrs) =>
+    | false
+    | {
+        /** A modified contentElement function to allow for nested structures to be modified **/
+        contentElement?: (element: HTMLElement) => HTMLElement;
+        /** A modified getAttrs that returns attrs matching the new model **/
+        getAttrs?: (element: HTMLElement) => RdfaAttrs;
+      };
 };
 
 const emberNodeConfig: (options?: Options) => EmberNodeConfig = ({
   rdfaAware = false,
+  modelMigrations,
 } = {}) => {
   return {
     name: 'inline-rdfa',
@@ -54,17 +68,33 @@ const emberNodeConfig: (options?: Options) => EmberNodeConfig = ({
         tag: 'span',
         // default prio is 50, highest prio comes first, and this parserule should at least come after all other nodes
         priority: 10,
-        getAttrs(node: string | HTMLElement) {
-          if (typeof node === 'string') {
+        getAttrs(element: string | HTMLElement) {
+          if (typeof element === 'string') {
             return false;
           }
-          const attrs = getRdfaAttrs(node, { rdfaAware });
+          const attrs = getRdfaAttrs(element, { rdfaAware });
           if (attrs) {
+            const migrations =
+              modelMigrations && modelMigrations(attrs as unknown as RdfaAttrs);
+            if (migrations && migrations.getAttrs) {
+              return migrations.getAttrs(element);
+            }
             return attrs;
           }
           return false;
         },
-        contentElement: getRdfaContentElement,
+        contentElement: (element) => {
+          if (rdfaAware && modelMigrations) {
+            const attrs = getRdfaAttrs(element, { rdfaAware });
+            if (attrs) {
+              const migrations = modelMigrations(attrs);
+              if (migrations && migrations.contentElement) {
+                return migrations.contentElement(element);
+              }
+            }
+          }
+          return getRdfaContentElement(element);
+        },
       },
     ],
     attrs: rdfaAttrSpec({ rdfaAware }),


### PR DESCRIPTION
### Overview
A proposal for a way to support migrating a data model to an updated version. Very similar in approach to simply adding new parsing rules, but intended to be applied to inline or block rdfa nodes (so far only applied to inline_rdfa as that is what I needed for the fix I was working on). See the linked plugins PR for a demonstration of such a migration.

##### connected issues and PRs:
Plugins PR TBC
Jira ticket for bug: https://binnenland.atlassian.net/browse/GN-5710

### Setup
Should be tested within the plugins PR.

### How to test/reproduce
See plugins PR. Otherwise, inline_rdfa nodes should work exactly as before.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
