### PR TITLE
Non block variables were not being added to the measure

### DIFF
--- a/.changeset/ready-radios-say.md
+++ b/.changeset/ready-radios-say.md
@@ -1,0 +1,5 @@
+---
+'@lblod/say-roadsign-regulation-plugin': patch
+---
+
+Fix non block variables were not being added to the measure

--- a/packages/say-roadsign-regulation-plugin/src/plugin/construct-measure-fragment.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/construct-measure-fragment.ts
@@ -35,6 +35,8 @@ export function constructMeasureFragment(
             currentParagraphContent = [];
           }
           fragment.push(node);
+        } else {
+          currentParagraphContent.push(node);
         }
       } else {
         currentParagraphContent.push(schema.text(part));


### PR DESCRIPTION
### Overview
The non block variables were not being added to the measure construction function

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6206


### Setup
None

### How to test/reproduce
Add a measure with non block variables, for example C43 and verify that it works

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: feedback for any loading/error states
- [x] Tested on Firefox and Chrome-based browsers
- [x] changelog
- [x] npm lint
- [x] no new deprecation warnings
