### PR TITLE
`LPDC-1636`: input-rules - add support for matching Enter keypress

### DIFF
--- a/.changeset/good-walls-burn.md
+++ b/.changeset/good-walls-burn.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+link plugin: add 'Enter' key as a trigger to the input rule

--- a/.changeset/two-signs-buy.md
+++ b/.changeset/two-signs-buy.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add support for enter keys in inputrules. The 'Enter' key can be captured using \n in the regex of the inputrule

--- a/packages/ember-rdfa-editor/src/index.ts
+++ b/packages/ember-rdfa-editor/src/index.ts
@@ -118,7 +118,7 @@ export {
   textblockTypeInputRule,
   undoInputRule,
   wrappingInputRule,
-} from 'prosemirror-inputrules';
+} from '#root/plugins/inputrules/index.ts';
 export { history } from 'prosemirror-history';
 export { dropCursor } from 'prosemirror-dropcursor';
 

--- a/packages/ember-rdfa-editor/src/plugins/inputrules/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/inputrules/index.ts
@@ -1,0 +1,70 @@
+import { ProsePlugin } from '#root/prosemirror-aliases.ts';
+import {
+  closeDoubleQuote,
+  closeSingleQuote,
+  ellipsis,
+  emDash,
+  InputRule,
+  openDoubleQuote,
+  openSingleQuote,
+  smartQuotes,
+  textblockTypeInputRule,
+  undoInputRule,
+  wrappingInputRule,
+  inputRules,
+} from 'prosemirror-inputrules';
+import { TextSelection } from 'prosemirror-state';
+
+
+function sayInputRules({
+  rules,
+}: {
+  rules: readonly InputRule[];
+}) {
+  const originalPlugin = inputRules({ rules });
+  return new ProsePlugin({
+    ...originalPlugin.spec,
+    props: {
+      ...originalPlugin.spec.props,
+      handleKeyDown: (view, event) => {
+        if (!originalPlugin.spec.props?.handleTextInput) {
+          return false;
+        }
+        if (event.key !== 'Enter') return false;
+        if (!(view.state.selection instanceof TextSelection)) {
+          return false;
+        }
+        const { $cursor } = view.state.selection;
+        if (!$cursor) {
+          return false;
+        }
+        originalPlugin.spec.props.handleTextInput.call(
+          originalPlugin,
+          view,
+          $cursor.pos,
+          $cursor.pos,
+          '\n',
+          () => {}
+        );
+
+        // process 'Enter' as usual
+        return false;
+      },
+    }
+  })
+}
+
+export {
+  sayInputRules as inputRules,
+  closeDoubleQuote,
+  closeSingleQuote,
+  ellipsis,
+  emDash,
+  InputRule,
+  openDoubleQuote,
+  openSingleQuote,
+  smartQuotes,
+  textblockTypeInputRule,
+  undoInputRule,
+  wrappingInputRule,
+};

--- a/packages/ember-rdfa-editor/src/plugins/inputrules/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/inputrules/index.ts
@@ -15,12 +15,7 @@ import {
 } from 'prosemirror-inputrules';
 import { TextSelection } from 'prosemirror-state';
 
-
-function sayInputRules({
-  rules,
-}: {
-  rules: readonly InputRule[];
-}) {
+function sayInputRules({ rules }: { rules: readonly InputRule[] }) {
   const originalPlugin = inputRules({ rules });
   return new ProsePlugin({
     ...originalPlugin.spec,
@@ -44,14 +39,14 @@ function sayInputRules({
           $cursor.pos,
           $cursor.pos,
           '\n',
-          () => {}
+          () => {},
         );
 
         // process 'Enter' as usual
         return false;
       },
-    }
-  })
+    },
+  });
 }
 
 export {

--- a/packages/ember-rdfa-editor/src/plugins/link/input-rule.ts
+++ b/packages/ember-rdfa-editor/src/plugins/link/input-rule.ts
@@ -30,7 +30,7 @@ const DEFAULT_REGEX = new RegExp(
       [A-Za-z]{2,} ${/* extension */ ''}
     )
   )
-  (\s)$ ${/* single space after url/email */ ''}
+  ( |\n)$ ${/* single space or newline/enter after url/email */ ''}
   `
     .replace(/^\s+|\s+$/gm, '') // remove white space before and at the end of lines (trimming)
     .replace(/\n/g, ''), // remove newlines
@@ -80,7 +80,13 @@ export const link_input_rule = ({
     // replace only the email text
     tr.replaceWith(linkStart, end, node);
 
-    tr.insertText(textAfterLink, linkStart + node.nodeSize);
+    /**
+     * Only run this when textAfterLink is not \n. The \n is 'fake' and represents an 'Enter' keypress.
+     */
+    if (textAfterLink !== '\n') {
+      // 
+      tr.insertText(textAfterLink, linkStart + node.nodeSize);
+    }
 
     return tr;
   });

--- a/packages/ember-rdfa-editor/src/plugins/link/input-rule.ts
+++ b/packages/ember-rdfa-editor/src/plugins/link/input-rule.ts
@@ -84,7 +84,7 @@ export const link_input_rule = ({
      * Only run this when textAfterLink is not \n. The \n is 'fake' and represents an 'Enter' keypress.
      */
     if (textAfterLink !== '\n') {
-      // 
+      //
       tr.insertText(textAfterLink, linkStart + node.nodeSize);
     }
 


### PR DESCRIPTION
### Overview
This PR adds support for matching enter keypresses in input rules. To match an enter keypress, use `\n` in you regex statement.
This feature is used to match the enter key for automatic link creation.
Code and logic is inspired by https://discuss.prosemirror.net/t/trigger-inputrule-on-enter/1118/5

##### connected issues and PRs:
[LPDC-1636](https://binnenland.atlassian.net/browse/LPDC-1636?atlOrigin=eyJpIjoiMTNlNmI3ZjIwZTVhNDE1Mzk3ZDMxYjMxODc5OTI2ZDIiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the test-app
- Type a url in the editor, and press the enter key. The typed URL should now be converted to a link node.

### Challenges/uncertainties
The usage of `\n` to represent an enter keypress is a bit of a workaround to represent the enter key in a regex statement.



### Checks PR readiness
- [x] UI: feedback for any loading/error states
- [x] Tested on Firefox and Chrome-based browsers
- [x] changelog
- [x] npm lint
- [x] no new deprecation warnings
