### PR TITLE
Fix floating plus not opening context actions

### DIFF
--- a/.changeset/silent-lamps-own.md
+++ b/.changeset/silent-lamps-own.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix floating plus not opening context actions

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -40,6 +40,7 @@ export default class ContextualActionsContainer extends Component<Args> {
    * which we want to ignore
    */
   @tracked localEditorState: EditorState | null = null;
+  @tracked plusButtonClicked = false;
 
   editorStateListener = (oldState: EditorState, newState: EditorState) => {
     const docChanged = !oldState.doc.eq(newState.doc);
@@ -76,12 +77,19 @@ export default class ContextualActionsContainer extends Component<Args> {
     const tr = this.controller.mainEditorState.tr;
     tr.setMeta('SLASH_COMMANDS_PLUGIN', 'close_context_menu');
     this.controller.mainEditorView.dispatch(tr);
+    this.plusButtonClicked = false;
   };
 
   openContextMenu = () => {
+    // Send a transaction to signal the slash commands plugin (if present) that
+    // the menu is open. This hides the placeholder text
     const tr = this.controller.mainEditorState.tr;
     tr.setMeta('SLASH_COMMANDS_PLUGIN', 'open_context_menu');
     this.controller.mainEditorView.dispatch(tr);
+
+    // Opening the menu cannot rely on the slash commands plugin 
+    // to be present, thats why we keep the openness state locally as well
+    this.plusButtonClicked = true;
   };
 
   get controller() {
@@ -140,7 +148,7 @@ export default class ContextualActionsContainer extends Component<Args> {
   }
 
   get showContextMenu() {
-    return this.slashCommandsPluginState?.shouldOpenContextActions;
+    return this.slashCommandsPluginState?.shouldOpenContextActions || this.plusButtonClicked;
   }
 
   <template>

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -123,6 +123,7 @@ export default class ContextualActionsContainer extends Component<Args> {
   @action
   executeAction(action: ContextualAction) {
     if (
+      !this.plusButtonClicked && 
       this.slashCommandsPluginState?.shouldOpenContextActions && // Menu was opened by a slash
       this.slashCommandsPluginState?.latestState
     ) {

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -87,7 +87,7 @@ export default class ContextualActionsContainer extends Component<Args> {
     tr.setMeta('SLASH_COMMANDS_PLUGIN', 'open_context_menu');
     this.controller.mainEditorView.dispatch(tr);
 
-    // Opening the menu cannot rely on the slash commands plugin 
+    // Opening the menu cannot rely on the slash commands plugin
     // to be present, thats why we keep the openness state locally as well
     this.plusButtonClicked = true;
   };
@@ -123,7 +123,7 @@ export default class ContextualActionsContainer extends Component<Args> {
   @action
   executeAction(action: ContextualAction) {
     if (
-      !this.plusButtonClicked && 
+      !this.plusButtonClicked &&
       this.slashCommandsPluginState?.shouldOpenContextActions && // Menu was opened by a slash
       this.slashCommandsPluginState?.latestState
     ) {
@@ -149,7 +149,10 @@ export default class ContextualActionsContainer extends Component<Args> {
   }
 
   get showContextMenu() {
-    return this.slashCommandsPluginState?.shouldOpenContextActions || this.plusButtonClicked;
+    return (
+      this.slashCommandsPluginState?.shouldOpenContextActions ||
+      this.plusButtonClicked
+    );
   }
 
   <template>

--- a/packages/ember-rdfa-editor/src/plugins/slash-commands/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/slash-commands/index.ts
@@ -28,6 +28,9 @@ function shouldShowPlaceholder(
   state: EditorState,
   getGroups: GetContextualActionGroups,
 ) {
+  const pluginState = getSlashCommandsPluginState(state);
+  if (pluginState?.shouldOpenContextActions) return false;
+
   const groups = getGroups.flatMap((getGroups) => getGroups(state));
   if (groups.length === 0) return false;
   const { selection } = state;
@@ -119,7 +122,9 @@ export function slashCommandsPlugin(options: SlashCommandsPluginArgs) {
         };
       },
       apply(tr, pluginState, oldState, newState) {
-        // TODO fix issue where if you put 2 / and naviate with the arrows it keeps the menu open
+        if (tr.getMeta('SLASH_COMMANDS_PLUGIN') === 'open_context_menu') {
+          return { ...pluginState, shouldOpenContextActions: true };
+        }
         if (pluginState.shouldOpenContextActions) {
           return {
             ...pluginState,


### PR DESCRIPTION
### Overview
Fixes a bug where the context actions menu does not open when the button is clicked.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6102



### Checks PR readiness
- [x] changelog
- [x] npm lint
