### PR TITLE
Always use "plaatsbeschrijving" as classic location variable label

### DIFF
--- a/.changeset/warm-spoons-hug.md
+++ b/.changeset/warm-spoons-hug.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Always use "plaatsbeschrijving" as label for `classicLocationVariable`s

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/create-classic-location-variable.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/create-classic-location-variable.ts
@@ -42,7 +42,6 @@ export function createClassicLocationVariableAttrs({
   variable,
   variableInstance,
   __rdfaId,
-  label,
   source,
   backlinks = [],
 }: CreateClassicLocationVariableAttrsArgs) {
@@ -84,7 +83,7 @@ export function createClassicLocationVariableAttrs({
     __rdfaId,
     externalTriples,
     backlinks: [...backlinks, ...addedBacklinks],
-    label: label ?? 'Plaatsbeschrijving',
+    label: 'Plaatsbeschrijving',
     source,
     placeholder: 'Plaatsbeschrijving toevoegen',
   };


### PR DESCRIPTION
### Overview
This PR enforces that the classic location variables always use "plaatsbeschrijving" as label

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6205

### How to test/reproduce
Inserted mobility measures now always contain an rdfa block that has "plaatsbeschrijving" as label.

### Challenges/uncertainties
This hardcodes the label for all so called "classic location variables" (plaatsbeschrijvingen), we might want to spend more time and find out where the wrong label is coming from?


### Checks PR readiness
- [x] changelog
- [x] npm lint
