### PR TITLE
Improve contextual actions menu placement

### DIFF
--- a/.changeset/cuddly-bananas-sort.md
+++ b/.changeset/cuddly-bananas-sort.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Improve context actions menu placement

--- a/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
+++ b/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
@@ -49,6 +49,7 @@
 
   display: flex;
   flex-direction: column;
+  position: fixed;
 
   border: 0.1rem solid var(--au-gray-200);
   min-width: 20em;

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -1,9 +1,8 @@
 import Component from '@glimmer/component';
 import {
-  flip,
+  autoPlacement,
   hide,
   offset,
-  shift,
   size,
   type Middleware,
 } from '@floating-ui/dom';
@@ -199,7 +198,11 @@ export default class ContextualActionsMenu extends Component<Args> {
   get tooltipMiddleWare(): Middleware[] {
     return [
       offset(10),
-      flip(),
+      autoPlacement({
+        allowedPlacements: this.textIsRightAligned
+          ? ['bottom-end', 'top-end']
+          : ['bottom-start', 'top-start'],
+      }),
       size({
         apply({ availableHeight, elements }) {
           Object.assign(elements.floating.style, {
@@ -207,7 +210,6 @@ export default class ContextualActionsMenu extends Component<Args> {
           });
         },
       }),
-      shift(),
       hide({ strategy: 'referenceHidden' }),
       hide({ strategy: 'escaped' }),
     ];
@@ -259,12 +261,13 @@ export default class ContextualActionsMenu extends Component<Args> {
     };
   });
 
-  get menuPlacement() {
+  get textIsRightAligned() {
     const parent = this.controller.mainEditorState.selection.$from.parent;
-    if (!parent) return 'bottom-start';
-    return parent.attrs['alignment'] === 'right'
-      ? 'bottom-end'
-      : 'bottom-start';
+    return parent.attrs['alignment'] === 'right';
+  }
+
+  get menuPlacement() {
+    return this.textIsRightAligned ? 'bottom-end' : 'bottom-start';
   }
 
   setSearchQuery = (event: InputEvent) => {


### PR DESCRIPTION
### Overview
Previously, the context menu stayed on the bottom of the text after loading, even if there was more space available above. This change makes the menu always appear on the side with the most space.


### How to test/reproduce
Open the menu where the text is almost at the bottom of the screen, the menu should open on top.


### Checks PR readiness
- [x] changelog
- [x] npm lint
