### PR TITLE
Update build process to use node v24

### DIFF
--- a/.changeset/rude-ghosts-listen.md
+++ b/.changeset/rude-ghosts-listen.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Update node version used for build process to v24

--- a/.changeset/sad-vans-live.md
+++ b/.changeset/sad-vans-live.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Move to pnpm 11.4

--- a/.woodpecker/.changeset.yml
+++ b/.woodpecker/.changeset.yml
@@ -1,6 +1,6 @@
 steps:
   changeset:
-    image: danlynn/ember-cli:6.1.0
+    image: danlynn/ember-cli:6.5.0
     commands:
       - git fetch origin master
       - git diff -wb --name-only origin/master..HEAD | grep "\.changeset/.*\.md"

--- a/.woodpecker/.dev-release.yml
+++ b/.woodpecker/.dev-release.yml
@@ -9,8 +9,7 @@ steps:
     commands:
       - npm config set ignore-scripts true
       - cat .npmrc
-      # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       # pnpm doesn't handle this setting well, so we do it with npm
       - npm config set --location project '//registry.npmjs.org/:_authToken' $NPM_TOKEN
       - pnpm i --frozen-lockfile

--- a/.woodpecker/.dev-release.yml
+++ b/.woodpecker/.dev-release.yml
@@ -1,11 +1,11 @@
 steps:
   version:
-    image: node:22-slim
+    image: node:24-slim
     directory: packages/ember-rdfa-editor
     commands:
       - npm version --no-git-tag-version ${CI_COMMIT_TAG##@lblod/ember-rdfa-editor@}
   publish:
-    image: node:22-slim
+    image: node:24-slim
     commands:
       - npm config set ignore-scripts true
       - cat .npmrc

--- a/.woodpecker/.e2e.yml
+++ b/.woodpecker/.e2e.yml
@@ -3,8 +3,7 @@ steps:
     # this image must be the same as in `scripts/e2e.sh`
     image: mcr.microsoft.com/playwright:v1.50.0-jammy
     commands:
-      # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       - pnpm i --frozen-lockfile
       - pnpm build
       - pnpm i -f

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,13 +1,13 @@
 steps:
   install:
-    image: node:22-slim
+    image: node:24-slim
     commands:
       - corepack enable
       # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
       - npm i -g corepack@0.31
       - pnpm i --frozen-lockfile
   release-next:
-    image: node:22-slim
+    image: node:24-slim
     commands:
       - npm config set ignore-scripts true
       # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
@@ -24,7 +24,7 @@ steps:
       ref:
         include: refs/tags/@lblod/ember-rdfa-editor@*-next.*
   release:
-    image: node:22-slim
+    image: node:24-slim
     commands:
       - npm config set ignore-scripts true
       # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -3,15 +3,13 @@ steps:
     image: node:24-slim
     commands:
       - corepack enable
-      # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       - pnpm i --frozen-lockfile
   release-next:
     image: node:24-slim
     commands:
       - npm config set ignore-scripts true
-      # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       # pnpm doesn't handle this setting well, so we do it with npm
       - npm config set --location project '//registry.npmjs.org/:_authToken' $NPM_TOKEN
       - pnpm i --frozen-lockfile
@@ -27,8 +25,7 @@ steps:
     image: node:24-slim
     commands:
       - npm config set ignore-scripts true
-      # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       # pnpm doesn't handle this setting well, so we do it with npm
       - npm config set --location project '//registry.npmjs.org/:_authToken' $NPM_TOKEN
       - pnpm i --frozen-lockfile

--- a/.woodpecker/.test-compat-4.12.yml
+++ b/.woodpecker/.test-compat-4.12.yml
@@ -4,7 +4,9 @@ steps:
     commands:
       - echo "inject-workspace-packages=true" >> .npmrc
       - echo "sync-injected-deps-after-scripts[]=build" >> .npmrc
-      - npm i -g corepack@0.35
+      # Install pnpm 10 for Node <v22 support
+      - npm i -g pnpm@10.34.1
+      - sed -i 's/pnpm@11.4.0/pnpm@10.34.1/' package.json
       - pnpm i --no-frozen-lockfile
       - pnpm build
       - pnpm --filter test-app exec ember try:one ember-lts-4.12 --skip-cleanup=true

--- a/.woodpecker/.test-compat-4.12.yml
+++ b/.woodpecker/.test-compat-4.12.yml
@@ -4,8 +4,7 @@ steps:
     commands:
       - echo "inject-workspace-packages=true" >> .npmrc
       - echo "sync-injected-deps-after-scripts[]=build" >> .npmrc
-      # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       - pnpm i --no-frozen-lockfile
       - pnpm build
       - pnpm --filter test-app exec ember try:one ember-lts-4.12 --skip-cleanup=true

--- a/.woodpecker/.test-compat-6.12.yml
+++ b/.woodpecker/.test-compat-6.12.yml
@@ -4,7 +4,9 @@ steps:
     commands:
       - echo "inject-workspace-packages=true" >> .npmrc
       - echo "sync-injected-deps-after-scripts[]=build" >> .npmrc
-      - npm i -g corepack@0.35
+      # Install pnpm 10 for Node <v22 support
+      - npm i -g pnpm@10.34.1
+      - sed -i 's/pnpm@11.4.0/pnpm@10.34.1/' package.json
       - pnpm i --no-frozen-lockfile
       - pnpm build
       - pnpm --filter test-app exec ember try:one ember-lts-6.12.0 --skip-cleanup=true

--- a/.woodpecker/.test-compat-6.12.yml
+++ b/.woodpecker/.test-compat-6.12.yml
@@ -4,8 +4,7 @@ steps:
     commands:
       - echo "inject-workspace-packages=true" >> .npmrc
       - echo "sync-injected-deps-after-scripts[]=build" >> .npmrc
-      # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       - pnpm i --no-frozen-lockfile
       - pnpm build
       - pnpm --filter test-app exec ember try:one ember-lts-6.12.0 --skip-cleanup=true

--- a/.woodpecker/.test-compat-quickstart.yml
+++ b/.woodpecker/.test-compat-quickstart.yml
@@ -1,20 +1,20 @@
 steps:
   setup:
-    image: node:22-slim
+    image: node:24-slim
     commands:
       # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
       - npm i -g corepack@0.31
       - pnpm i --no-frozen-lockfile
       - pnpm test:quickstart:setup
   lint:
-    image: node:22-slim
+    image: node:24-slim
     depends_on: [setup]
     commands:
       - cd quickstart
       - npm run lint:js
       - npm run lint:types
   test:
-    image: danlynn/ember-cli:6.1.0
+    image: danlynn/ember-cli:6.10.0
     depends_on: [setup]
     commands:
       - cd quickstart

--- a/.woodpecker/.test-compat-quickstart.yml
+++ b/.woodpecker/.test-compat-quickstart.yml
@@ -2,8 +2,7 @@ steps:
   setup:
     image: node:24-slim
     commands:
-      # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       - pnpm i --no-frozen-lockfile
       - pnpm test:quickstart:setup
   lint:

--- a/.woodpecker/.verify-pr.yml
+++ b/.woodpecker/.verify-pr.yml
@@ -3,10 +3,7 @@ steps:
     image: node:24-slim
     commands:
       - npm config set ignore-scripts true
-      # pinning to 10.0.0 because of https://github.com/nodejs/corepack/issues/612
-      # corepack use also runs an install
-      # installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       - corepack enable
       - pnpm i --frozen-lockfile
       - pnpm build
@@ -16,13 +13,13 @@ steps:
     image: node:24-slim
     depends_on: [install]
     commands:
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       - pnpm lint
   test:
     image: danlynn/ember-cli:6.5.0
     depends_on: [install]
     commands:
-      - npm i -g corepack@0.31
+      - npm i -g corepack@0.35
       - pnpm test
 when:
   event:

--- a/.woodpecker/.verify-pr.yml
+++ b/.woodpecker/.verify-pr.yml
@@ -1,6 +1,6 @@
 steps:
   install:
-    image: node:22-slim
+    image: node:24-slim
     commands:
       - npm config set ignore-scripts true
       # pinning to 10.0.0 because of https://github.com/nodejs/corepack/issues/612
@@ -13,13 +13,13 @@ steps:
       # resync injected addon build
       - pnpm i -f
   lint:
-    image: node:22-slim
+    image: node:24-slim
     depends_on: [install]
     commands:
       - npm i -g corepack@0.31
       - pnpm lint
   test:
-    image: danlynn/ember-cli:6.1.0
+    image: danlynn/ember-cli:6.5.0
     depends_on: [install]
     commands:
       - npm i -g corepack@0.31

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## NPM and node
 
-This project requires [node](https://nodejs.org/en/download/) (currently tested on v22) and
+This project requires [node](https://nodejs.org/en/download/) (currently tested on v24) and
 [pnpm](https://pnpm.io/installation).
 
 ## Installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM node:24-slim AS builder
 LABEL maintainer="info@redpencil.io"
 
 RUN corepack enable
-# installing the latest corepack manually because of https://github.com/nodejs/corepack/issues/612
-RUN npm i -g corepack@0.31
+RUN npm i -g corepack@0.35
 WORKDIR /app
 COPY . .
 RUN npm config set ignore-scripts true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY . .
 RUN npm config set ignore-scripts true
 RUN corepack enable
-RUN corepack use pnpm@10.5.2
+RUN corepack use pnpm@11.4.0
 RUN pnpm build
 RUN pnpm build:test-app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim AS builder
+FROM node:24-slim AS builder
 
 LABEL maintainer="info@redpencil.io"
 

--- a/package.json
+++ b/package.json
@@ -25,26 +25,7 @@
     "doc:generate": "pnpm say doc:generate",
     "doc:serve": "pnpm static-server ./packages/ember-rdfa-editor/docs"
   },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "react": "18",
-        "react-dom": "18",
-        "@ember/render-modifiers>ember-source": "6"
-      }
-    },
-    "patchedDependencies": {
-      "ember-headless-form": "patches/ember-headless-form.patch"
-    },
-    "allowUnusedPatches": true,
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "core-js",
-      "ember-source",
-      "esbuild"
-    ]
-  },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.4.0",
   "devDependencies": {
     "@changesets/cli": "catalog:",
     "@changesets/get-release-plan": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,8 +388,8 @@ catalogs:
       specifier: ^1.7.1
       version: 1.7.1
     prosemirror-dev-tools:
-      specifier: ^4.2.0
-      version: 4.2.0
+      specifier: ^4.3.0
+      version: 4.3.0
     prosemirror-dropcursor:
       specifier: ^1.8.2
       version: 1.8.2
@@ -427,11 +427,11 @@ catalogs:
       specifier: ^1.1.3
       version: 1.1.3
     react:
-      specifier: ^18.3.1
-      version: 18.3.1
+      specifier: ^19.2.4
+      version: 19.2.7
     react-dom:
-      specifier: ^18.3.1
-      version: 18.3.1
+      specifier: ^19.2.4
+      version: 19.2.7
     reactiveweb:
       specifier: ^1.9.1
       version: 1.9.1
@@ -1096,7 +1096,7 @@ importers:
         version: 8.11.0(@babel/core@7.28.6)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.28.6)(@glint/template@1.7.3))(@glimmer/component@1.1.2(@babel/core@7.28.6))(@glint/template@1.7.3)(ember-source@6.7.0(@glimmer/component@1.1.2(@babel/core@7.28.6))(rsvp@4.8.5))
       ember-cli:
         specifier: 'catalog:'
-        version: 6.5.0(@types/node@20.19.30)(handlebars@4.7.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.7)
+        version: 6.5.0(@types/node@20.19.30)(handlebars@4.7.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(underscore@1.13.7)
       ember-cli-babel:
         specifier: 'catalog:'
         version: 8.2.0(@babel/core@7.28.6)
@@ -1180,7 +1180,7 @@ importers:
         version: 2.1.2(prettier@3.8.0)
       prosemirror-dev-tools:
         specifier: 'catalog:'
-        version: 4.2.0(@babel/core@7.28.6)(@babel/template@7.28.6)(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.3.0(@babel/core@7.28.6)(@babel/template@7.28.6)(@types/react@19.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       prosemirror-test-builder:
         specifier: 'catalog:'
         version: 1.1.1
@@ -1195,10 +1195,10 @@ importers:
         version: 1.1.3
       react:
         specifier: 'catalog:'
-        version: 18.3.1
+        version: 19.2.7
       react-dom:
         specifier: 'catalog:'
-        version: 18.3.1(react@18.3.1)
+        version: 19.2.7(react@19.2.7)
       read-package-up:
         specifier: 'catalog:'
         version: 11.0.0
@@ -1958,10 +1958,10 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@compiled/react@0.11.4':
-    resolution: {integrity: sha512-mtnEUFM7w/5xABWWWj3wW0vjS/cHSg0PAttJC+hOpQ5z5qGZCwk43Gy8Hfjruxvll73igJ5DSMzcAyek6DMKjw==}
+  '@compiled/react@0.19.1':
+    resolution: {integrity: sha512-vurcg91LVBeLVz/TQ4XaQMInkaIpuCvL9PzfNReiVW7z4SkoqO0KnXR14OAi0ABUuhBNPhlgviFeWwAut9SlsA==}
     peerDependencies:
-      react: '>= 16.12.0'
+      react: '>=18.0.0'
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -2009,6 +2009,9 @@ packages:
     peerDependencies:
       prosemirror-model: ^1.18.1
       prosemirror-state: ^1.4.1
+
+  '@dmsnell/diff-match-patch@1.1.0':
+    resolution: {integrity: sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==}
 
   '@dual-bundle/import-meta-resolve@4.2.1':
     resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
@@ -3330,9 +3333,6 @@ packages:
   '@types/babel__code-frame@7.0.6':
     resolution: {integrity: sha512-Anitqkl3+KrzcW2k77lRlg/GfLZLWXBuNgbEcIOU6M92yw42vsd3xV/Z/yAHEj8m+KUjL6bWOVOFqX8PFPJ4LA==}
 
-  '@types/base16@1.0.5':
-    resolution: {integrity: sha512-OzOWrTluG9cwqidEzC/Q6FAmIPcnZfm8BFRlIx0+UIUqnuAmi5OS88O0RpT3Yz6qdmqObvUhasrbNsCofE4W9A==}
-
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -3412,6 +3412,9 @@ packages:
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+
   '@types/lodash@4.17.20':
     resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
 
@@ -3452,9 +3455,6 @@ packages:
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
-
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
   '@types/prosemirror-dev-tools@3.0.6':
     resolution: {integrity: sha512-zARROV118nwc+sX7W+0ea4cffqUeRNOSac0jttSpJ921aS6w++Be+RakAgGiTqoRpPV+J+wKomMR/RuKBAlEMg==}
@@ -4116,9 +4116,6 @@ packages:
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
 
-  base16@1.0.0:
-    resolution: {integrity: sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ==}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -4507,8 +4504,9 @@ packages:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
 
-  color@3.2.1:
-    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
 
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -5035,9 +5033,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  diff-match-patch@1.0.5:
-    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
@@ -6773,44 +6768,22 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  jotai@1.13.1:
-    resolution: {integrity: sha512-RUmH1S4vLsG3V6fbGlKzGJnLrDcC/HNb5gH2AeA9DzuJknoVxSGvvg8OBB7lke+gDc4oXmdVsaKn/xDUhWZ0vw==}
+  jotai@2.20.0:
+    resolution: {integrity: sha512-b5GAqgmXmXzB4WPaTH26ppk9Sl7AA9WSQX7yfdM+gJ1rFROiWcVbi97gFuN/yVCojOcbcvop2sfLL+fjxW0JVg==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
-      '@babel/core': '*'
-      '@babel/template': '*'
-      jotai-devtools: '*'
-      jotai-immer: '*'
-      jotai-optics: '*'
-      jotai-redux: '*'
-      jotai-tanstack-query: '*'
-      jotai-urql: '*'
-      jotai-valtio: '*'
-      jotai-xstate: '*'
-      jotai-zustand: '*'
-      react: '>=16.8'
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
       '@babel/template':
         optional: true
-      jotai-devtools:
+      '@types/react':
         optional: true
-      jotai-immer:
-        optional: true
-      jotai-optics:
-        optional: true
-      jotai-redux:
-        optional: true
-      jotai-tanstack-query:
-        optional: true
-      jotai-urql:
-        optional: true
-      jotai-valtio:
-        optional: true
-      jotai-xstate:
-        optional: true
-      jotai-zustand:
+      react:
         optional: true
 
   js-beautify@1.15.4:
@@ -6895,11 +6868,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsondiffpatch@0.4.1:
-    resolution: {integrity: sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==}
-    engines: {node: '>=8.17.0'}
+  jsondiffpatch@0.7.6:
+    resolution: {integrity: sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
-    bundledDependencies: []
 
   jsonfile@2.4.0:
     resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}
@@ -7008,6 +6980,9 @@ packages:
     resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash._baseflatten@3.1.4:
     resolution: {integrity: sha512-fESngZd+X4k+GbTxdMutf8ohQa0s3sJEHIcwtu4/LsIQ2JTDzdRxDCMQjW+ezzwRitLmHnacVVmosCbxifefbw==}
 
@@ -7019,9 +6994,6 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
-  lodash.curry@4.1.1:
-    resolution: {integrity: sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA==}
 
   lodash.debounce@3.1.1:
     resolution: {integrity: sha512-lcmJwMpdPAtChA4hfiwxTtgFeNAaow701wWUgVUqeD0XJF7vMXIN+bu/2FJSGxT0NUbZy9g9VFrlOFfPjl+0Ew==}
@@ -7070,10 +7042,6 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
-  loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -7460,6 +7428,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   nanomatch@1.2.13:
@@ -8026,9 +7999,6 @@ packages:
     resolution: {integrity: sha512-KYcnXctWUWyVD3W3Ye0ZDuA1N8Szrh85cVCxpG6xYrOk/0CttRtYCmU30nWsUch0NuExQQ63QXvzRE6FLimZmg==}
     engines: {node: 10.* || >= 12.*}
 
-  prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -8038,12 +8008,12 @@ packages:
   prosemirror-commands@1.7.1:
     resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
 
-  prosemirror-dev-tools@4.2.0:
-    resolution: {integrity: sha512-Hm1HRgK0Fxhb+Dy507R1uHgP3Ixuwbh7ZHD6NUZGEAl26BKW95L70nwdA1P4odPfxPsx0lBZm1KMpulsOJMwpQ==}
+  prosemirror-dev-tools@4.3.0:
+    resolution: {integrity: sha512-u3jlguWG+voAlTWoUCw/D2l2FImKoNNZUrkCcPvWkRZBpMVxH+sMtZTXH+em520HDD7z2JNVzOIHl/0ZXh3j7w==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   prosemirror-dropcursor@1.8.2:
     resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
@@ -8151,31 +8121,28 @@ packages:
   rdf-data-factory@1.1.3:
     resolution: {integrity: sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==}
 
-  react-base16-styling@0.9.1:
-    resolution: {integrity: sha512-1s0CY1zRBOQ5M3T61wetEpvQmsYSNtWEcdYzyZNxKa8t7oDvaOn9d21xrGezGAHFWLM7SHcktPuPTrvoqxSfKw==}
+  react-base16-styling@0.10.0:
+    resolution: {integrity: sha512-H1k2eFB6M45OaiRru3PBXkuCcn2qNmx+gzLb4a9IPMR7tMH8oBRXU5jGbPDYG1Hz+82d88ED0vjR8BmqU3pQdg==}
 
-  react-dock@0.6.0:
-    resolution: {integrity: sha512-jEOhv1s+pqRQ4JxgUw4XUotnprOehZ23mqchf3whxYXnvNgTQOXCxh6bpcqW8P6OybIk2bYO18r3qimZ3ypCbg==}
+  react-dock@0.8.0:
+    resolution: {integrity: sha512-/sUBWnsNlHIxmxoUHFPq8gcaH5k7MWGuHHeG3UjnXH3UblByxnARlUYewlMBtCUqcmbpPquYE5+GGvaG/hRkkg==}
     peerDependencies:
-      '@types/react': ^16.3.0 || ^17.0.0 || ^18.0.0
-      react: ^16.3.0 || ^17.0.0 || ^18.0.0
+      '@types/react': ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^18.3.1
+      react: ^19.2.7
 
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
-  react-json-tree@0.17.0:
-    resolution: {integrity: sha512-hcWjibI/fAvsKnfYk+lka5OrE1Lvb1jH5pSnFhIU5T8cCCxB85r6h/NOzDPggSSgErjmx4rl3+2EkeclIKBOhg==}
+  react-json-tree@0.20.0:
+    resolution: {integrity: sha512-h+f9fUNAxzBx1rbrgUF7+zSWKGHDtt2VPYLErIuB0JyKGnWgFMM21ksqQyb3EXwXNnoMW2rdE5kuAaubgGOx2Q==}
     peerDependencies:
-      '@types/react': ^16.3.0 || ^17.0.0 || ^18.0.0
-      react: ^16.3.0 || ^17.0.0 || ^18.0.0
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   reactiveweb@1.9.1:
@@ -8524,8 +8491,8 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
-  scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   schema-utils@2.7.1:
     resolution: {integrity: sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==}
@@ -10841,10 +10808,10 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@compiled/react@0.11.4(react@18.3.1)':
+  '@compiled/react@0.19.1(react@19.2.7)':
     dependencies:
       csstype: 3.1.3
-      react: 18.3.1
+      react: 19.2.7
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -10879,6 +10846,8 @@ snapshots:
     dependencies:
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
+
+  '@dmsnell/diff-match-patch@1.1.0': {}
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
@@ -12427,8 +12396,6 @@ snapshots:
 
   '@types/babel__code-frame@7.0.6': {}
 
-  '@types/base16@1.0.5': {}
-
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -12526,6 +12493,10 @@ snapshots:
     dependencies:
       '@types/node': 24.5.2
 
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.20
+
   '@types/lodash@4.17.20': {}
 
   '@types/mdast@4.0.4':
@@ -12564,8 +12535,6 @@ snapshots:
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
-
-  '@types/prop-types@15.7.15': {}
 
   '@types/prosemirror-dev-tools@3.0.6':
     dependencies:
@@ -13378,8 +13347,6 @@ snapshots:
 
   balanced-match@2.0.0: {}
 
-  base16@1.0.0: {}
-
   base64-js@1.5.1: {}
 
   base64id@2.0.0: {}
@@ -13983,9 +13950,9 @@ snapshots:
 
   color-support@1.1.3: {}
 
-  color@3.2.1:
+  color@4.2.3:
     dependencies:
-      color-convert: 1.9.3
+      color-convert: 2.0.1
       color-string: 1.9.1
 
   colord@2.9.3: {}
@@ -14087,15 +14054,15 @@ snapshots:
       ora: 3.4.0
       through2: 3.0.2
 
-  consolidate@0.16.0(handlebars@4.7.8)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.7):
+  consolidate@0.16.0(handlebars@4.7.8)(lodash@4.17.21)(mustache@4.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(underscore@1.13.7):
     dependencies:
       bluebird: 3.7.2
     optionalDependencies:
       handlebars: 4.7.8
       lodash: 4.17.21
       mustache: 4.2.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       underscore: 1.13.7
 
   content-disposition@0.5.4:
@@ -14330,8 +14297,6 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-
-  diff-match-patch@1.0.5: {}
 
   diff@7.0.0: {}
 
@@ -14672,7 +14637,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli@6.5.0(@types/node@20.19.30)(handlebars@4.7.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.7):
+  ember-cli@6.5.0(@types/node@20.19.30)(handlebars@4.7.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(underscore@1.13.7):
     dependencies:
       '@pnpm/find-workspace-dir': 1000.1.3
       babel-remove-types: 1.0.1
@@ -14749,7 +14714,7 @@ snapshots:
       sort-package-json: 2.15.1
       symlink-or-copy: 1.3.1
       temp: 0.9.4
-      testem: 3.16.0(handlebars@4.7.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.7)
+      testem: 3.16.0(handlebars@4.7.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(underscore@1.13.7)
       tiny-lr: 2.0.0
       tree-sync: 2.1.0
       walk-sync: 3.0.0
@@ -16971,12 +16936,12 @@ snapshots:
 
   jju@1.4.0: {}
 
-  jotai@1.13.1(@babel/core@7.28.6)(@babel/template@7.28.6)(react@18.3.1):
-    dependencies:
-      react: 18.3.1
+  jotai@2.20.0(@babel/core@7.28.6)(@babel/template@7.28.6)(@types/react@19.1.13)(react@19.2.7):
     optionalDependencies:
       '@babel/core': 7.28.6
       '@babel/template': 7.28.6
+      '@types/react': 19.1.13
+      react: 19.2.7
 
   js-beautify@1.15.4:
     dependencies:
@@ -17088,10 +17053,9 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsondiffpatch@0.4.1:
+  jsondiffpatch@0.7.6:
     dependencies:
-      chalk: 4.1.2
-      diff-match-patch: 1.0.5
+      '@dmsnell/diff-match-patch': 1.1.0
 
   jsonfile@2.4.0:
     optionalDependencies:
@@ -17201,6 +17165,8 @@ snapshots:
     dependencies:
       p-locate: 6.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash._baseflatten@3.1.4:
     dependencies:
       lodash.isarguments: 3.1.0
@@ -17211,8 +17177,6 @@ snapshots:
   lodash._isiterateecall@3.0.9: {}
 
   lodash.camelcase@4.3.0: {}
-
-  lodash.curry@4.1.1: {}
 
   lodash.debounce@3.1.1:
     dependencies:
@@ -17253,10 +17217,6 @@ snapshots:
       is-unicode-supported: 0.1.0
 
   longest-streak@3.1.0: {}
-
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
 
   lower-case@2.0.2:
     dependencies:
@@ -17720,6 +17680,8 @@ snapshots:
       readable-stream: 4.7.0
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.11: {}
 
   nanomatch@1.2.13:
     dependencies:
@@ -18253,12 +18215,6 @@ snapshots:
 
   promise.hash.helper@1.0.8: {}
 
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
-
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -18273,33 +18229,24 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.11.0
 
-  prosemirror-dev-tools@4.2.0(@babel/core@7.28.6)(@babel/template@7.28.6)(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  prosemirror-dev-tools@4.3.0(@babel/core@7.28.6)(@babel/template@7.28.6)(@types/react@19.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@babel/runtime': 7.28.6
-      '@compiled/react': 0.11.4(react@18.3.1)
+      '@compiled/react': 0.19.1(react@19.2.7)
       html: 1.0.0
-      jotai: 1.13.1(@babel/core@7.28.6)(@babel/template@7.28.6)(react@18.3.1)
-      jsondiffpatch: 0.4.1
-      nanoid: 3.3.11
+      jotai: 2.20.0(@babel/core@7.28.6)(@babel/template@7.28.6)(@types/react@19.1.13)(react@19.2.7)
+      jsondiffpatch: 0.7.6
+      nanoid: 5.1.11
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
-      react: 18.3.1
-      react-dock: 0.6.0(@types/react@19.1.13)(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      react-json-tree: 0.17.0(@types/react@19.1.13)(react@18.3.1)
+      react: 19.2.7
+      react-dock: 0.8.0(@types/react@19.1.13)(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+      react-json-tree: 0.20.0(@types/react@19.1.13)(react@19.2.7)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
       - '@types/react'
-      - jotai-devtools
-      - jotai-immer
-      - jotai-optics
-      - jotai-redux
-      - jotai-tanstack-query
-      - jotai-urql
-      - jotai-valtio
-      - jotai-xstate
-      - jotai-zustand
 
   prosemirror-dropcursor@1.8.2:
     dependencies:
@@ -18437,47 +18384,33 @@ snapshots:
     dependencies:
       '@rdfjs/types': 1.1.2
 
-  react-base16-styling@0.9.1:
+  react-base16-styling@0.10.0:
     dependencies:
-      '@babel/runtime': 7.28.6
-      '@types/base16': 1.0.5
       '@types/lodash': 4.17.20
-      base16: 1.0.0
-      color: 3.2.1
+      color: 4.2.3
       csstype: 3.1.3
-      lodash.curry: 4.1.1
+      lodash-es: 4.18.1
 
-  react-dock@0.6.0(@types/react@19.1.13)(react@18.3.1):
+  react-dock@0.8.0(@types/react@19.1.13)(react@19.2.7):
     dependencies:
-      '@babel/runtime': 7.28.6
-      '@types/lodash': 4.17.20
-      '@types/prop-types': 15.7.15
+      '@types/lodash-es': 4.17.12
       '@types/react': 19.1.13
-      lodash.debounce: 4.0.8
-      prop-types: 15.8.1
-      react: 18.3.1
+      lodash-es: 4.18.1
+      react: 19.2.7
 
-  react-dom@18.3.1(react@18.3.1):
+  react-dom@19.2.7(react@19.2.7):
     dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
+      react: 19.2.7
+      scheduler: 0.27.0
 
-  react-is@16.13.1: {}
-
-  react-json-tree@0.17.0(@types/react@19.1.13)(react@18.3.1):
+  react-json-tree@0.20.0(@types/react@19.1.13)(react@19.2.7):
     dependencies:
-      '@babel/runtime': 7.28.6
       '@types/lodash': 4.17.20
-      '@types/prop-types': 15.7.15
       '@types/react': 19.1.13
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-base16-styling: 0.9.1
+      react: 19.2.7
+      react-base16-styling: 0.10.0
 
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
+  react@19.2.7: {}
 
   reactiveweb@1.9.1(@babel/core@7.28.6)(@ember/test-waiters@4.1.1(@glint/template@1.7.3))(@glimmer/component@1.1.2(@babel/core@7.28.6))(@glint/template@1.7.3):
     dependencies:
@@ -18911,9 +18844,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
+  scheduler@0.27.0: {}
 
   schema-utils@2.7.1:
     dependencies:
@@ -19529,7 +19460,7 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  testem@3.16.0(handlebars@4.7.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.7):
+  testem@3.16.0(handlebars@4.7.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(underscore@1.13.7):
     dependencies:
       '@xmldom/xmldom': 0.8.11
       backbone: 1.6.1
@@ -19537,7 +19468,7 @@ snapshots:
       charm: 1.0.2
       commander: 2.20.3
       compression: 1.8.1
-      consolidate: 0.16.0(handlebars@4.7.8)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.7)
+      consolidate: 0.16.0(handlebars@4.7.8)(lodash@4.17.21)(mustache@4.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(underscore@1.13.7)
       execa: 1.0.0
       express: 4.21.2
       fireworm: 0.7.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 catalogs:
@@ -520,9 +520,7 @@ overrides:
   prosemirror-view: ^1.41.5
 
 patchedDependencies:
-  ember-headless-form:
-    hash: 3ffd83a43b842fdb4a0b3056a043c8a1a03cf60563de70328abd79a49a1707dd
-    path: patches/ember-headless-form.patch
+  ember-headless-form: 3ffd83a43b842fdb4a0b3056a043c8a1a03cf60563de70328abd79a49a1707dd
 
 importers:
 
@@ -606,6 +604,9 @@ importers:
       '@ember/render-modifiers':
         specifier: 'catalog:'
         version: 3.0.0(@glint/template@1.7.3)(ember-source@6.7.0(@glimmer/component@1.1.2(@babel/core@7.28.6))(rsvp@4.8.5))
+      '@ember/test-helpers':
+        specifier: ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
+        version: 5.4.1(@babel/core@7.28.6)(@glint/template@1.7.3)
       '@embroider/addon-shim':
         specifier: 'catalog:'
         version: 1.10.2
@@ -864,10 +865,10 @@ importers:
         version: 9.1.2(eslint@9.36.0(jiti@2.6.1))
       eslint-plugin-ember:
         specifier: 'catalog:'
-        version: 12.7.5(@babel/core@7.28.6)(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 12.7.5(@babel/core@7.28.6)(@typescript-eslint/parser@7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-import:
         specifier: 'catalog:'
-        version: 2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 17.23.2(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
@@ -3326,6 +3327,7 @@ packages:
 
   '@tsconfig/ember@3.0.12':
     resolution: {integrity: sha512-ypFTXqIzQAB5HpYPi4TwDElDcUheWrKsEaYXgjiCAvsH6zxcQ4zUeuJqmfT+FoUlHTPZ3Xyel81OxrcjI+rilw==}
+    deprecated: Please use @ember/app-tsconfig or @ember/library-tsconfig instead. These live at https://github.com/ember-cli/tsconfigs
 
   '@types/aws-lambda@8.10.152':
     resolution: {integrity: sha512-soT/c2gYBnT5ygwiHPmd9a1bftj462NWVk2tKCc1PYHSIacB2UwbTS2zYG4jzag1mRDuzg/OjtxQjQ2NKRB6Rw==}
@@ -3730,6 +3732,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -3779,6 +3782,11 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -9348,10 +9356,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache@2.4.0:
@@ -12976,8 +12986,8 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv-formats@2.1.1:
-    dependencies:
+  ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
       ajv: 8.17.1
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -14809,6 +14819,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ember-eslint-parser@0.5.11(@babel/core@7.28.6)(@typescript-eslint/parser@7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.28.6)(eslint@9.36.0(jiti@2.6.1))
+      '@glimmer/syntax': 0.95.0
+      '@typescript-eslint/tsconfig-utils': 8.44.1(typescript@5.9.3)
+      content-tag: 2.0.3
+      eslint-scope: 7.2.2
+      html-tags: 3.3.1
+      mathml-tag-names: 2.1.3
+      svg-tags: 1.0.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint
+      - typescript
+
   ember-eslint-parser@0.5.11(@babel/core@7.28.6)(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.28.6
@@ -15430,15 +15457,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.36.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.36.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.44.1(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.36.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-ember@12.7.5(@babel/core@7.28.6)(@typescript-eslint/parser@7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@ember-data/rfc395-data': 0.0.4
+      css-tree: 3.1.0
+      ember-eslint-parser: 0.5.11(@babel/core@7.28.6)(@typescript-eslint/parser@7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
+      ember-rfc176-data: 0.3.18
+      eslint: 9.36.0(jiti@2.6.1)
+      eslint-utils: 3.0.0(eslint@9.36.0(jiti@2.6.1))
+      estraverse: 5.3.0
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      requireindex: 1.2.0
+      snake-case: 3.0.4
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - typescript
 
   eslint-plugin-ember@12.7.5(@babel/core@7.28.6)(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -15466,7 +15512,7 @@ snapshots:
       eslint: 9.36.0(jiti@2.6.1)
       eslint-compat-utils: 0.5.1(eslint@9.36.0(jiti@2.6.1))
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15477,7 +15523,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.36.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.36.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.36.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15489,7 +15535,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.44.1(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -18862,7 +18908,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.17.1
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
   semver@5.7.2: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -181,3 +181,18 @@ overrides:
   chalk@^2.0.0: ^4.1.2
   js-beautify>glob: ^10.5.0
   prosemirror-view: 'catalog:'
+
+peerDependencyRules:
+  allowedVersions:
+    react: "18"
+    react-dom: "18"
+    "@ember/render-modifiers>ember-source": "6"
+
+patchedDependencies:
+  ember-headless-form: "patches/ember-headless-form.patch"
+allowUnusedPatches: true
+
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -126,13 +126,13 @@ catalog:
   mdast-util-to-string: ^4.0.0
   mdn-polyfills: ^5.20.0
   mongoose: ^8.21.0
-  n3: ^2.0.3  
+  n3: ^2.0.3
   octokit: ^4.1.4
   postcss: ^8.5.6
   prettier: ^3.8.0
   prettier-plugin-ember-template-tag: ^2.1.2
   prosemirror-commands: ^1.7.1
-  prosemirror-dev-tools: ^4.2.0
+  prosemirror-dev-tools: ^4.3.0
   prosemirror-dropcursor: ^1.8.2
   prosemirror-history: ./packages/ember-rdfa-editor/vendored-deps/prosemirror-history-1.5.0.tgz
   prosemirror-inputrules: ^1.5.1
@@ -147,8 +147,8 @@ catalog:
   qunit: ^2.25.0
   qunit-dom: ^3.5.0
   rdf-data-factory: ^1.1.3
-  react: ^18.3.1
-  react-dom: ^18.3.1
+  react: ^19.2.4
+  react-dom: ^19.2.4
   reactiveweb: ^1.9.1
   read-package-up: ^11.0.0
   relative-to-absolute-iri: ^1.0.7


### PR DESCRIPTION
### Overview
Use the latest Node version supported by our ember version. Moves corepack and pnpm to more recent versions too. Since corepack will be removed from node 25+, I removed the comments about how we install it, since that will remain one of the recommended ways in the future.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Build process should work as expected...

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] changelog