### PR TITLE
Add support for model migrations to `block_rdfa`

### DIFF
--- a/.changeset/open-paths-sort.md
+++ b/.changeset/open-paths-sort.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add support for model migrations to `block_rdfa` node

--- a/packages/ember-rdfa-editor/src/nodes/block-rdfa.ts
+++ b/packages/ember-rdfa-editor/src/nodes/block-rdfa.ts
@@ -1,5 +1,9 @@
 import { Node as PNode } from 'prosemirror-model';
-import { isRdfaAttrs } from '#root/core/rdfa-types.ts';
+import {
+  isRdfaAttrs,
+  type ModelMigrationGenerator,
+  type RdfaAttrs,
+} from '#root/core/rdfa-types.ts';
 import {
   getRdfaAttrs,
   getRdfaContentElement,
@@ -18,10 +22,16 @@ const FALLBACK_LABEL = 'Data-object';
 
 type Config = {
   rdfaAware?: boolean;
+  /**
+   * Migrations to apply to nodes parsed as block-rdfa, to modify the data model.
+   * @returns false to use the default parsing or an object to define overrides
+   **/
+  modelMigrations?: ModelMigrationGenerator[];
 };
 
 export const blockRdfaWithConfig: (config?: Config) => SayNodeSpec = ({
   rdfaAware = false,
+  modelMigrations = [],
 } = {}) => {
   return {
     content: 'block+',
@@ -43,17 +53,36 @@ export const blockRdfaWithConfig: (config?: Config) => SayNodeSpec = ({
         tag: `p, div, address, article, aside, blockquote, details, dialog, dd, dt, fieldset, figcaption, figure, footer, form, header, hgroup, hr, main, nav, pre, section`,
         // Default priority is 50, so this means a more specific definition matches before this one
         priority: 40,
-        getAttrs(node: string | HTMLElement) {
-          if (typeof node === 'string') {
+        getAttrs(element: string | HTMLElement) {
+          if (typeof element === 'string') {
             return false;
           }
-          const attrs = getRdfaAttrs(node, { rdfaAware });
+          const attrs = getRdfaAttrs(element, { rdfaAware });
           if (attrs) {
-            return { ...attrs, label: node.dataset['label'] };
+            const migration = modelMigrations.find((migration) =>
+              migration(attrs as unknown as RdfaAttrs),
+            )?.(attrs as unknown as RdfaAttrs);
+            if (migration && migration.getAttrs) {
+              return migration.getAttrs(element);
+            }
+            return { ...attrs, label: element.dataset['label'] };
           }
           return false;
         },
-        contentElement: getRdfaContentElement,
+        contentElement: (element) => {
+          if (rdfaAware && modelMigrations.length > 0) {
+            const attrs = getRdfaAttrs(element, { rdfaAware });
+            if (attrs) {
+              const migration = modelMigrations.find((migration) =>
+                migration(attrs as unknown as RdfaAttrs),
+              )?.(attrs as unknown as RdfaAttrs);
+              if (migration && migration.contentElement) {
+                return migration.contentElement(element);
+              }
+            }
+          }
+          return getRdfaContentElement(element);
+        },
       },
     ],
     toDOM(node: PNode) {


### PR DESCRIPTION
### Overview
This PR adds support for model migrations to the `block_rdfa` nodespec

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/604

### How to test/reproduce
Check-out https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/604

### Challenges/uncertainties
I didn't abstract the logic away, and just used the same logic as the `inline_rdfa` spec is using.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
