### PR TITLE
Fix RDFa aware headings to be not isolating

### DIFF
--- a/.changeset/slow-suns-strive.md
+++ b/.changeset/slow-suns-strive.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix RDFa aware headings to behave as expected when hitting 'enter' to go onto a newline

--- a/packages/ember-rdfa-editor/src/plugins/heading/nodes/heading.ts
+++ b/packages/ember-rdfa-editor/src/plugins/heading/nodes/heading.ts
@@ -42,7 +42,9 @@ export const headingWithConfig: (config?: Config) => SayNodeSpec = ({
     group: 'block',
     defining: true,
     editable: rdfaAware,
-    isolating: rdfaAware,
+    // Should be false to ensure newlines leave the node and become a new paragraph instead of
+    // remaining a heading
+    isolating: false,
     selectable: rdfaAware,
     classNames: ['say-heading'],
     parseDOM: [

--- a/test-app/app/templates/editable-node.gts
+++ b/test-app/app/templates/editable-node.gts
@@ -236,7 +236,7 @@ export default class extends Component {
         cellContent: 'block+',
         inlineBorderStyle: { width: '0.5px', color: '#CCD1D9' },
       }),
-      heading: headingWithConfig({ rdfaAware: false }),
+      heading: headingWithConfig({ rdfaAware: true }),
       blockquote,
 
       horizontal_rule,


### PR DESCRIPTION
### Overview
It's unclear whether there was a strong reason to set isolating, but there seems to be no adverse effects. The behaviour is now as expected in text editors in general.

##### connected issues and PRs:
Part of https://binnenland.atlassian.net/browse/GN-6149
Fixes: https://github.com/lblod/frontend-embeddable-notule-editor/issues/289

### Setup
While this was reported on embeddable, just setting `rdfaAware: true` for `headingWithConfig` is enough to see the issue here.

### How to test/reproduce
Headings should behave as expected. For example, pressing enter at the end of a heading will start a new line that is not a heading.

### Challenges/uncertainties
Finding the issue...

### Checks PR readiness
- [x] changelog
- [x] npm lint
- [x] no new deprecations
