### PR TITLE
LPDC-1688: link-plugin - correctly detect potential link suffixes

### DIFF
--- a/.changeset/cyan-shrimps-cheat.md
+++ b/.changeset/cyan-shrimps-cheat.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Link plugin: detect path/query string/fragment correctly

--- a/packages/ember-rdfa-editor/src/plugins/link/input-rule.ts
+++ b/packages/ember-rdfa-editor/src/plugins/link/input-rule.ts
@@ -65,9 +65,7 @@ export const link_input_rule = ({
     const link = match[2];
     const textAfterLink = match[3];
     const linkStart = start + textBeforeLink.length;
-    console.log('Link: ', link);
     const linkParserResult = linkParser(link);
-    console.log(linkParserResult);
     if (!linkParserResult.isSuccessful) {
       return null;
     }

--- a/packages/ember-rdfa-editor/src/plugins/link/input-rule.ts
+++ b/packages/ember-rdfa-editor/src/plugins/link/input-rule.ts
@@ -28,9 +28,10 @@ const DEFAULT_REGEX = new RegExp(
       [A-Za-z0-9.-]+ ${/* domain */ ''}
       \.
       [A-Za-z]{2,} ${/* extension */ ''}
+      (?:[\/?#][^\s]*)? ${/* optional path, query string, or fragment */ ''}
     )
   )
-  ( |\n)$ ${/* single space or newline/enter after url/email */ ''}
+  ([ \n])$ ${/* single space or newline/enter after url/email */ ''}
   `
     .replace(/^\s+|\s+$/gm, '') // remove white space before and at the end of lines (trimming)
     .replace(/\n/g, ''), // remove newlines
@@ -64,8 +65,9 @@ export const link_input_rule = ({
     const link = match[2];
     const textAfterLink = match[3];
     const linkStart = start + textBeforeLink.length;
-
+    console.log('Link: ', link);
     const linkParserResult = linkParser(link);
+    console.log(linkParserResult);
     if (!linkParserResult.isSuccessful) {
       return null;
     }


### PR DESCRIPTION
### Overview
This PR ensures that the regex of the link input rule takes potential link suffixes into account.

##### connected issues and PRs:
[LPDC-1688](https://binnenland.atlassian.net/browse/LPDC-1688)
https://github.com/nfrasser/linkifyjs/pull/557

### How to test/reproduce
- Start the dummy app
- Type a plain text link with a suffix: e.g. `example.org/`, `example.org/page1`, `example.org/?a=1`

### Challenges/uncertainties
The underlying `linkifyjs` package used by the link plugin has a limitation that it doesn't detect `?` and `#` suffixes correctly when not preceded by a forward slash.
See https://github.com/nfrasser/linkifyjs/issues/516 and https://github.com/nfrasser/linkifyjs/pull/557
The PR which fixes the issue is quite recent, so I'm hopeful it could get merged in the near future.
Potential solutions around this problem:
- Fork `linkifyjs` ourselves (ideally publishing it under the `@say` namespace on npm to prevent using github deps)
- Patch the `linkifyjs` package, is not transitively applied to dependents of the say editor however.
- Wait for the fix to be merged, and live with the limitation for now.

### Checks PR readiness
- [x] UI: feedback for any loading/error states
- [x] Tested on Firefox and Chrome-based browsers
- [x] changelog
- [x] npm lint
- [x] no new deprecation warnings
