### PR TITLE
add sticky groups

### DIFF
--- a/.changeset/cuddly-bananas-sort.md
+++ b/.changeset/cuddly-bananas-sort.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Improve context actions menu placement

--- a/.changeset/spotty-rings-invent.md
+++ b/.changeset/spotty-rings-invent.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add `sticky` property to `ContextualActionGroups`

--- a/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
+++ b/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
@@ -97,8 +97,6 @@
   overflow-y: scroll;
   overflow-x: hidden;
 
-  // padding-bottom: au-settings.$au-unit-tiny;
-
   button {
     cursor: pointer;
     outline: none;

--- a/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
+++ b/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
@@ -70,13 +70,34 @@
   }
 }
 
+.say-contextual-actions-menu-group-wrapper {
+  background-color: white;
+  z-index: 1;
+  &:nth-last-child(2) {
+    padding-bottom: au-settings.$au-unit-tiny;
+  }
+  &.sticky-bottom {
+    position: sticky;
+    bottom: 0;
+  }
+  &.sticky-bottom.is-stuck-bottom {
+    box-shadow: 0 -2px 3px 0px rgba(0, 0, 0, 0.04);
+    // border-bottom: 1px solid var(--au-gray-200);
+    transition: box-shadow 0.15s ease;
+  }
+  &.sticky-top {
+    position: sticky;
+    top: 0;
+  }
+}
+
 .say-contextual-actions-menu-entries-container {
   display: flex;
   flex-direction: column;
   overflow-y: scroll;
   overflow-x: hidden;
 
-  padding-bottom: au-settings.$au-unit-tiny;
+  // padding-bottom: au-settings.$au-unit-tiny;
 
   button {
     cursor: pointer;

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -49,6 +49,19 @@ function sortByPriority(
   return itemB.priority - itemA.priority;
 }
 
+function sortGroups(
+  itemA: { sticky?: 'bottom'; priority?: number },
+  itemB: { sticky?: 'bottom'; priority?: number },
+) {
+  if (itemA.sticky === itemB.sticky) {
+    return sortByPriority(itemA, itemB);
+  } else if (itemA.sticky) {
+    return 1;
+  } else {
+    return -1;
+  }
+}
+
 export default class ContextualActionsMenu extends Component<Args> {
   @tracked selectedActionIndex: number = 0;
 
@@ -175,7 +188,7 @@ export default class ContextualActionsMenu extends Component<Args> {
             .toSorted(sortByPriority) ?? [],
       }))
       .filter((group) => group.actions.length > 0)
-      .toSorted(sortByPriority);
+      .toSorted(sortGroups);
   }
 
   get actionAmount() {

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -19,10 +19,11 @@ import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
 import AuInput from '@appuniversum/ember-appuniversum/components/au-input';
 import AuIcon from '@appuniversum/ember-appuniversum/components/au-icon';
 import t from 'ember-intl/helpers/t';
-import { modifier } from 'ember-modifier';
+import { modifier as eModifier } from 'ember-modifier';
 import { getReferenceElementFromSelection } from '#root/components/utils/floating-ui-reference-element.ts';
 import { cached, tracked } from '@glimmer/tracking';
 import { runTask } from 'ember-lifeline';
+import { eq } from 'ember-truth-helpers';
 
 type Args = {
   controller: SayController;
@@ -61,7 +62,7 @@ export default class ContextualActionsMenu extends Component<Args> {
     }
   };
 
-  setUpListeners = modifier(() => {
+  setUpListeners = eModifier(() => {
     const handleMousedown = () => {
       this.args.onClose?.();
     };
@@ -216,30 +217,42 @@ export default class ContextualActionsMenu extends Component<Args> {
   }
 
   // This can be removed once the `:sticky` selector becomes supported
-  observeSticky = modifier((element: HTMLElement) => {
-    const sentinel = element.previousElementSibling as HTMLElement;
-    const container = element.closest(
-      '.say-contextual-actions-menu-entries-container',
-    );
+  observeSticky = eModifier(
+    (element: HTMLElement, [position]: ['top' | 'bottom']) => {
+      const container = element.closest(
+        '.say-contextual-actions-menu-entries-container',
+      );
 
-    if (!sentinel || !container) return;
+      if (!container) return;
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          element.classList.remove('is-stuck');
-        } else {
-          element.classList.add('is-stuck');
-        }
-      },
-      {
-        root: container,
-        threshold: [1],
-      },
-    );
+      const sentinel =
+        position === 'top'
+          ? element.previousElementSibling
+          : element.nextElementSibling;
 
-    observer.observe(sentinel);
-  });
+      if (!sentinel) return;
+
+      const stuckClass = position === 'top' ? 'is-stuck' : 'is-stuck-bottom';
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          element.classList.toggle(stuckClass, !entry.isIntersecting);
+        },
+        {
+          root: container,
+          threshold: [1],
+          // Rootmargin is needed because otherwise the shadow effect is not
+          // being applied to stuck groups when the menu is placed
+          // above the text
+          rootMargin: '0px 0px 1px 0px',
+        },
+      );
+
+      observer.observe(sentinel);
+
+      return () => observer.disconnect();
+    },
+  );
 
   selectAction = (action: ContextualAction) => {
     this.args.onActionSelected?.(action);
@@ -254,7 +267,7 @@ export default class ContextualActionsMenu extends Component<Args> {
     this.selectedActionIndex = this.getIndexByAction(action);
   };
 
-  addActionElementToMap = modifier((element, [action]: [ContextualAction]) => {
+  addActionElementToMap = eModifier((element, [action]: [ContextualAction]) => {
     this.actionToElement.set(action, element);
     return () => {
       this.actionToElement.delete(action);
@@ -275,7 +288,7 @@ export default class ContextualActionsMenu extends Component<Args> {
     this.args.onSearch?.((event.target as HTMLInputElement).value);
   };
 
-  focus = modifier((element: HTMLElement) => {
+  focus = eModifier((element: HTMLElement) => {
     runTask(this, () => element.focus());
   });
 
@@ -322,11 +335,21 @@ export default class ContextualActionsMenu extends Component<Args> {
       {{else}}
         <div class="say-contextual-actions-menu-entries-container">
           {{#each this.groupedActions as |group|}}
-            <div class="say-contextual-actions-menu-group-wrapper">
+            <div
+              class="say-contextual-actions-menu-group-wrapper
+                {{if (eq group.sticky 'bottom') 'sticky-bottom'}}{{if
+                  (eq group.sticky 'top')
+                  'sticky-top'
+                }}"
+              {{(if
+                (eq group.sticky "bottom")
+                (modifier this.observeSticky "bottom")
+              )}}
+            >
               <div class="say-contextual-actions-menu-group-sticky-sentinel" />
               <div
                 class="say-contextual-actions-menu-group-header au-u-muted"
-                {{this.observeSticky}}
+                {{this.observeSticky "top"}}
               >
                 {{group.label}}
               </div>
@@ -357,6 +380,7 @@ export default class ContextualActionsMenu extends Component<Args> {
                 {{/each}}
               </div>
             </div>
+            <div class="say-contextual-actions-menu-group-sticky-sentinel" />
           {{else}}
             <AuAlert
               @size="small"

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -341,6 +341,7 @@ export default class ContextualActionsMenu extends Component<Args> {
                   (eq group.sticky 'top')
                   'sticky-top'
                 }}"
+              {{! @glint-expect-error type of the modifier helper is incorrect}}
               {{(if
                 (eq group.sticky "bottom")
                 (modifier this.observeSticky "bottom")

--- a/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
@@ -15,6 +15,7 @@ export type ContextualActionGroup = {
   id: string;
   label: string;
 
+  sticky?: 'bottom';
   priority?: number;
 };
 

--- a/packages/ember-rdfa-editor/src/plugins/heading/nodes/heading.ts
+++ b/packages/ember-rdfa-editor/src/plugins/heading/nodes/heading.ts
@@ -42,9 +42,7 @@ export const headingWithConfig: (config?: Config) => SayNodeSpec = ({
     group: 'block',
     defining: true,
     editable: rdfaAware,
-    // Should be false to ensure newlines leave the node and become a new paragraph instead of
-    // remaining a heading
-    isolating: false,
+    isolating: rdfaAware,
     selectable: rdfaAware,
     classNames: ['say-heading'],
     parseDOM: [

--- a/test-app/app/dummy-plugins/expose-contextual-actions.ts
+++ b/test-app/app/dummy-plugins/expose-contextual-actions.ts
@@ -132,6 +132,7 @@ export function getContextualGroups(state: EditorState) {
     {
       id: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Invoegen',
+      sticky: 'bottom',
     },
     {
       id: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',

--- a/test-app/app/dummy-plugins/expose-contextual-actions.ts
+++ b/test-app/app/dummy-plugins/expose-contextual-actions.ts
@@ -4,6 +4,7 @@ import {
   TextSelection,
   Transaction,
 } from '@lblod/ember-rdfa-editor';
+import type { ContextualActionGroup } from '@lblod/ember-rdfa-editor/plugins/contextual-actions';
 import { v4 as uuidv4 } from 'uuid';
 
 export async function getContextualActions(
@@ -124,7 +125,7 @@ export async function getContextualActions(
 }
 
 export function getContextualGroups(state: EditorState) {
-  const groups = [
+  const groups: ContextualActionGroup[] = [
     {
       id: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Plaatsbepaling',

--- a/test-app/app/templates/editable-node.gts
+++ b/test-app/app/templates/editable-node.gts
@@ -236,7 +236,7 @@ export default class extends Component {
         cellContent: 'block+',
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
       }),
-      heading: headingWithConfig({ rdfaAware: true }),
+      heading: headingWithConfig({ rdfaAware: false }),
       blockquote,
 
       horizontal_rule,


### PR DESCRIPTION
### Overview
Adds the ability for `ContextualActionGroups` to be always displayed at the bottom of the context menu.

##### connected issues and PRs:
Required for https://binnenland.atlassian.net/browse/GN-6164

### How to test/reproduce
The dummy context actions now contain a stickied group called "insert". It should always be visible at the bottom of the menu. When no scroll bar is present, the shadow effect should disappear.

### Challenges/uncertainties
Currently, making a action group sticky does not change the group order. I'm not sure if we want to override the `priority` property here or let the implementer deal with making sure that the stickied group is at the bottom.

### Checks PR readiness
- [x] changelog
- [x] npm lint
