### PR TITLE
Tweak types and docs

### DIFF
--- a/.changeset/green-memes-report.md
+++ b/.changeset/green-memes-report.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Deprecate SayNodeViewConstructor in favour of using Prosemirror's NodeViewConstructor directly (exported from `@lblod/ember-rdfa-editor`)

--- a/.changeset/kind-dogs-create.md
+++ b/.changeset/kind-dogs-create.md
@@ -1,0 +1,5 @@
+---
+'@lblod/say-ar-design-plugin': patch
+---
+
+Add basic docs for ArDesignQuery function

--- a/.changeset/stale-rocks-win.md
+++ b/.changeset/stale-rocks-win.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Fix mistake in lblod-utils insert-article which always used 'insert freely' mode

--- a/packages/ember-rdfa-editor/src/utils/_private/ember-node.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/ember-node.ts
@@ -24,6 +24,7 @@ import {
   type EditorView,
   type DecorationSource,
   type NodeView,
+  type NodeViewConstructor,
 } from 'prosemirror-view';
 import { v4 as uuidv4 } from 'uuid';
 // eslint-disable-next-line ember/no-classic-components
@@ -502,6 +503,7 @@ export function createEmberNodeSpec(config: EmberNodeConfig): SayNodeSpec {
   };
 }
 
+/** @deprecated just use import type { NodeViewConstructor } from '@lblod/ember-rdfa-editor' */
 export type SayNodeViewConstructor = (
   node: PNode,
   view: EditorView,
@@ -512,7 +514,7 @@ export type SayNodeViewConstructor = (
  * See {@link EmberNodeView}
  */
 export function createEmberNodeView(config: EmberNodeConfig) {
-  return function (controller: SayController): SayNodeViewConstructor {
+  return function (controller: SayController): NodeViewConstructor {
     return function (node, view: EditorView, getPos) {
       return new EmberNodeView(controller, config, node, view, getPos);
     };

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
@@ -38,7 +38,7 @@ export function insertArticle(
     const tr = state.tr;
     let replacementTr: Transaction;
     let insertLocation: number | undefined;
-    if ('insertFreely' in args) {
+    if ('insertFreely' in args && args.insertFreely) {
       replacementTr = tr.replaceSelectionWith(node);
     } else {
       const { position } = args;

--- a/packages/say-ar-design-plugin/README.md
+++ b/packages/say-ar-design-plugin/README.md
@@ -5,3 +5,99 @@
 A plugin for [say-editor](https://say-editor.com) RDFa aware text editor, which enables insertion of annotated "Aanvullend Reglementen" designs into Flemish municipality documents.
 
 This documentation is incomplete, please use the [lblod-plugins page of the test-app](test-app/app/templates/lblod-plugins.gts) to see an example of integrating this plugin into an installation of say-editor.
+
+### ArDesignQuery function
+
+It is necessary to pass a function to the @designQuery argument of the SidebarWidget component to fetch AR design information.
+This has the following signature:
+
+```ts
+type ArDesignQuery = (pagination: Pagination) => Promise<DesignInfo>;
+
+type Pagination = {
+  pageNumber: number;
+  pageSize: number;
+  sort?: "name" | "-name" | "date" | "-date";
+  nameFilter?: string;
+};
+
+type DesignInfo = {
+  /** the designs themselves */
+  designs: ArDesign[];
+  /**
+   * for each design, a promise resolving to the number of documents this design is used in
+   * (indexed by id)
+   */
+  inDocs: Record<string, Promise<number>>;
+};
+
+interface ArDesign {
+  id: string | null;
+  uri: string;
+  name: string;
+  date: Date;
+
+  measureDesigns: AsyncHasMany<MeasureDesign> | Promise<MeasureDesign[]>;
+}
+interface MeasureDesign {
+  id: string | null;
+  uri: string;
+
+  trafficSignals: HasMany<TrafficSignal> | TrafficSignal[];
+
+  measureConcept: MeasureConcept;
+
+  unusedSignalConcepts: HasMany<TrafficSignalConcept> | TrafficSignalConcept[];
+
+  unIncludedSignalConcepts:
+    | HasMany<TrafficSignalConcept>
+    | TrafficSignalConcept[];
+
+  variableInstances: HasMany<VariableInstance> | VariableInstance[];
+}
+interface TrafficSignal {
+  id: string | null;
+  uri: string;
+  designStatus?: string;
+
+  trafficSignalConcept: TrafficSignalConcept;
+}
+interface TrafficSignalConcept {
+  id: string | null;
+  uri: string;
+  code: string;
+  regulatoryNotation?: string;
+  type: string;
+
+  categories: RoadSignCategory[];
+}
+interface RoadSignCategory {
+  id: string | null;
+  uri: string;
+  label: string;
+}
+interface MeasureConcept {
+  id: string | null;
+  uri: string;
+  label: string;
+  templateString: string;
+  rawTemplateString: string;
+}
+interface VariableInstance {
+  id: string | null;
+  uri: string;
+  value?: string;
+  valueLabel?: string;
+
+  variable: Variable;
+}
+export default interface Variable {
+  id: string | null;
+  type: "text" | "number" | "date" | "codelist" | "location";
+
+  label: string;
+  uri: string;
+  source: string;
+  codelist?: string;
+}
+```

--- a/packages/say-ar-design-plugin/src/plugin/types.ts
+++ b/packages/say-ar-design-plugin/src/plugin/types.ts
@@ -25,7 +25,12 @@ export type Pagination = {
 };
 
 export type DesignInfo = {
+  /** the designs themselves */
   designs: ArDesign[];
+  /**
+   * for each design, a promise resolving to the number of documents this design is used in
+   * (indexed by id)
+   */
   inDocs: Record<string, Promise<number>>;
 };
 

--- a/test-app/app/templates/editable-node.gts
+++ b/test-app/app/templates/editable-node.gts
@@ -300,7 +300,6 @@ export default class extends Component {
       image: imageView(controller),
       inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
       block_rdfa: (...args: Parameters<NodeViewConstructor>) =>
-        // in tests in a consuming app, so there must be something wrong with the test-app config
         new BlockRDFaView(args, controller),
     };
   };

--- a/test-app/app/templates/lblod-plugins.gts
+++ b/test-app/app/templates/lblod-plugins.gts
@@ -392,7 +392,6 @@ export default class LblodPluginsTemplate extends Component {
       image: imageView(controller),
       inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
       block_rdfa: (...args: Parameters<NodeViewConstructor>) =>
-        // in tests in a consuming app, so there must be something wrong with the test-app config
         new BlockRDFaView(args, controller),
       text_variable: textVariableView(controller),
       person_variable: personVariableView(controller),

--- a/test-app/app/templates/plugins.gts
+++ b/test-app/app/templates/plugins.gts
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inputRules } from '@lblod/ember-rdfa-editor';
+import { inputRules, type NodeViewConstructor } from '@lblod/ember-rdfa-editor';
 import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import { inline_rdfa } from '@lblod/ember-rdfa-editor/marks';
 import {
@@ -55,7 +55,6 @@ import {
   superscript,
   underline,
 } from '@lblod/ember-rdfa-editor/plugins/text-style/index';
-import type { SayNodeViewConstructor } from '@lblod/ember-rdfa-editor/utils/ember-node';
 import { Schema } from '@lblod/ember-rdfa-editor';
 import { tracked } from 'tracked-built-ins';
 import {
@@ -175,7 +174,7 @@ export default class extends Component {
 
   @tracked nodeViews: (
     proseController: SayController,
-  ) => Record<string, SayNodeViewConstructor> = (proseController) => {
+  ) => Record<string, NodeViewConstructor> = (proseController) => {
     return {
       card: cardView(proseController),
       counter: counterView(proseController),


### PR DESCRIPTION
### Overview
Deprecate SayNodeViewConstructor and add the start of docs for ArDesignQuery function of ar-design-plugin.
Also includes a logic fix for the insert-article util as it was always working in 'insert freely' mode.

##### connected issues and PRs:
Part of [binnenland.atlassian.net/browse/GN-6155](https://binnenland.atlassian.net/browse/GN-6155)
Referenced by https://github.com/lblod/frontend-embeddable-notule-editor/pull/292

### Setup
N/A

### How to test/reproduce
Types should work out well!

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: feedback for any loading/error states
- [ ] Tested on Firefox and Chrome-based browsers
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecation warnings
