### PR TITLE
Slash commands inline search

### DIFF
--- a/.changeset/public-bushes-hug.md
+++ b/.changeset/public-bushes-hug.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add inline search for slash commands

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -122,6 +122,7 @@ export default class ContextualActionsMenu extends Component<Args> {
         }
         case 'Delete':
         case 'Backspace':
+          if (!this.args.enableSearch) break;
           if (!this.args.searchQuery) {
             event.preventDefault();
             this.args.onClose?.();
@@ -365,6 +366,8 @@ export default class ContextualActionsMenu extends Component<Args> {
             }}
           />
         </div>
+      {{else}}
+        <div class="au-u-padding-top-tiny" />
       {{/if}}
       {{#if @isLoading}}
         <div class="au-u-flex au-u-flex--center au-u-padding">

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -24,6 +24,8 @@ import { getReferenceElementFromSelection } from '#root/components/utils/floatin
 import { cached, tracked } from '@glimmer/tracking';
 import { runTask } from 'ember-lifeline';
 import { eq, and } from 'ember-truth-helpers';
+import { getSlashCommandsPluginState } from '#root/plugins/slash-commands/index.ts';
+import { TextSelection } from 'prosemirror-state';
 
 type GroupWithStatus = ContextualActionGroup & {
   isLoading: boolean;
@@ -218,9 +220,15 @@ export default class ContextualActionsMenu extends Component<Args> {
   }
 
   get referenceElement() {
+    const state = this.controller.mainEditorState;
+    const slashPos = getSlashCommandsPluginState(state)?.slashPos;
+    const selection = slashPos
+      ? TextSelection.create(state.doc, slashPos)
+      : state.selection;
     return getReferenceElementFromSelection({
       editorState: this.controller.mainEditorState,
       editorView: this.controller.mainEditorView,
+      selection,
     });
   }
 

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -28,6 +28,7 @@ import {
   timeout,
   type TaskInstance,
 } from 'ember-concurrency';
+import { not } from 'ember-truth-helpers';
 
 type GroupWithStatus = ContextualActionGroup & {
   isLoading: boolean;
@@ -50,7 +51,7 @@ export default class ContextualActionsContainer extends Component<Args> {
   @service declare intl: IntlService;
 
   @tracked loadActionsError: string | null = null;
-  @tracked searchQuery: string = '';
+  @tracked localSearchQuery: string = '';
   @tracked loadGroupTaskInstances: {
     group: ContextualActionGroup;
     taskInstance: TaskInstance<ContextualAction[]>;
@@ -120,7 +121,7 @@ export default class ContextualActionsContainer extends Component<Args> {
     tr.setMeta('SLASH_COMMANDS_PLUGIN', 'close_context_menu');
     this.controller.mainEditorView.dispatch(tr);
     this.plusButtonClicked = false;
-    this.searchQuery = '';
+    this.localSearchQuery = '';
     this.selectedEditorNodeLocal = null;
     void this.getActionsTask.cancelAll();
     runTask(this, () => this.controller.mainEditorView.focus());
@@ -197,16 +198,18 @@ export default class ContextualActionsContainer extends Component<Args> {
     }));
   }
 
+  get menuWasOpenedBySlash() {
+    return !this.plusButtonClicked && this.slashCommandsPluginState?.menuOpen;
+  }
+
   @action
   executeAction(action: ContextualAction) {
-    const menuWasOpenedBySlash =
-      !this.plusButtonClicked && this.slashCommandsPluginState?.menuOpen;
     if (
-      menuWasOpenedBySlash &&
-      this.slashCommandsPluginState?.latestEditorState
+      this.menuWasOpenedBySlash &&
+      this.slashCommandsPluginState?.preSlashEditorState
     ) {
       this.controller.mainEditorView.updateState(
-        this.slashCommandsPluginState.latestEditorState,
+        this.slashCommandsPluginState.preSlashEditorState,
       );
     }
     if ('command' in action) {
@@ -236,8 +239,12 @@ export default class ContextualActionsContainer extends Component<Args> {
     );
   }
 
+  get searchQuery() {
+    return this.slashCommandsPluginState?.searchString ?? this.localSearchQuery;
+  }
+
   setSearchQuery = (query: string) => {
-    this.searchQuery = query;
+    this.localSearchQuery = query;
   };
 
   startGetActionsTask = modifier(() => {
@@ -260,13 +267,13 @@ export default class ContextualActionsContainer extends Component<Args> {
       {{#if this.showContextMenu}}
         <ContextualActionsMenu
           {{this.startGetActionsTask}}
-          @enableSearch={{true}}
+          @enableSearch={{not this.menuWasOpenedBySlash}}
           @controller={{this.controller}}
           @groups={{this.groupsWithStatus}}
           @onActionSelected={{this.selectAction}}
           @onClose={{this.closeContextMenu}}
           @onSearch={{this.setSearchQuery}}
-          @searchQuery={{this.searchQuery}}
+          @searchQuery={{this.localSearchQuery}}
         />
       {{/if}}
     </div>

--- a/packages/ember-rdfa-editor/src/components/utils/floating-ui-reference-element.ts
+++ b/packages/ember-rdfa-editor/src/components/utils/floating-ui-reference-element.ts
@@ -1,5 +1,5 @@
 import type { VirtualElement } from '@floating-ui/dom';
-import type { EditorState } from 'prosemirror-state';
+import type { EditorState, Selection } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
 
 type Coords = {
@@ -21,6 +21,7 @@ type GetReferenceElementArgs = {
   getRight?: GetPositionFromSelectionCoords;
   getBottom?: GetPositionFromSelectionCoords;
   getTop?: GetPositionFromSelectionCoords;
+  selection?: Selection
 };
 
 /**
@@ -35,12 +36,13 @@ export function getReferenceElementFromSelection({
   getRight,
   getBottom,
   getTop,
+  selection,
 }: GetReferenceElementArgs) {
-  const { selection } = editorState;
+  const _selection = selection ?? editorState.selection;
   const virtualElement: VirtualElement = {
     getBoundingClientRect: () => {
-      const coordsFrom = editorView.coordsAtPos(selection.from, -1);
-      const coordsTo = editorView.coordsAtPos(selection.to, -1);
+      const coordsFrom = editorView.coordsAtPos(_selection.from, -1);
+      const coordsTo = editorView.coordsAtPos(_selection.to, -1);
       const left =
         getLeft?.(coordsFrom, coordsTo) ??
         Math.min(coordsFrom.left, coordsTo.left);

--- a/packages/ember-rdfa-editor/src/components/utils/floating-ui-reference-element.ts
+++ b/packages/ember-rdfa-editor/src/components/utils/floating-ui-reference-element.ts
@@ -21,7 +21,7 @@ type GetReferenceElementArgs = {
   getRight?: GetPositionFromSelectionCoords;
   getBottom?: GetPositionFromSelectionCoords;
   getTop?: GetPositionFromSelectionCoords;
-  selection?: Selection
+  selection?: Selection;
 };
 
 /**

--- a/packages/ember-rdfa-editor/src/plugins/slash-commands/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/slash-commands/index.ts
@@ -6,8 +6,9 @@ import { ReplaceStep } from 'prosemirror-transform';
 
 export interface PluginState {
   menuOpen: boolean;
-  latestEditorState: EditorState | null;
+  preSlashEditorState: EditorState | null;
   slashPos: number | null;
+  searchString: string | null;
   transition: (
     tr: Transaction,
     oldState: EditorState,
@@ -19,10 +20,11 @@ export interface PluginState {
 class IdleState implements PluginState {
   menuOpen = false;
   slashPos = null;
-  latestEditorState: EditorState | null;
+  searchString = null;
+  preSlashEditorState: EditorState | null;
 
   constructor(latestState?: EditorState | null) {
-    this.latestEditorState = latestState ?? null;
+    this.preSlashEditorState = latestState ?? null;
   }
 
   transition(
@@ -43,7 +45,8 @@ class IdleState implements PluginState {
       shouldShowPlaceholder(oldState, getGroups) &&
       transactionIsSlashTyped(tr)
     ) {
-      return new SearchingState(oldState, newState.selection.$from.pos);
+      const pos = newState.selection.$from.pos;
+      return new SearchingState(oldState, pos, pos, '');
     }
     return new IdleState(newState);
   }
@@ -51,34 +54,119 @@ class IdleState implements PluginState {
 
 class SearchingState implements PluginState {
   menuOpen = true;
+  preSlashEditorState: EditorState;
   slashPos: number;
-  latestEditorState: EditorState;
+  endPos: number;
+  searchString: string;
 
-  constructor(latestState: EditorState, slashPos: number) {
+  constructor(
+    preSlashEditorState: EditorState,
+    slashPos: number,
+    endPos: number,
+    searchString: string,
+  ) {
+    this.preSlashEditorState = preSlashEditorState;
     this.slashPos = slashPos;
-    this.latestEditorState = latestState;
+    this.endPos = endPos;
+    this.searchString = searchString;
   }
 
   transition(tr: Transaction, _oldState: EditorState, newState: EditorState) {
-    if (keepOpenContextActions(newState, tr, this.slashPos)) {
-      return new SearchingState(this.latestEditorState, this.slashPos);
+    if (tr.getMeta('SLASH_COMMANDS_PLUGIN') === 'close_context_menu') {
+      return new IdleState(newState);
     }
 
-    return new IdleState(newState);
+    const newSlashPos = tr.mapping.map(this.slashPos, -1);
+    const newEndPos = tr.mapping.map(this.endPos, 1);
+
+    if (!isValidSearchRange(newState, newSlashPos, newEndPos)) {
+      return new IdleState(newState);
+    }
+
+    // The cursor must stay within the search range
+    const { selection } = newState;
+    if (
+      !selection.empty ||
+      selection.$from.pos < newSlashPos ||
+      selection.$from.pos > newEndPos
+    ) {
+      return new IdleState(newState);
+    }
+
+    return new SearchingState(
+      this.preSlashEditorState,
+      newSlashPos,
+      newEndPos,
+      getTextBetween(newState, newSlashPos, newEndPos) ?? '',
+    );
   }
+}
+
+function isValidSearchRange(
+  state: EditorState,
+  slashPos: number,
+  endPos: number,
+): boolean {
+  if (endPos < slashPos) return false;
+
+  let $slash;
+  try {
+    $slash = state.doc.resolve(slashPos);
+  } catch {
+    return false;
+  }
+  if (!$slash.parent.isTextblock) return false;
+
+  const slashOffset = $slash.parentOffset;
+  const charBeforeSlash = $slash.parent.textBetween(
+    slashOffset - 1,
+    slashOffset,
+    '\0',
+    '\0',
+  );
+  if (charBeforeSlash !== '/') return false;
+
+  let $end;
+  try {
+    $end = state.doc.resolve(endPos);
+  } catch {
+    return false;
+  }
+
+  // Search must stay in same block
+  if ($end.parent !== $slash.parent) return false;
+
+  return true;
+}
+
+function getTextBetween(
+  state: EditorState,
+  slashPos: number,
+  endPos: number,
+): string | null {
+  if (!isValidSearchRange(state, slashPos, endPos)) return null;
+  const $slash = state.doc.resolve(slashPos);
+  const $end = state.doc.resolve(endPos);
+  return $slash.parent.textBetween(
+    $slash.parentOffset,
+    $end.parentOffset,
+    '\0',
+    '\0',
+  );
 }
 
 /*
  * This is needed because we need to be able to hide the placeholder
- * when the menu is opened externally
+ * when the menu is opened externally (e.g. via the floating plus button)
  */
 class MenuExternallyOpenedState implements PluginState {
   menuOpen = true;
   slashPos = null;
-  latestEditorState: EditorState;
+  preSlashEditorState: EditorState;
+  searchString = null;
 
-  constructor(latestState: EditorState) {
-    this.latestEditorState = latestState;
+  constructor(preSlashEditorState: EditorState) {
+    this.preSlashEditorState = preSlashEditorState;
   }
 
   transition(_tr: Transaction, _oldState: EditorState, newState: EditorState) {
@@ -93,7 +181,8 @@ export function slashCommandsStateChanged(
   return (
     oldState?.menuOpen !== newState?.menuOpen ||
     oldState?.slashPos !== newState?.slashPos ||
-    oldState?.latestEditorState !== newState?.latestEditorState ||
+    oldState?.preSlashEditorState !== newState?.preSlashEditorState ||
+    oldState?.searchString !== newState?.searchString ||
     oldState?.constructor.name !== newState?.constructor.name
   );
 }
@@ -144,39 +233,13 @@ interface SlashCommandsPluginArgs {
   getGroups: GetContextualActionGroups;
 }
 
-function keepOpenContextActions(
-  state: EditorState,
-  tr: Transaction,
-  slashPos: number | null,
-) {
-  if (tr.getMeta('SLASH_COMMANDS_PLUGIN') === 'close_context_menu') {
-    return false;
-  }
-  if (slashPos === null) return false;
-
-  const { pos } = state.selection.$from;
-  if (pos !== slashPos) return false;
-
-  const $slash = state.doc.resolve(slashPos);
-  const { parent, parentOffset } = $slash;
-  const textBetween = parent.textBetween(
-    parentOffset - 1,
-    parentOffset,
-    '\0',
-    '\0',
-  );
-  if (textBetween !== '/') return false;
-
-  return true;
-}
-
 function activeIsRightAligned(state: EditorState) {
   const parent = state.selection.$from.parent;
   if (!parent) return false;
   return parent.attrs['alignment'] === 'right';
 }
 
-function transactionIsSlashTyped(tr: Transaction) {
+function transactionIsCharacterTyped(tr: Transaction, character: string) {
   if (tr.steps.length !== 1) return false;
   const [step] = tr.steps;
   if (!(step instanceof ReplaceStep)) return false;
@@ -184,8 +247,12 @@ function transactionIsSlashTyped(tr: Transaction) {
   return (
     slice.content.childCount === 1 &&
     slice.content.firstChild?.isText &&
-    slice.content.firstChild.text === '/'
+    slice.content.firstChild.text === character
   );
+}
+
+function transactionIsSlashTyped(tr: Transaction) {
+  return transactionIsCharacterTyped(tr, '/');
 }
 
 export function slashCommandsPlugin(options: SlashCommandsPluginArgs) {

--- a/packages/ember-rdfa-editor/src/plugins/slash-commands/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/slash-commands/index.ts
@@ -8,6 +8,8 @@ export interface PluginState {
   menuOpen: boolean;
   preSlashEditorState: EditorState | null;
   slashPos: number | null;
+  // Search end position
+  endPos: number | null;
   searchString: string | null;
   transition: (
     tr: Transaction,
@@ -20,6 +22,7 @@ export interface PluginState {
 class IdleState implements PluginState {
   menuOpen = false;
   slashPos = null;
+  endPos = null;
   searchString = null;
   preSlashEditorState: EditorState | null;
 
@@ -102,6 +105,26 @@ class SearchingState implements PluginState {
   }
 }
 
+/*
+ * This is needed because we need to be able to hide the placeholder
+ * when the menu is opened externally (e.g. via the floating plus button)
+ */
+class MenuExternallyOpenedState implements PluginState {
+  menuOpen = true;
+  slashPos = null;
+  endPos = null;
+  preSlashEditorState: EditorState;
+  searchString = null;
+
+  constructor(preSlashEditorState: EditorState) {
+    this.preSlashEditorState = preSlashEditorState;
+  }
+
+  transition(_tr: Transaction, _oldState: EditorState, newState: EditorState) {
+    return new IdleState(newState);
+  }
+}
+
 function isValidSearchRange(
   state: EditorState,
   slashPos: number,
@@ -153,25 +176,6 @@ function getTextBetween(
     '\0',
     '\0',
   );
-}
-
-/*
- * This is needed because we need to be able to hide the placeholder
- * when the menu is opened externally (e.g. via the floating plus button)
- */
-class MenuExternallyOpenedState implements PluginState {
-  menuOpen = true;
-  slashPos = null;
-  preSlashEditorState: EditorState;
-  searchString = null;
-
-  constructor(preSlashEditorState: EditorState) {
-    this.preSlashEditorState = preSlashEditorState;
-  }
-
-  transition(_tr: Transaction, _oldState: EditorState, newState: EditorState) {
-    return new IdleState(newState);
-  }
 }
 
 export function slashCommandsStateChanged(
@@ -255,6 +259,48 @@ function transactionIsSlashTyped(tr: Transaction) {
   return transactionIsCharacterTyped(tr, '/');
 }
 
+function createPlaceholderDecoration(state: EditorState, text: string) {
+  return Decoration.widget(
+    state.selection.from,
+    () => {
+      const el = document.createElement('span');
+      el.textContent = text;
+      el.style.color = 'rgb(161, 158, 153)';
+      el.style.caretColor = '#000';
+      return el;
+    },
+    { side: activeIsRightAligned(state) ? -1 : 1 },
+  );
+}
+
+function getDecorations(state: EditorState, options: SlashCommandsPluginArgs) {
+  const pluginState = getSlashCommandsPluginState(state);
+  if (
+    pluginState instanceof IdleState &&
+    shouldShowPlaceholder(state, options.getGroups)
+  ) {
+    return [
+      createPlaceholderDecoration(
+        state,
+        options.intl.t(
+          'ember-rdfa-editor.contextual-actions.type-/-for-actions',
+        ),
+      ),
+    ];
+  }
+  if (
+    pluginState instanceof SearchingState &&
+    pluginState.slashPos === pluginState.endPos
+  ) {
+    return [
+      createPlaceholderDecoration(
+        state,
+        options.intl.t('ember-rdfa-editor.contextual-actions.type-to-search'),
+      ),
+    ];
+  }
+}
+
 export function slashCommandsPlugin(options: SlashCommandsPluginArgs) {
   return new Plugin<PluginState>({
     key: slashCommandsPluginKey,
@@ -273,25 +319,11 @@ export function slashCommandsPlugin(options: SlashCommandsPluginArgs) {
     },
     props: {
       decorations(state: EditorState) {
-        const { doc, selection } = state;
-        if (!shouldShowPlaceholder(state, options.getGroups)) {
-          return null;
-        }
-        return DecorationSet.create(doc, [
-          Decoration.widget(
-            selection.from,
-            () => {
-              const el = document.createElement('span');
-              el.textContent = options.intl.t(
-                'ember-rdfa-editor.contextual-actions.type-/-for-actions',
-              );
-              el.style.color = 'rgb(161, 158, 153)';
-              el.style.caretColor = '#000';
-              return el;
-            },
-            { side: activeIsRightAligned(state) ? -1 : 1 },
-          ),
-        ]);
+        const { doc } = state;
+        const decorations = getDecorations(state, options);
+        if (!decorations) return;
+
+        return DecorationSet.create(doc, decorations);
       },
     },
   });

--- a/test-app/app/dummy-plugins/expose-contextual-actions.ts
+++ b/test-app/app/dummy-plugins/expose-contextual-actions.ts
@@ -94,6 +94,26 @@ const streetSuggestionActions = [
     priority: 2,
   },
   {
+    label: 'Molenstraat 3, 9300 Aalst',
+    group: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+    priority: 2,
+  },
+  {
+    label: 'Perceel 45A 1.2',
+    group: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+    priority: 2,
+  },
+  {
+    label: 'Recreatiepark Blaarmeersen',
+    group: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+    priority: 2,
+  },
+  {
+    label: 'Monterreystraat 37, 9000 Gent',
+    group: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
+    priority: 2,
+  },
+  {
     label: 'Perceel 44A, 9000 Aalst',
     group: 'street-suggestions-1d8563d6-bfd8-487f-a2a0-6d7a6ab01cb5',
     priority: 9,


### PR DESCRIPTION
### Overview
Allow inline search for the slash commands


### How to test/reproduce
On the dummy plugins page, typing a slash should open the slash menu, and subsequently typing should search the menu. This works almost exactly like in Notion.


### Checks PR readiness
- [x] Tested on Firefox and Chrome-based browsers
- [x] changelog
- [x] npm lint
