### PR TITLE
LPDC-1479: link-plugin - add support for customizing target attribute of outputted html

### DIFF
--- a/.changeset/forty-poems-argue.md
+++ b/.changeset/forty-poems-argue.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+link-plugin: add support for customizing `target` attribute of outputted html

--- a/packages/ember-rdfa-editor/src/plugins/link/nodes/link.ts
+++ b/packages/ember-rdfa-editor/src/plugins/link/nodes/link.ts
@@ -18,6 +18,7 @@ type LinkOptions = {
   interactive?: boolean;
   rdfaAware?: boolean;
   linkParser?: LinkParser;
+  target?: '_self' | '_blank' | '_parent' | '_top' | '_unfencedTop';
 };
 
 // TODO this spec doesn't play well with RDFa editing tools. It has been modified so that any
@@ -27,6 +28,7 @@ const emberNodeConfig: (options?: LinkOptions) => EmberNodeConfig = ({
   interactive = false,
   rdfaAware = false,
   linkParser = defaultLinkParser(),
+  target,
 } = {}) => {
   return {
     name: 'link',
@@ -88,11 +90,15 @@ const emberNodeConfig: (options?: LinkOptions) => EmberNodeConfig = ({
         return renderRdfaAware({
           renderable: node,
           tag: 'a',
-          attrs: { ...attrs, class: getClassnamesFromNode(node) },
+          attrs: { ...attrs, target, class: getClassnamesFromNode(node) },
           content: 0,
         });
       } else {
-        return ['a', { ...attrs, class: getClassnamesFromNode(node) }, 0];
+        return [
+          'a',
+          { ...attrs, target, class: getClassnamesFromNode(node) },
+          0,
+        ];
       }
     },
   };

--- a/test-app/app/templates/index.gts
+++ b/test-app/app/templates/index.gts
@@ -137,7 +137,8 @@ export default class extends Component {
   get linkOptions() {
     return {
       interactive: true,
-    };
+      target: '_blank',
+    } as const;
   }
 
   @tracked plugins: PluginConfig = [


### PR DESCRIPTION
### Overview
This PR adds support for customizing the `target` attribute of the link node html output. This way host applications can adjust the default link opening behaviour.
The default value of the `target` attribute remains `_self`.
##### connected issues and PRs:
[LPDC-1479](https://binnenland.atlassian.net/browse/LPDC-1479)

### How to test/reproduce
- Start the dummy app and open the index page
- Insert a link
- Display the outputted html
- Ensure the link opens in a new tab when simply clicking on it (as the `target` setting is set to `_blank` for the index page configuration)

### Checks PR readiness
- [x] UI: feedback for any loading/error states
- [x] Tested on Firefox and Chrome-based browsers
- [x] changelog
- [x] npm lint
- [x] no new deprecation warnings
