### PR TITLE
say-ar-design-plugin: modernize scss usage

### DIFF
--- a/.changeset/wise-taxis-mix.md
+++ b/.changeset/wise-taxis-mix.md
@@ -1,0 +1,5 @@
+---
+'@lblod/say-ar-design-plugin': patch
+---
+
+Use scss `@use` API in favour of deprecated `@import` API

--- a/packages/say-ar-design-plugin/say-ar-design-plugin.scss
+++ b/packages/say-ar-design-plugin/say-ar-design-plugin.scss
@@ -1,7 +1,5 @@
-// We use variables from here, so it seems we need to import it here too. @import is deprecated but
-// we can't move away from it until AU has
-@import "@appuniversum/ember-appuniversum/styles/settings/s-colors";
-@import "@appuniversum/ember-appuniversum/styles/settings/s-global";
+@use "@appuniversum/ember-appuniversum/styles/settings/s-root"; // AU css variables
+@use "@appuniversum/ember-appuniversum/styles/a-settings" as au-settings;
 
 .ar-importer-overview {
   display: flex;
@@ -11,7 +9,7 @@
 
 .ar-importer-overview__sidebar {
   flex-basis: 30rem;
-  padding: $au-unit;
+  padding: au-settings.$au-unit;
   min-width: 0;
   flex-grow: 0;
   flex-shrink: 0;
@@ -23,8 +21,8 @@
 .ar-importer-overview__form {
   display: flex;
   flex-direction: column;
-  margin-top: $au-unit;
-  gap: $au-unit;
+  margin-top: au-settings.$au-unit;
+  gap: au-settings.$au-unit;
 }
 
 .ar-importer-overview__form__label {

--- a/test-app/app/styles/app.scss
+++ b/test-app/app/styles/app.scss
@@ -1,14 +1,11 @@
 /* ==================================
    #DUMMY APP
    ================================== */
-
+@use "@appuniversum/ember-appuniversum/styles";
 @use "@lblod/ember-rdfa-editor";
 @use "@lblod/say-roadsign-regulation-plugin";
+@use "@lblod/say-ar-design-plugin";
 @use "c-dummy";
-// @import is deprecated but we use variables from AU in the ar-design styles, so it seems we need
-// to use import for them both here. We can't move everything to @use until AU has.
-@import "@appuniversum/ember-appuniversum/styles";
-@import "@lblod/say-ar-design-plugin";
 
 html,
 body {


### PR DESCRIPTION
### Overview
This PR modernizes the scss of the `say-ar-design-plugin` a bit by using the `@use` API in favour of the deprecated `@import` API.
Additionally, this change resolves some styling issues in the test-app, due to the introduced `@import` (https://github.com/lblod/ember-rdfa-editor/pull/1384/changes#diff-f9ffc7e6d514c75f94434e9f960df09ddf6c4cadcd13110f1f904563ab1561e5) changing the order of the stylesheets being imported in the test-app.

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor/pull/1384

### How to test/reproduce
- Start the test-app
- Ensure the styling of AR-designs is still the same (using the LBLOD plugins tab)
- Ensure the styling of the editor (e.g. link popups) has been fixed.



### Checks PR readiness
- [x] UI: feedback for any loading/error states
- [x] Tested on Firefox and Chrome-based browsers
- [x] changelog
- [x] npm lint
- [x] no new deprecation warnings
