### PR TITLE
Improve `transactionCombinator` behaviour

### DIFF
--- a/.changeset/gentle-webs-float.md
+++ b/.changeset/gentle-webs-float.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+`transactionCombinator`: apply manual selection changes performed in the transaction-monads

--- a/.changeset/wet-parts-yawn.md
+++ b/.changeset/wet-parts-yawn.md
@@ -1,0 +1,6 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+`transactionCombinator`: apply all steps of the resulting transactions coming from `State.apply`
+

--- a/packages/ember-rdfa-editor/src/utils/transaction-utils.ts
+++ b/packages/ember-rdfa-editor/src/utils/transaction-utils.ts
@@ -139,7 +139,9 @@ export function transactionCombinator<R>(
       appliedTransactions.push(...transactions);
 
       results.push(result);
-      for (const step of transaction.steps) {
+      for (const step of transactions.flatMap(
+        (transaction) => transaction.steps,
+      )) {
         tr.step(step);
       }
     }

--- a/packages/ember-rdfa-editor/src/utils/transaction-utils.ts
+++ b/packages/ember-rdfa-editor/src/utils/transaction-utils.ts
@@ -144,6 +144,7 @@ export function transactionCombinator<R>(
       )) {
         tr.step(step);
       }
+      tr.setSelection(state.selection.getBookmark().resolve(tr.doc));
     }
     return {
       transaction: tr,


### PR DESCRIPTION
### Overview
This PR improves the behaviour of the `transactionCombinator` function in two ways:
- It ensures that all steps of all resulting `transactions` of the `State.applyTransaction` method are applied to the combined transaction
- It ensures that manual selection changes introduced in the monads are also applied to the combined transaction

##### connected issues and PRs:
[GN-5750](https://binnenland.atlassian.net/browse/GN-5750?atlOrigin=eyJpIjoiZGQwNjFlZTFhZDJjNDgxYjgzYzM2MDcxNzc4ZmUzNDEiLCJwIjoiaiJ9)

### How to test/reproduce
Not sure yet, I'll to set-up a test in combination with the plugins package.

### Challenges/uncertainties
- Not sure why not all transaction steps were applied before
- We should not need to map the selection, as this is already done for us.
- unknown if this affects performance due to the extra steps being applied
- We might be able to do away with the intermediate `applyTransaction` calls, this way plugins can't react to the intermediate monad transactions.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
