### PR TITLE
Contextual actions rework

### DIFF
--- a/.changeset/many-ends-juggle.md
+++ b/.changeset/many-ends-juggle.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Contextual actions: add per-group loading, per-group debounce time, allow groups without label

--- a/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
+++ b/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
@@ -40,12 +40,25 @@
 }
 
 .say-contextual-actions-menu-search-bar {
+  position: sticky;
+  top: 0;
+  background-color: white;
+  z-index: 2;
+  &.is-stuck {
+    box-shadow: 0 2px 3px 0px rgba(0, 0, 0, 0.04);
+    // border-bottom: 1px solid var(--au-gray-200);
+    transition: box-shadow 0.15s ease;
+  }
   padding: 0.9rem;
-  padding-bottom: 0.6rem;
 }
 
 .say-contextual-actions-menu {
   @extend .say-floating-element;
+
+  overflow-y: scroll;
+  overflow-x: hidden;
+
+  max-height: 50vh;
 
   display: flex;
   flex-direction: column;
@@ -91,10 +104,6 @@
 .say-contextual-actions-menu-entries-container {
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
-  overflow-x: hidden;
-
-  max-height: 50vh;
 
   button {
     cursor: pointer;
@@ -129,20 +138,16 @@
 }
 
 .say-contextual-actions-menu-group-header {
-  position: sticky;
-  top: 0;
-  background-color: white;
-  z-index: 1;
   text-transform: uppercase;
 
   padding-bottom: 0.3rem;
   padding-left: au-settings.$au-unit-small;
   padding-right: au-settings.$au-unit-small;
-
-  &.is-stuck {
-    box-shadow: 0 2px 3px 0px rgba(0, 0, 0, 0.04);
-    // border-bottom: 1px solid var(--au-gray-200);
-    transition: box-shadow 0.15s ease;
+  // The :empty pseudo-selector does not seem to work here
+  // maybe due to whitespace being present?
+  // :-moz-only-whitespace does not work in chrome
+  &.empty {
+    padding-bottom: au-settings.$au-unit-tiny;
   }
 }
 

--- a/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
+++ b/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
@@ -58,7 +58,11 @@
   overflow-y: scroll;
   overflow-x: hidden;
 
-  max-height: 50vh;
+  // Because the scroll is set on the whole menu, the overscroll behavior on
+  // firefox makes the search bar and sticky groups move, this is not desired
+  // Might be better to put `overflow: scroll` only on the container that has the
+  // non-sticky groups.
+  overscroll-behavior: none;
 
   display: flex;
   flex-direction: column;

--- a/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
+++ b/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
@@ -71,6 +71,7 @@
 }
 
 .say-contextual-actions-menu-group-wrapper {
+  padding-bottom: au-settings.$au-unit-tiny;
   background-color: white;
   z-index: 1;
   &:nth-last-child(2) {
@@ -84,10 +85,6 @@
     box-shadow: 0 -2px 3px 0px rgba(0, 0, 0, 0.04);
     // border-bottom: 1px solid var(--au-gray-200);
     transition: box-shadow 0.15s ease;
-  }
-  &.sticky-top {
-    position: sticky;
-    top: 0;
   }
 }
 
@@ -141,7 +138,6 @@
   padding-bottom: 0.3rem;
   padding-left: au-settings.$au-unit-small;
   padding-right: au-settings.$au-unit-small;
-  padding-top: au-settings.$au-unit-tiny;
 
   &.is-stuck {
     box-shadow: 0 2px 3px 0px rgba(0, 0, 0, 0.04);
@@ -150,10 +146,9 @@
   }
 }
 
-// .say-contextual-actions-menu-separator {
-//   height: 1px;
-//   background-color: black;
-// }
+.say-contextual-actions-menu-separator {
+  border-bottom: solid 1px var(--au-gray-200);
+}
 
 .say-contextual-actions-menu-entry {
   display: flex;

--- a/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
+++ b/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
@@ -97,8 +97,6 @@
   overflow-y: scroll;
   overflow-x: hidden;
 
-  padding-bottom: au-settings.$au-unit-tiny;
-
   max-height: 50vh;
 
   button {
@@ -151,6 +149,11 @@
     transition: box-shadow 0.15s ease;
   }
 }
+
+// .say-contextual-actions-menu-separator {
+//   height: 1px;
+//   background-color: black;
+// }
 
 .say-contextual-actions-menu-entry {
   display: flex;

--- a/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
+++ b/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
@@ -97,6 +97,10 @@
   overflow-y: scroll;
   overflow-x: hidden;
 
+  padding-bottom: au-settings.$au-unit-tiny;
+
+  max-height: 50vh;
+
   button {
     cursor: pointer;
     outline: none;

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -80,7 +80,7 @@ export default class ContextualActionsMenu extends Component<Args> {
       this.args.onClose?.();
     };
     const handleKeydown = (event: KeyboardEvent) => {
-      if (!this.args.isLoading && !this.actionAmount) return;
+      if (!this.args.isLoading) return;
 
       switch (event.key) {
         case 'ArrowDown':

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -117,13 +117,12 @@ export default class ContextualActionsMenu extends Component<Args> {
           break;
         }
         case 'Delete':
-        case 'Backspace': {
-          if (this.args.searchQuery?.length === 0) {
+        case 'Backspace':
+          if (!this.args.searchQuery) {
             event.preventDefault();
             this.args.onClose?.();
           }
           break;
-        }
         case 'Tab':
           if (this.actionAmount) {
             if (event.shiftKey) {

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -233,7 +233,7 @@ export default class ContextualActionsMenu extends Component<Args> {
       size({
         apply({ availableHeight, elements }) {
           Object.assign(elements.floating.style, {
-            maxHeight: `${Math.max(0, availableHeight)}px`,
+            height: `${Math.max(0, availableHeight)}px`,
           });
         },
       }),

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -25,10 +25,15 @@ import { cached, tracked } from '@glimmer/tracking';
 import { runTask } from 'ember-lifeline';
 import { eq } from 'ember-truth-helpers';
 
+type GroupWithStatus = ContextualActionGroup & {
+  isLoading: boolean;
+  errorMessage: string | null;
+  actions: ContextualAction[] | null;
+};
+
 type Args = {
   controller: SayController;
-  actions?: ContextualAction[];
-  groups?: ContextualActionGroup[];
+  groups?: GroupWithStatus[];
   isLoading?: boolean;
   errorMessage?: string;
   enableSearch?: boolean;
@@ -80,8 +85,6 @@ export default class ContextualActionsMenu extends Component<Args> {
       this.args.onClose?.();
     };
     const handleKeydown = (event: KeyboardEvent) => {
-      if (!this.args.isLoading) return;
-
       switch (event.key) {
         case 'ArrowDown':
         case 'Down':
@@ -184,18 +187,22 @@ export default class ContextualActionsMenu extends Component<Args> {
     return searchIndex;
   }
 
+  get sortedGroups() {
+    // TODO fix on merge, need to sort by prio and stickyness
+    return this.args.groups?.toSorted(sortByPriority);
+  }
+
   @cached
   get groupedActions() {
-    return this.args.groups
+    return this.sortedGroups
       ?.map((group) => ({
         ...group,
         actions:
-          this.args.actions
+          group.actions
             ?.filter((action) => action.group === group.id)
             .toSorted(sortByPriority) ?? [],
       }))
-      .filter((group) => group.actions.length > 0)
-      .toSorted(sortGroups);
+      .filter((group) => group.isLoading || group.actions.length > 0);
   }
 
   get actionAmount() {
@@ -350,7 +357,7 @@ export default class ContextualActionsMenu extends Component<Args> {
           @size="small"
           @icon="alert-triangle"
           @skin="error"
-          class="au-u-margin-bottom-tiny au-u-margin-top-tiny au-u-margin-left-tiny au-u-margin-right-tiny"
+          class="au-u-margin-tiny"
         >{{@errorMessage}}</AuAlert>
       {{else}}
         <div class="say-contextual-actions-menu-entries-container">
@@ -375,30 +382,45 @@ export default class ContextualActionsMenu extends Component<Args> {
                 {{group.label}}
               </div>
               <div class="au-u-padding-left-tiny au-u-padding-right-tiny">
-                {{#each group.actions as |actionItem|}}
-                  <button
-                    {{this.addActionElementToMap actionItem}}
-                    {{on "click" (fn this.selectAction actionItem)}}
-                    {{on
-                      "mousemove"
-                      (fn this.updateSelectedActionIndex actionItem)
-                    }}
-                    class="say-contextual-actions-menu-entry au-u-text-left
-                      {{if
-                        (this.isSelectedAction actionItem)
-                        'focused-menu-entry'
-                      }}"
-                    type="button"
-                    title={{actionItem.description}}
-                  >
-                    <div id="button-content">
-                      {{#if actionItem.icon}}
-                        <AuIcon @size="large" @icon={{actionItem.icon}} />
-                      {{/if}}
-                      <span>{{actionItem.label}}</span>
-                    </div>
-                  </button>
-                {{/each}}
+                {{#if group.isLoading}}
+                  <div class="au-u-flex au-u-flex--center au-u-padding">
+                    <AuLoader>{{t
+                        "ember-rdfa-editor.contextual-actions.loading-actions"
+                      }}</AuLoader>
+                  </div>
+                {{else if group.errorMessage}}
+                  <AuAlert
+                    @size="small"
+                    @icon="alert-triangle"
+                    @skin="error"
+                    class="au-u-margin-tiny"
+                  >{{group.errorMessage}}</AuAlert>
+                {{else}}
+                  {{#each group.actions as |actionItem|}}
+                    <button
+                      {{this.addActionElementToMap actionItem}}
+                      {{on "click" (fn this.selectAction actionItem)}}
+                      {{on
+                        "mousemove"
+                        (fn this.updateSelectedActionIndex actionItem)
+                      }}
+                      class="say-contextual-actions-menu-entry au-u-text-left
+                        {{if
+                          (this.isSelectedAction actionItem)
+                          'focused-menu-entry'
+                        }}"
+                      type="button"
+                      title={{actionItem.description}}
+                    >
+                      <div id="button-content">
+                        {{#if actionItem.icon}}
+                          <AuIcon @size="large" @icon={{actionItem.icon}} />
+                        {{/if}}
+                        <span>{{actionItem.label}}</span>
+                      </div>
+                    </button>
+                  {{/each}}
+                {{/if}}
               </div>
             </div>
             <div class="say-contextual-actions-menu-group-sticky-sentinel" />

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -364,10 +364,7 @@ export default class ContextualActionsMenu extends Component<Args> {
           {{#each this.groupedActions as |group|}}
             <div
               class="say-contextual-actions-menu-group-wrapper
-                {{if (eq group.sticky 'bottom') 'sticky-bottom'}}{{if
-                  (eq group.sticky 'top')
-                  'sticky-top'
-                }}"
+                {{if (eq group.sticky 'bottom') 'sticky-bottom'}}"
               {{! @glint-expect-error type of the modifier helper is incorrect}}
               {{(if
                 (eq group.sticky "bottom")
@@ -375,6 +372,9 @@ export default class ContextualActionsMenu extends Component<Args> {
               )}}
             >
               <div class="say-contextual-actions-menu-group-sticky-sentinel" />
+              {{#unless group.label}}
+                <div class="say-contextual-actions-menu-separator"></div>
+              {{/unless}}
               <div
                 class="say-contextual-actions-menu-group-header au-u-muted"
                 {{this.observeSticky "top"}}

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -23,7 +23,7 @@ import { modifier as eModifier } from 'ember-modifier';
 import { getReferenceElementFromSelection } from '#root/components/utils/floating-ui-reference-element.ts';
 import { cached, tracked } from '@glimmer/tracking';
 import { runTask } from 'ember-lifeline';
-import { eq } from 'ember-truth-helpers';
+import { eq, and } from 'ember-truth-helpers';
 
 type GroupWithStatus = ContextualActionGroup & {
   isLoading: boolean;
@@ -69,6 +69,7 @@ function sortGroups(
 
 export default class ContextualActionsMenu extends Component<Args> {
   @tracked selectedActionIndex: number = 0;
+  @tracked menuHeightPx: number = 0;
 
   actionToElement = new Map<ContextualAction, Element>();
 
@@ -316,6 +317,23 @@ export default class ContextualActionsMenu extends Component<Args> {
     runTask(this, () => element.focus());
   });
 
+  trackElementHeight = eModifier((element: HTMLElement) => {
+    const observer = new ResizeObserver((entries) => {
+      entries.forEach((entry) => {
+        const size = entry.contentBoxSize[0];
+        if (!size) return null;
+        this.menuHeightPx = size.blockSize;
+      });
+    });
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  });
+
+  get shouldAllowStickyGroups() {
+    return this.menuHeightPx > 250;
+  }
+
   <template>
     <div
       {{floatingUI
@@ -328,6 +346,7 @@ export default class ContextualActionsMenu extends Component<Args> {
       class="say-contextual-actions-menu"
       ...attributes
       {{this.setUpListeners}}
+      {{this.trackElementHeight}}
     >
       {{#if @enableSearch}}
         <div class="say-contextual-actions-menu-group-sticky-sentinel" />
@@ -365,7 +384,10 @@ export default class ContextualActionsMenu extends Component<Args> {
           {{#each this.groupedActions as |group|}}
             <div
               class="say-contextual-actions-menu-group-wrapper
-                {{if (eq group.sticky 'bottom') 'sticky-bottom'}}"
+                {{if
+                  (and (eq group.sticky 'bottom') this.shouldAllowStickyGroups)
+                  'sticky-bottom'
+                }}"
               {{! @glint-expect-error type of the modifier helper is incorrect}}
               {{(if
                 (eq group.sticky "bottom")

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -233,7 +233,7 @@ export default class ContextualActionsMenu extends Component<Args> {
       size({
         apply({ availableHeight, elements }) {
           Object.assign(elements.floating.style, {
-            height: `${Math.max(0, availableHeight)}px`,
+            maxHeight: `${Math.min(window.innerHeight / 2, availableHeight)}px`,
           });
         },
       }),
@@ -245,9 +245,7 @@ export default class ContextualActionsMenu extends Component<Args> {
   // This can be removed once the `:sticky` selector becomes supported
   observeSticky = eModifier(
     (element: HTMLElement, [position]: ['top' | 'bottom']) => {
-      const container =
-        element.closest('.say-contextual-actions-menu-entries-container') ??
-        element.closest('.say-contextual-actions-menu');
+      const container = element.closest('.say-contextual-actions-menu');
 
       if (!container) return;
 

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -245,9 +245,9 @@ export default class ContextualActionsMenu extends Component<Args> {
   // This can be removed once the `:sticky` selector becomes supported
   observeSticky = eModifier(
     (element: HTMLElement, [position]: ['top' | 'bottom']) => {
-      const container = element.closest(
-        '.say-contextual-actions-menu-entries-container',
-      );
+      const container =
+        element.closest('.say-contextual-actions-menu-entries-container') ??
+        element.closest('.say-contextual-actions-menu');
 
       if (!container) return;
 
@@ -332,7 +332,11 @@ export default class ContextualActionsMenu extends Component<Args> {
       {{this.setUpListeners}}
     >
       {{#if @enableSearch}}
-        <div class="say-contextual-actions-menu-search-bar">
+        <div class="say-contextual-actions-menu-group-sticky-sentinel" />
+        <div
+          class="say-contextual-actions-menu-search-bar"
+          {{this.observeSticky "top"}}
+        >
           <AuInput
             {{this.focus}}
             @icon="search"
@@ -375,8 +379,8 @@ export default class ContextualActionsMenu extends Component<Args> {
                 <div class="say-contextual-actions-menu-separator"></div>
               {{/unless}}
               <div
-                class="say-contextual-actions-menu-group-header au-u-muted"
-                {{this.observeSticky "top"}}
+                class="say-contextual-actions-menu-group-header au-u-muted
+                  {{unless group.label 'empty'}}"
               >
                 {{group.label}}
               </div>

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -188,8 +188,7 @@ export default class ContextualActionsMenu extends Component<Args> {
   }
 
   get sortedGroups() {
-    // TODO fix on merge, need to sort by prio and stickyness
-    return this.args.groups?.toSorted(sortByPriority);
+    return this.args.groups?.toSorted(sortGroups);
   }
 
   @cached

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -384,9 +384,15 @@ export default class ContextualActionsMenu extends Component<Args> {
               <div class="au-u-padding-left-tiny au-u-padding-right-tiny">
                 {{#if group.isLoading}}
                   <div class="au-u-flex au-u-flex--center au-u-padding">
-                    <AuLoader>{{t
-                        "ember-rdfa-editor.contextual-actions.loading-actions"
-                      }}</AuLoader>
+                    <AuLoader>
+                      {{#if group.loadingMessage}}
+                        {{group.loadingMessage}}
+                      {{else}}
+                        {{t
+                          "ember-rdfa-editor.contextual-actions.loading-actions"
+                        }}
+                      {{/if}}
+                    </AuLoader>
                   </div>
                 {{else if group.errorMessage}}
                   <AuAlert

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -20,7 +20,7 @@ import {
   getSlashCommandsPluginState,
   slashCommandsStateChanged,
 } from '#root/plugins/slash-commands/index.ts';
-import { localCopy, dedupeTracked } from 'tracked-toolbox';
+import { localCopy } from 'tracked-toolbox';
 import {
   all,
   restartableTask,
@@ -28,14 +28,11 @@ import {
   timeout,
   type TaskInstance,
 } from 'ember-concurrency';
-import { TrackedArray } from 'tracked-built-ins';
 
 type Args = {
   controller: SayController;
   getGroups?: GetContextualActionGroups;
 };
-
-const SEARCH_TIMEOUT_MS = 500;
 
 export default class ContextualActionsContainer extends Component<Args> {
   /*
@@ -62,7 +59,7 @@ export default class ContextualActionsContainer extends Component<Args> {
    * actions menu because it changes the editor state onBlur
    * which we want to ignore
    */
-  @dedupeTracked localEditorState: EditorState | null = null;
+  @tracked localEditorState: EditorState | null = null;
   @tracked plusButtonClicked = false;
 
   editorStateListener = (oldState: EditorState, newState: EditorState) => {
@@ -151,8 +148,13 @@ export default class ContextualActionsContainer extends Component<Args> {
   }
 
   loadGroupTask = task(
-    async (state: EditorState, group: ContextualActionGroup) =>
-      await group.getActions(state, this.searchQuery),
+    async (state: EditorState, group: ContextualActionGroup) => {
+      if (this.searchQuery) {
+        await timeout(group.searchDebounceMs ?? 0);
+      }
+
+      return await group.getActions(state, this.searchQuery);
+    },
   );
 
   // We don't use a trackedfunction because it causes the menu to reload
@@ -162,10 +164,6 @@ export default class ContextualActionsContainer extends Component<Args> {
     console.log('started the task');
     const state = this.localEditorState;
     if (!this.showContextMenu || !state) return [];
-
-    // if (this.searchQuery) {
-    //   await timeout(SEARCH_TIMEOUT_MS);
-    // }
 
     this.loadGroupTaskInstances = this.groups.map((group) =>
       this.loadGroupTask.perform(state, group),

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -12,7 +12,6 @@ import { on } from '@ember/modifier';
 import {
   type ContextualAction,
   type GetContextualActionGroups,
-  type GetContextualActions,
 } from '#root/plugins/contextual-actions/index.ts';
 import { action } from '@ember/object';
 import { runTask } from 'ember-lifeline';
@@ -25,7 +24,6 @@ import { restartableTask, timeout } from 'ember-concurrency';
 
 type Args = {
   controller: SayController;
-  getActions?: GetContextualActions;
   getGroups?: GetContextualActionGroups;
 };
 
@@ -131,10 +129,12 @@ export default class ContextualActionsContainer extends Component<Args> {
   // after the first load (after the debounce time)
   // See https://discord.com/channels/480462759797063690/1501197288603910266
   getActionsTask = restartableTask(async () => {
-    await timeout(SEARCH_TIMEOUT_MS);
+    if (this.searchQuery) {
+      await timeout(SEARCH_TIMEOUT_MS);
+    }
     const state = this.localEditorState;
     if (!this.showContextMenu || !state || this.loadActionsError) return [];
-    const getActions = this.args.getActions ?? [];
+    const getActions = this.groups?.flatMap((group) => group.getActions) ?? [];
 
     try {
       this.contextualActions = (

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -29,6 +29,12 @@ import {
   type TaskInstance,
 } from 'ember-concurrency';
 
+type GroupWithStatus = ContextualActionGroup & {
+  isLoading: boolean;
+  errorMessage: string | null;
+  actions: ContextualAction[] | null;
+};
+
 type Args = {
   controller: SayController;
   getGroups?: GetContextualActionGroups;
@@ -47,7 +53,10 @@ export default class ContextualActionsContainer extends Component<Args> {
   @tracked searchQuery: string = '';
 
   // @tracked groupsWithStatus: TrackedArray<GroupWithStatus> = new TrackedArray();
-  @tracked loadGroupTaskInstances: TaskInstance<ContextualAction[]>[] = [];
+  @tracked loadGroupTaskInstances: {
+    group: ContextualActionGroup;
+    taskInstance: TaskInstance<ContextualAction[]>;
+  }[] = [];
 
   // Local copy because we want to control openness of context menu (by setting this to null to close)
   @localCopy('selectedEditorNode', null) selectedEditorNodeLocal = null;
@@ -149,7 +158,11 @@ export default class ContextualActionsContainer extends Component<Args> {
 
   loadGroupTask = task(
     async (state: EditorState, group: ContextualActionGroup) => {
-      if (this.searchQuery) {
+      if (
+        this.searchQuery &&
+        group.searchDebounceMs &&
+        group.searchDebounceMs > 0
+      ) {
         await timeout(group.searchDebounceMs ?? 0);
       }
 
@@ -165,25 +178,30 @@ export default class ContextualActionsContainer extends Component<Args> {
     const state = this.localEditorState;
     if (!this.showContextMenu || !state) return [];
 
-    this.loadGroupTaskInstances = this.groups.map((group) =>
-      this.loadGroupTask.perform(state, group),
-    );
+    this.loadGroupTaskInstances = this.groups.map((group) => ({
+      group,
+      taskInstance: this.loadGroupTask.perform(state, group),
+    }));
 
     // Child tasks get cancelled automagically on restart
     await all(this.loadGroupTaskInstances);
   });
 
-  get groupsWithStatus() {
-    return this.groups.map((group, index) => {
-      const taskInstance = this.loadGroupTaskInstances[index];
+  get groupsWithStatus(): GroupWithStatus[] {
+    return this.loadGroupTaskInstances.map(({ group, taskInstance }) => {
       if (taskInstance === undefined)
-        return { ...group, actions: [], isLoading: false, errorMessage: null };
+        return {
+          ...group,
+          actions: [],
+          isLoading: false,
+          errorMessage: null,
+        };
       return {
         ...group,
         actions: taskInstance.isError ? [] : taskInstance.value,
         isLoading: taskInstance.isRunning,
         errorMessage: taskInstance.isError
-          ? this.getErrorMessage(this.getErrorMessage(taskInstance.error))
+          ? this.getErrorMessage(taskInstance.error)
           : null,
       };
     });

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -11,6 +11,7 @@ import AuIcon from '@appuniversum/ember-appuniversum/components/au-icon';
 import { on } from '@ember/modifier';
 import {
   type ContextualAction,
+  type ContextualActionGroup,
   type GetContextualActionGroups,
 } from '#root/plugins/contextual-actions/index.ts';
 import { action } from '@ember/object';
@@ -19,33 +20,37 @@ import {
   getSlashCommandsPluginState,
   slashCommandsStateChanged,
 } from '#root/plugins/slash-commands/index.ts';
-import { localCopy } from 'tracked-toolbox';
-import { restartableTask, timeout } from 'ember-concurrency';
+import { localCopy, dedupeTracked } from 'tracked-toolbox';
+import {
+  all,
+  restartableTask,
+  task,
+  timeout,
+  type TaskInstance,
+} from 'ember-concurrency';
+import { TrackedArray } from 'tracked-built-ins';
 
 type Args = {
   controller: SayController;
   getGroups?: GetContextualActionGroups;
 };
 
-type GroupWithStatus = {
-  isLoading: boolean;
-  errorMessage: string | null;
-  actions: ContextualAction[];
-};
-
 const SEARCH_TIMEOUT_MS = 500;
 
 export default class ContextualActionsContainer extends Component<Args> {
+  /*
+   * DO NOT USE this.controller.mainEditorState in this component
+   * unless you know what you are doing. Use this.localEditorState instead.
+   * Otherwise the tracking will cause unnecessary reloading of data
+   */
+
   @service declare intl: IntlService;
 
   @tracked loadActionsError: string | null = null;
   @tracked searchQuery: string = '';
 
-  /**
-   * We use 2 separate properties to avoid getting the "used value in the same computation" error
-   */
-  @tracked groupsWithStatus: GroupWithStatus[] = [];
-  groupsWithStatusUntracked: GroupWithStatus[] = [];
+  // @tracked groupsWithStatus: TrackedArray<GroupWithStatus> = new TrackedArray();
+  @tracked loadGroupTaskInstances: TaskInstance<ContextualAction[]>[] = [];
 
   // Local copy because we want to control openness of context menu (by setting this to null to close)
   @localCopy('selectedEditorNode', null) selectedEditorNodeLocal = null;
@@ -57,7 +62,7 @@ export default class ContextualActionsContainer extends Component<Args> {
    * actions menu because it changes the editor state onBlur
    * which we want to ignore
    */
-  @tracked localEditorState: EditorState | null = null;
+  @dedupeTracked localEditorState: EditorState | null = null;
   @tracked plusButtonClicked = false;
 
   editorStateListener = (oldState: EditorState, newState: EditorState) => {
@@ -75,15 +80,12 @@ export default class ContextualActionsContainer extends Component<Args> {
     }
   };
 
-  get contextualActions(): ContextualAction[] {
-    return this.groupsWithStatus.flatMap((g) => g.actions);
-  }
-
   /**
    * Returns the node to display the menu for
    */
   get selectedEditorNode() {
-    const selection = this.controller.mainEditorState.selection;
+    if (!this.localEditorState) return null;
+    const { selection } = this.localEditorState;
     if (selection instanceof NodeSelection) {
       return selection.node;
     }
@@ -116,6 +118,7 @@ export default class ContextualActionsContainer extends Component<Args> {
     this.plusButtonClicked = false;
     this.searchQuery = '';
     this.selectedEditorNodeLocal = null;
+    void this.getActionsTask.cancelAll();
     runTask(this, () => this.controller.mainEditorView.focus());
   };
 
@@ -139,65 +142,54 @@ export default class ContextualActionsContainer extends Component<Args> {
     return this.groups.length > 0 && !this.showContextMenu;
   }
 
-  updateGroupWithStatusAt(
-    groupWithStatus: Partial<GroupWithStatus>,
-    index: number,
-  ) {
-    const newGroupsWithStatus = [...this.groupsWithStatusUntracked];
-    newGroupsWithStatus[index] = {
-      ...this.groupsWithStatusUntracked[index],
-      ...groupWithStatus,
-    };
-    this.groupsWithStatusUntracked = newGroupsWithStatus;
+  getErrorMessage(error: unknown) {
+    return error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : this.intl.t('ember-rdfa-editor.utils.something-went-wrong');
   }
+
+  loadGroupTask = task(
+    async (state: EditorState, group: ContextualActionGroup) =>
+      await group.getActions(state, this.searchQuery),
+  );
 
   // We don't use a trackedfunction because it causes the menu to reload
   // after the first load (after the debounce time)
   // See https://discord.com/channels/480462759797063690/1501197288603910266
   getActionsTask = restartableTask(async () => {
-    if (this.searchQuery) {
-      await timeout(SEARCH_TIMEOUT_MS);
-    }
+    console.log('started the task');
     const state = this.localEditorState;
     if (!this.showContextMenu || !state) return [];
 
-    const groups = this.groups;
+    // if (this.searchQuery) {
+    //   await timeout(SEARCH_TIMEOUT_MS);
+    // }
 
-    // Reset the groupsWithStatus "map"
-    this.groupsWithStatusUntracked = groups.map(() => ({
-      isLoading: true,
-      errorMessage: null,
-      actions: [],
-    }));
-
-    await Promise.all(
-      groups.map(async (group, index) => {
-        try {
-          const results = await group.getActions(state, this.searchQuery);
-          this.updateGroupWithStatusAt(
-            {
-              errorMessage: null,
-              actions: results.flat(),
-            },
-            index,
-          );
-          this.groupsWithStatus = [...this.groupsWithStatusUntracked];
-        } catch (error) {
-          const message =
-            error instanceof Error
-              ? error.message
-              : typeof error === 'string'
-                ? error
-                : this.intl.t('ember-rdfa-editor.utils.something-went-wrong');
-          this.updateGroupWithStatusAt({ errorMessage: message }, index);
-          this.groupsWithStatus = [...this.groupsWithStatusUntracked];
-        } finally {
-          this.updateGroupWithStatusAt({ isLoading: false }, index);
-          this.groupsWithStatus = [...this.groupsWithStatusUntracked];
-        }
-      }),
+    this.loadGroupTaskInstances = this.groups.map((group) =>
+      this.loadGroupTask.perform(state, group),
     );
+
+    // Child tasks get cancelled automagically on restart
+    await all(this.loadGroupTaskInstances);
   });
+
+  get groupsWithStatus() {
+    return this.groups.map((group, index) => {
+      const taskInstance = this.loadGroupTaskInstances[index];
+      if (taskInstance === undefined)
+        return { ...group, actions: [], isLoading: false, errorMessage: null };
+      return {
+        ...group,
+        actions: taskInstance.isError ? [] : taskInstance.value,
+        isLoading: taskInstance.isRunning,
+        errorMessage: taskInstance.isError
+          ? this.getErrorMessage(this.getErrorMessage(taskInstance.error))
+          : null,
+      };
+    });
+  }
 
   @action
   executeAction(action: ContextualAction) {
@@ -240,7 +232,6 @@ export default class ContextualActionsContainer extends Component<Args> {
 
   setSearchQuery = (query: string) => {
     this.searchQuery = query;
-    void this.getActionsTask.perform();
   };
 
   startGetActionsTask = modifier(() => {
@@ -265,12 +256,7 @@ export default class ContextualActionsContainer extends Component<Args> {
           {{this.startGetActionsTask}}
           @enableSearch={{true}}
           @controller={{this.controller}}
-          @actions={{if
-            this.contextualActions
-            this.contextualActions
-            undefined
-          }}
-          @groups={{this.groups}}
+          @groups={{this.groupsWithStatus}}
           @onActionSelected={{this.selectAction}}
           @onClose={{this.closeContextMenu}}
           @onSearch={{this.setSearchQuery}}

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -27,6 +27,12 @@ type Args = {
   getGroups?: GetContextualActionGroups;
 };
 
+type GroupWithStatus = {
+  isLoading: boolean;
+  errorMessage: string | null;
+  actions: ContextualAction[];
+};
+
 const SEARCH_TIMEOUT_MS = 500;
 
 export default class ContextualActionsContainer extends Component<Args> {
@@ -34,6 +40,12 @@ export default class ContextualActionsContainer extends Component<Args> {
 
   @tracked loadActionsError: string | null = null;
   @tracked searchQuery: string = '';
+
+  /**
+   * We use 2 separate properties to avoid getting the "used value in the same computation" error
+   */
+  @tracked groupsWithStatus: GroupWithStatus[] = [];
+  groupsWithStatusUntracked: GroupWithStatus[] = [];
 
   // Local copy because we want to control openness of context menu (by setting this to null to close)
   @localCopy('selectedEditorNode', null) selectedEditorNodeLocal = null;
@@ -47,8 +59,6 @@ export default class ContextualActionsContainer extends Component<Args> {
    */
   @tracked localEditorState: EditorState | null = null;
   @tracked plusButtonClicked = false;
-
-  @tracked contextualActions: ContextualAction[] = [];
 
   editorStateListener = (oldState: EditorState, newState: EditorState) => {
     const docChanged = !oldState.doc.eq(newState.doc);
@@ -64,6 +74,10 @@ export default class ContextualActionsContainer extends Component<Args> {
       this.localEditorState = newState;
     }
   };
+
+  get contextualActions(): ContextualAction[] {
+    return this.groupsWithStatus.flatMap((g) => g.actions);
+  }
 
   /**
    * Returns the node to display the menu for
@@ -125,6 +139,18 @@ export default class ContextualActionsContainer extends Component<Args> {
     return this.groups.length > 0 && !this.showContextMenu;
   }
 
+  updateGroupWithStatusAt(
+    groupWithStatus: Partial<GroupWithStatus>,
+    index: number,
+  ) {
+    const newGroupsWithStatus = [...this.groupsWithStatusUntracked];
+    newGroupsWithStatus[index] = {
+      ...this.groupsWithStatusUntracked[index],
+      ...groupWithStatus,
+    };
+    this.groupsWithStatusUntracked = newGroupsWithStatus;
+  }
+
   // We don't use a trackedfunction because it causes the menu to reload
   // after the first load (after the debounce time)
   // See https://discord.com/channels/480462759797063690/1501197288603910266
@@ -133,24 +159,44 @@ export default class ContextualActionsContainer extends Component<Args> {
       await timeout(SEARCH_TIMEOUT_MS);
     }
     const state = this.localEditorState;
-    if (!this.showContextMenu || !state || this.loadActionsError) return [];
-    const getActions = this.groups?.flatMap((group) => group.getActions) ?? [];
+    if (!this.showContextMenu || !state) return [];
 
-    try {
-      this.contextualActions = (
-        await Promise.all(getActions.map((cb) => cb(state, this.searchQuery)))
-      ).flat();
-    } catch (error) {
-      if (error instanceof Error) {
-        this.loadActionsError = error.message;
-      } else if (typeof error === 'string') {
-        this.loadActionsError = error;
-      } else {
-        this.loadActionsError = this.intl.t(
-          'ember-rdfa-editor.utils.something-went-wrong',
-        );
-      }
-    }
+    const groups = this.groups;
+
+    // Reset the groupsWithStatus "map"
+    this.groupsWithStatusUntracked = groups.map(() => ({
+      isLoading: true,
+      errorMessage: null,
+      actions: [],
+    }));
+
+    await Promise.all(
+      groups.map(async (group, index) => {
+        try {
+          const results = await group.getActions(state, this.searchQuery);
+          this.updateGroupWithStatusAt(
+            {
+              errorMessage: null,
+              actions: results.flat(),
+            },
+            index,
+          );
+          this.groupsWithStatus = [...this.groupsWithStatusUntracked];
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : typeof error === 'string'
+                ? error
+                : this.intl.t('ember-rdfa-editor.utils.something-went-wrong');
+          this.updateGroupWithStatusAt({ errorMessage: message }, index);
+          this.groupsWithStatus = [...this.groupsWithStatusUntracked];
+        } finally {
+          this.updateGroupWithStatusAt({ isLoading: false }, index);
+          this.groupsWithStatus = [...this.groupsWithStatusUntracked];
+        }
+      }),
+    );
   });
 
   @action
@@ -229,7 +275,7 @@ export default class ContextualActionsContainer extends Component<Args> {
           @onClose={{this.closeContextMenu}}
           @onSearch={{this.setSearchQuery}}
           @searchQuery={{this.searchQuery}}
-          @isLoading={{this.getActionsTask.isRunning}}
+          @isLoading={{false}}
           @errorMessage={{if
             this.loadActionsError
             this.loadActionsError

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -51,8 +51,6 @@ export default class ContextualActionsContainer extends Component<Args> {
 
   @tracked loadActionsError: string | null = null;
   @tracked searchQuery: string = '';
-
-  // @tracked groupsWithStatus: TrackedArray<GroupWithStatus> = new TrackedArray();
   @tracked loadGroupTaskInstances: {
     group: ContextualActionGroup;
     taskInstance: TaskInstance<ContextualAction[]>;
@@ -176,7 +174,6 @@ export default class ContextualActionsContainer extends Component<Args> {
   // after the first load (after the debounce time)
   // See https://discord.com/channels/480462759797063690/1501197288603910266
   getActionsTask = restartableTask(async () => {
-    console.log('started the task');
     const state = this.localEditorState;
     if (!this.showContextMenu || !state) return [];
 
@@ -190,23 +187,14 @@ export default class ContextualActionsContainer extends Component<Args> {
   });
 
   get groupsWithStatus(): GroupWithStatus[] {
-    return this.loadGroupTaskInstances.map(({ group, taskInstance }) => {
-      if (taskInstance === undefined)
-        return {
-          ...group,
-          actions: [],
-          isLoading: false,
-          errorMessage: null,
-        };
-      return {
-        ...group,
-        actions: taskInstance.isError ? [] : taskInstance.value,
-        isLoading: taskInstance.isRunning,
-        errorMessage: taskInstance.isError
-          ? this.getErrorMessage(taskInstance.error)
-          : null,
-      };
-    });
+    return this.loadGroupTaskInstances.map(({ group, taskInstance }) => ({
+      ...group,
+      actions: taskInstance.isError ? [] : taskInstance.value,
+      isLoading: taskInstance.isRunning,
+      errorMessage: taskInstance.isError
+        ? this.getErrorMessage(taskInstance.error)
+        : null,
+    }));
   }
 
   @action
@@ -279,12 +267,6 @@ export default class ContextualActionsContainer extends Component<Args> {
           @onClose={{this.closeContextMenu}}
           @onSearch={{this.setSearchQuery}}
           @searchQuery={{this.searchQuery}}
-          @isLoading={{false}}
-          @errorMessage={{if
-            this.loadActionsError
-            this.loadActionsError
-            undefined
-          }}
         />
       {{/if}}
     </div>

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -160,10 +160,12 @@ export default class ContextualActionsContainer extends Component<Args> {
     async (state: EditorState, group: ContextualActionGroup) => {
       if (
         this.searchQuery &&
+        // We need to check if the searchDebounce is greater than zero
+        // If we wouldn't and just await the zero second timout, it causes screen flicker
         group.searchDebounceMs &&
         group.searchDebounceMs > 0
       ) {
-        await timeout(group.searchDebounceMs ?? 0);
+        await timeout(group.searchDebounceMs);
       }
 
       return await group.getActions(state, this.searchQuery);

--- a/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
@@ -13,8 +13,7 @@ export type ContextualAction = {
 
 export type ContextualActionGroup = {
   id: string;
-  label: string;
-
+  label?: string;
   sticky?: 'bottom';
   priority?: number;
 

--- a/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
@@ -18,6 +18,8 @@ export type ContextualActionGroup = {
   sticky?: 'bottom';
   priority?: number;
 
+  loadingMessage?: string;
+  searchDebounceMs?: number;
   getActions: GetContextualActions;
 };
 

--- a/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
@@ -17,6 +17,8 @@ export type ContextualActionGroup = {
 
   sticky?: 'bottom';
   priority?: number;
+
+  getActions: GetContextualActions;
 };
 
 export type GetContextualActionGroups = ((

--- a/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
@@ -25,7 +25,7 @@ export type GetContextualActionGroups = ((
   state: EditorState,
   searchQuery?: string,
 ) => ContextualActionGroup[])[];
-export type GetContextualActions = ((
+export type GetContextualActions = (
   state: EditorState,
   searchQuery?: string,
-) => ContextualAction[] | Promise<ContextualAction[]>)[];
+) => ContextualAction[] | Promise<ContextualAction[]>;

--- a/packages/ember-rdfa-editor/src/plugins/slash-commands/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/slash-commands/index.ts
@@ -32,7 +32,7 @@ class IdleState implements PluginState {
     getGroups: GetContextualActionGroups,
   ): PluginState {
     if (tr.getMeta('SLASH_COMMANDS_PLUGIN') === 'open_context_menu') {
-      return new MenuOpenState(newState);
+      return new MenuExternallyOpenedState(newState);
     }
 
     /**
@@ -68,7 +68,11 @@ class SearchingState implements PluginState {
   }
 }
 
-class MenuOpenState implements PluginState {
+/*
+ * This is needed because we need to be able to hide the placeholder
+ * when the menu is opened externally
+ */
+class MenuExternallyOpenedState implements PluginState {
   menuOpen = true;
   slashPos = null;
   latestEditorState: EditorState;

--- a/test-app/app/dummy-plugins/expose-contextual-actions.ts
+++ b/test-app/app/dummy-plugins/expose-contextual-actions.ts
@@ -143,7 +143,7 @@ function buildGetActions(
       });
   };
 }
-export function getContextualGroups(state: EditorState) {
+export function getContextualGroups(state: EditorState, searchQuery?: string) {
   const groups: ContextualActionGroup[] = [
     {
       id: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
@@ -157,18 +157,20 @@ export function getContextualGroups(state: EditorState) {
       getActions: buildGetActions(insertActions),
     },
     {
-      id: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-      label: 'Straten in Gent',
-      priority: 9,
-      getActions: buildGetActions(locationActions, 300),
-    },
-    {
       id: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Plaats suggesties',
       priority: 10,
       getActions: buildGetActions(streetSuggestionActions),
     },
   ];
+  if (searchQuery) {
+    groups.push({
+      id: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+      label: 'Straten in Gent',
+      priority: 9,
+      getActions: buildGetActions(locationActions, 300),
+    });
+  }
   if (
     state.selection instanceof NodeSelection &&
     state.selection.node.attrs['placeholderText']

--- a/test-app/app/dummy-plugins/expose-contextual-actions.ts
+++ b/test-app/app/dummy-plugins/expose-contextual-actions.ts
@@ -113,7 +113,9 @@ function buildGetActions(
   ignoreSearch = false,
 ) {
   return async function (_state: EditorState, searchQuery?: string) {
-    await new Promise((resolve) => setTimeout(resolve, loadingTimeMs));
+    if (loadingTimeMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, loadingTimeMs));
+    }
     return actionLabels
       .filter(
         ({ label }) =>

--- a/test-app/app/dummy-plugins/expose-contextual-actions.ts
+++ b/test-app/app/dummy-plugins/expose-contextual-actions.ts
@@ -160,7 +160,7 @@ export function getContextualGroups(state: EditorState, searchQuery?: string) {
       id: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Plaats suggesties',
       priority: 10,
-      getActions: buildGetActions(streetSuggestionActions),
+      getActions: buildGetActions(streetSuggestionActions, 400),
     },
   ];
   if (searchQuery) {

--- a/test-app/app/dummy-plugins/expose-contextual-actions.ts
+++ b/test-app/app/dummy-plugins/expose-contextual-actions.ts
@@ -110,14 +110,16 @@ function buildGetActions(
     insert?: string;
   }[],
   loadingTimeMs = 0,
+  ignoreSearch = false,
 ) {
   return async function (_state: EditorState, searchQuery?: string) {
     await new Promise((resolve) => setTimeout(resolve, loadingTimeMs));
     return actionLabels
-      .filter(({ label }) =>
-        searchQuery
-          ? label.toLowerCase().includes(searchQuery.toLowerCase())
-          : true,
+      .filter(
+        ({ label }) =>
+          ignoreSearch ||
+          !searchQuery ||
+          label.toLowerCase().includes(searchQuery.toLowerCase()),
       )
       .map((action) => {
         return {
@@ -148,19 +150,19 @@ export function getContextualGroups(state: EditorState, searchQuery?: string) {
     {
       id: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Plaatsbepaling',
-      getActions: buildGetActions(plaatsbepalingActions),
+      getActions: buildGetActions(plaatsbepalingActions, 2000),
     },
     {
       id: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Invoegen',
       sticky: 'bottom',
-      getActions: buildGetActions(insertActions),
+      getActions: buildGetActions(insertActions, 0, true),
     },
     {
       id: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Plaats suggesties',
       priority: 10,
-      getActions: buildGetActions(streetSuggestionActions, 400),
+      getActions: buildGetActions(streetSuggestionActions),
     },
   ];
   if (searchQuery) {
@@ -168,7 +170,7 @@ export function getContextualGroups(state: EditorState, searchQuery?: string) {
       id: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Straten in Gent',
       priority: 9,
-      getActions: buildGetActions(locationActions, 300),
+      getActions: buildGetActions(locationActions, 1000),
     });
   }
   if (

--- a/test-app/app/dummy-plugins/expose-contextual-actions.ts
+++ b/test-app/app/dummy-plugins/expose-contextual-actions.ts
@@ -151,6 +151,7 @@ export function getContextualGroups(state: EditorState, searchQuery?: string) {
       id: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Plaatsbepaling',
       getActions: buildGetActions(plaatsbepalingActions, 2000),
+      searchDebounceMs: 200,
     },
     {
       id: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
@@ -169,6 +170,8 @@ export function getContextualGroups(state: EditorState, searchQuery?: string) {
     groups.push({
       id: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Straten in Gent',
+      loadingMessage: 'Straten aan het ophalen',
+      searchDebounceMs: 500,
       priority: 9,
       getActions: buildGetActions(locationActions, 1000),
     });

--- a/test-app/app/dummy-plugins/expose-contextual-actions.ts
+++ b/test-app/app/dummy-plugins/expose-contextual-actions.ts
@@ -7,143 +7,166 @@ import {
 import type { ContextualActionGroup } from '@lblod/ember-rdfa-editor/plugins/contextual-actions';
 import { v4 as uuidv4 } from 'uuid';
 
-export async function getContextualActions(
-  _state: EditorState,
-  searchQuery?: string,
-) {
-  await new Promise((resolve) => setTimeout(resolve, 300));
-  return [
-    {
-      label: 'Op het kruispunt van de … met de … geldt',
-      group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label: 'Op alle wegen die uitkomen op … geldt',
-      group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label: 'Op de … ter hoogte van … geldt',
-      group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label: 'Op het kruispunt van de … met de … geldt',
-      group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label: 'Op … vanaf … tot … geldt',
-      group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label:
-        'Dit is een hele lange actie, die doet het menu waarschijnlijk overflowen, wat moet er dan gebeuren?',
-      description:
-        'Dit is een hele lange actie, die doet het menu waarschijnlijk overflowen, wat moet er dan gebeuren?',
-      group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label: 'Datum invoegen',
-      group: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-      insert: '11/02/2027',
-      icon: 'calendar',
-    },
-    {
-      label: 'Locatie invoegen',
-      group: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-      description: 'Voeg een locatie in',
-      icon: 'location',
-    },
-    {
-      label: 'Gebied invoegen',
-      group: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-      description: 'Voeg een gebied in',
-      icon: 'area',
-    },
-    {
-      label: 'Marcode invoegen',
-      group: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-      insert: 'MAR12',
-      description: 'Voeg een marcode in',
-    },
-    {
-      label: 'Pelikaanstraat',
-      group: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label: 'Tarbotstraat',
-      group: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label: 'Tolhuiskaai',
-      group: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label: 'Veldstraat',
-      group: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label: 'Op … vanaf … tot … geldt',
-      group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-    },
-    {
-      label: 'Markt 17, 9230 Wetteren',
-      group: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-      priority: 2,
-    },
-    {
-      label: 'Perceel 44A, 9000 Aalst',
-      group: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-      priority: 9,
-    },
-  ]
-    .filter(({ label }) =>
-      searchQuery
-        ? label.toLowerCase().includes(searchQuery.toLowerCase())
-        : true,
-    )
-    .map((action) => {
-      return {
-        ...action,
-        id: uuidv4(),
-        command: (
-          state: EditorState,
-          dispatch?: (transaction: Transaction) => void,
-        ) => {
-          if (dispatch) {
-            const tr = state.tr;
-            tr.replaceSelectionWith(
-              state.schema.text(action.insert ?? action.label),
-            );
-            tr.setSelection(
-              new TextSelection(tr.selection.$from, tr.selection.$from),
-            );
-            dispatch(tr);
-          }
-          return true;
-        },
-      };
-    });
-}
+const plaatsbepalingActions = [
+  {
+    label: 'Op het kruispunt van de … met de … geldt',
+    group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+  {
+    label: 'Op alle wegen die uitkomen op … geldt',
+    group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+  {
+    label: 'Op de … ter hoogte van … geldt',
+    group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+  {
+    label: 'Op het kruispunt van de … met de … geldt',
+    group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+  {
+    label: 'Op … vanaf … tot … geldt',
+    group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+  {
+    label:
+      'Dit is een hele lange actie, die doet het menu waarschijnlijk overflowen, wat moet er dan gebeuren?',
+    description:
+      'Dit is een hele lange actie, die doet het menu waarschijnlijk overflowen, wat moet er dan gebeuren?',
+    group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+  {
+    label: 'Op … vanaf … tot … geldt',
+    group: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+];
 
+const insertActions = [
+  {
+    label: 'Datum invoegen',
+    group: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+    insert: '11/02/2027',
+    icon: 'calendar',
+  },
+  {
+    label: 'Locatie invoegen',
+    group: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+    description: 'Voeg een locatie in',
+    icon: 'location',
+  },
+  {
+    label: 'Gebied invoegen',
+    group: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+    description: 'Voeg een gebied in',
+    icon: 'area',
+  },
+  {
+    label: 'Marcode invoegen',
+    group: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+    insert: 'MAR12',
+    description: 'Voeg een marcode in',
+  },
+];
+
+const locationActions = [
+  {
+    label: 'Pelikaanstraat',
+    group: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+  {
+    label: 'Tarbotstraat',
+    group: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+  {
+    label: 'Tolhuiskaai',
+    group: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+  {
+    label: 'Veldstraat',
+    group: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+  },
+];
+
+const streetSuggestionActions = [
+  {
+    label: 'Markt 17, 9230 Wetteren',
+    group: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+    priority: 2,
+  },
+  {
+    label: 'Perceel 44A, 9000 Aalst',
+    group: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+    priority: 9,
+  },
+];
+
+function buildGetActions(
+  actionLabels: {
+    label: string;
+    group: string;
+    priority?: number;
+    icon?: string;
+    description?: string;
+    insert?: string;
+  }[],
+  loadingTimeMs = 0,
+) {
+  return async function (_state: EditorState, searchQuery?: string) {
+    await new Promise((resolve) => setTimeout(resolve, loadingTimeMs));
+    return actionLabels
+      .filter(({ label }) =>
+        searchQuery
+          ? label.toLowerCase().includes(searchQuery.toLowerCase())
+          : true,
+      )
+      .map((action) => {
+        return {
+          ...action,
+          id: uuidv4(),
+          command: (
+            state: EditorState,
+            dispatch?: (transaction: Transaction) => void,
+          ) => {
+            if (dispatch) {
+              const tr = state.tr;
+              tr.replaceSelectionWith(
+                state.schema.text(action.insert ?? action.label),
+              );
+              tr.setSelection(
+                new TextSelection(tr.selection.$from, tr.selection.$from),
+              );
+              dispatch(tr);
+            }
+            return true;
+          },
+        };
+      });
+  };
+}
 export function getContextualGroups(state: EditorState) {
   const groups: ContextualActionGroup[] = [
     {
       id: 'plaatsbepaling-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Plaatsbepaling',
+      getActions: buildGetActions(plaatsbepalingActions),
     },
     {
       id: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Invoegen',
       sticky: 'bottom',
+      getActions: buildGetActions(insertActions),
     },
     {
       id: 'locations-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Straten in Gent',
       priority: 9,
+      getActions: buildGetActions(locationActions, 300),
     },
     {
       id: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
       label: 'Plaats suggesties',
       priority: 10,
+      getActions: buildGetActions(streetSuggestionActions),
     },
   ];
   if (

--- a/test-app/app/dummy-plugins/expose-contextual-actions.ts
+++ b/test-app/app/dummy-plugins/expose-contextual-actions.ts
@@ -157,7 +157,6 @@ export function getContextualGroups(state: EditorState, searchQuery?: string) {
     },
     {
       id: 'insert-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
-      label: 'Invoegen',
       sticky: 'bottom',
       getActions: buildGetActions(insertActions, 0, true),
     },

--- a/test-app/app/templates/plugins.gts
+++ b/test-app/app/templates/plugins.gts
@@ -84,10 +84,7 @@ import DebugTools from '@lblod/ember-rdfa-editor/components/debug-tools';
 import Editor from '@lblod/ember-rdfa-editor/components/editor';
 import { link_input_rule } from '@lblod/ember-rdfa-editor/plugins/link/input-rule';
 import ContextualActionsContainer from '@lblod/ember-rdfa-editor/components/plugins/contextual-actions/container';
-import {
-  getContextualActions,
-  getContextualGroups,
-} from 'test-app/dummy-plugins/expose-contextual-actions';
+import { getContextualGroups } from 'test-app/dummy-plugins/expose-contextual-actions';
 import { slashCommandsPlugin } from '@lblod/ember-rdfa-editor/plugins/slash-commands/index';
 import { service } from '@ember/service';
 import type IntlService from 'ember-intl/services/intl';
@@ -189,7 +186,6 @@ export default class extends Component {
     };
   };
 
-  contextualActionGetters = [getContextualActions];
   contextualGroupGetters = [getContextualGroups];
 
   get plugins() {
@@ -258,7 +254,6 @@ export default class extends Component {
             {{#if this.rdfaEditor}}
               <ContextualActionsContainer
                 @controller={{this.rdfaEditor}}
-                @getActions={{this.contextualActionGetters}}
                 @getGroups={{this.contextualGroupGetters}}
               />
             {{/if}}


### PR DESCRIPTION
### Overview
This rework includes:
- Per-group loading: Instead of showing a single loading bar until all groups have finished loading, every group has its own loading bar.
- Per-group debounce time: When searching, a group can define its own debounce time. (default = 0ms)
- Allow groups without label: these groups automatically get a separator line between them

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6142


### How to test/reproduce
The test setup now contains a single sticky group without a label.
The dummy actions in test-app/app/dummy-plugins/expose-contextual-actions.ts now can be configured with a loading time and debounce time.


### Checks PR readiness
- [x] changelog
- [x] npm lint
