### PR TITLE
fix type for `renderRdfaAttrs`

### DIFF
--- a/.changeset/purple-sheep-attend.md
+++ b/.changeset/purple-sheep-attend.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+fix type for renderRdfaAttrs

--- a/packages/ember-rdfa-editor/src/core/schema.ts
+++ b/packages/ember-rdfa-editor/src/core/schema.ts
@@ -624,7 +624,7 @@ export type RdfaRenderArgs = Omit<
   rdfaContainerTag?: string;
   contentContainerTag?: string;
   contentContainerAttrs?: Record<string, unknown>;
-} & ({ content: DOMOutputSpec | 0 } | { contentArray: unknown[] });
+} & ({ content: DOMOutputSpec | string | 0 } | { contentArray: unknown[] });
 
 function determineChildTag(renderable: Mark | PNode) {
   if (renderable instanceof Mark) {


### PR DESCRIPTION
### Overview
Fixes a typing issue that was caused by an underlying prosemirror type change

### How to test/reproduce
Everything should still work


### Checks PR readiness
- [x] changelog
- [x] npm lint
