### PR TITLE
Support multiple-select context actions

### DIFF
--- a/.changeset/modern-rabbits-rhyme.md
+++ b/.changeset/modern-rabbits-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add selected prop to context actions to support multiple select

--- a/.changeset/short-times-behave.md
+++ b/.changeset/short-times-behave.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add option to contextual action groups to keep the menu open after selection

--- a/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
+++ b/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
@@ -141,6 +141,7 @@
       gap: 0.5rem;
       display: flex;
       align-items: center;
+      min-height: var(--au-icon-size-large);
     }
 
     // This util is added by AU 3.16, so won't be needed after upgrading beyond that

--- a/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
+++ b/packages/ember-rdfa-editor/scss/_c-contextual-actions.scss
@@ -121,6 +121,10 @@
     font-family: "flanders-sans";
     font-size: var(--au-global-font-size);
 
+    &.selected-menu-entry {
+      background-color: var(--au-select-text-bg);
+    }
+
     &:hover,
     &.focused-menu-entry {
       color: var(--au-gray-900);
@@ -137,6 +141,11 @@
       gap: 0.5rem;
       display: flex;
       align-items: center;
+    }
+
+    // This util is added by AU 3.16, so won't be needed after upgrading beyond that
+    .au-u-flex-grow {
+      flex-grow: 1 !important;
     }
   }
 }

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -70,16 +70,16 @@ function sortGroups(
 }
 
 export default class ContextualActionsMenu extends Component<Args> {
-  @tracked selectedActionIndex: number = 0;
+  @tracked focusedActionIndex: number = 0;
   @tracked menuHeightPx: number = 0;
 
   actionToElement = new Map<ContextualAction, Element>();
 
   scrollActionIntoView = (actionIndex: number) => {
-    const selectedAction = this.getActionByIndex(actionIndex);
-    if (selectedAction !== null && selectedAction !== undefined) {
-      const selectedActionElement = this.actionToElement.get(selectedAction);
-      selectedActionElement?.scrollIntoView({ block: 'center' });
+    const focusedAction = this.getActionByIndex(actionIndex);
+    if (focusedAction !== null && focusedAction !== undefined) {
+      const focusedActionElement = this.actionToElement.get(focusedAction);
+      focusedActionElement?.scrollIntoView({ block: 'center' });
     }
   };
 
@@ -93,18 +93,18 @@ export default class ContextualActionsMenu extends Component<Args> {
         case 'Down':
           if (
             this.actionAmount &&
-            this.selectedActionIndex < this.actionAmount - 1
+            this.focusedActionIndex < this.actionAmount - 1
           ) {
-            this.selectedActionIndex += 1;
-            this.scrollActionIntoView(this.selectedActionIndex);
+            this.focusedActionIndex += 1;
+            this.scrollActionIntoView(this.focusedActionIndex);
           }
           event.preventDefault();
           break;
         case 'ArrowUp':
         case 'Up':
-          if (this.selectedActionIndex > 0) {
-            this.selectedActionIndex -= 1;
-            this.scrollActionIntoView(this.selectedActionIndex);
+          if (this.focusedActionIndex > 0) {
+            this.focusedActionIndex -= 1;
+            this.scrollActionIntoView(this.focusedActionIndex);
           }
           event.preventDefault();
           break;
@@ -113,12 +113,12 @@ export default class ContextualActionsMenu extends Component<Args> {
           break;
         case 'Enter': {
           event.preventDefault();
-          if (this.selectedActionIndex === null) break;
-          const selectedAction = this.getActionByIndex(
-            this.selectedActionIndex,
+          if (this.focusedActionIndex === null) break;
+          const focusedAction = this.getActionByIndex(
+            this.focusedActionIndex,
           );
-          if (selectedAction !== null && selectedAction !== undefined) {
-            this.args.onActionSelected?.(selectedAction);
+          if (focusedAction !== null && focusedAction !== undefined) {
+            this.args.onActionSelected?.(focusedAction);
           }
           break;
         }
@@ -133,14 +133,14 @@ export default class ContextualActionsMenu extends Component<Args> {
         case 'Tab':
           if (this.actionAmount) {
             if (event.shiftKey) {
-              this.selectedActionIndex =
-                (this.selectedActionIndex - 1 + this.actionAmount) %
+              this.focusedActionIndex =
+                (this.focusedActionIndex - 1 + this.actionAmount) %
                 this.actionAmount;
             } else {
-              this.selectedActionIndex =
-                (this.selectedActionIndex + 1) % this.actionAmount;
+              this.focusedActionIndex =
+                (this.focusedActionIndex + 1) % this.actionAmount;
             }
-            this.scrollActionIntoView(this.selectedActionIndex);
+            this.scrollActionIntoView(this.focusedActionIndex);
           }
           event.preventDefault();
           break;
@@ -159,7 +159,7 @@ export default class ContextualActionsMenu extends Component<Args> {
   });
 
   getActionByIndex(index: number) {
-    if (!this.groupedActions || this.selectedActionIndex === null) return null;
+    if (!this.groupedActions || this.focusedActionIndex === null) return null;
 
     let searchIndex = 0;
     for (const group of this.groupedActions) {
@@ -175,7 +175,7 @@ export default class ContextualActionsMenu extends Component<Args> {
 
   getIndexByAction(action: ContextualAction) {
     // Better to return null here but this should never happen
-    if (!this.groupedActions || this.selectedActionIndex === null) return 0;
+    if (!this.groupedActions || this.focusedActionIndex === null) return 0;
 
     let searchIndex = 0;
     for (const group of this.groupedActions) {
@@ -292,13 +292,13 @@ export default class ContextualActionsMenu extends Component<Args> {
     this.args.onActionSelected?.(action);
   };
 
-  isSelectedAction = (action: ContextualAction) => {
-    return this.getIndexByAction(action) === this.selectedActionIndex;
+  isFocusedAction = (action: ContextualAction) => {
+    return this.getIndexByAction(action) === this.focusedActionIndex;
   };
 
-  updateSelectedActionIndex = (action: ContextualAction, event: MouseEvent) => {
+  updateFocusedActionIndex = (action: ContextualAction, event: MouseEvent) => {
     if (event.movementX === 0 && event.movementY === 0) return;
-    this.selectedActionIndex = this.getIndexByAction(action);
+    this.focusedActionIndex = this.getIndexByAction(action);
   };
 
   addActionElementToMap = eModifier((element, [action]: [ContextualAction]) => {
@@ -318,7 +318,7 @@ export default class ContextualActionsMenu extends Component<Args> {
   }
 
   setSearchQuery = (event: InputEvent) => {
-    this.selectedActionIndex = 0;
+    this.focusedActionIndex = 0;
     this.args.onSearch?.((event.target as HTMLInputElement).value);
   };
 
@@ -442,12 +442,16 @@ export default class ContextualActionsMenu extends Component<Args> {
                       {{on "click" (fn this.selectAction actionItem)}}
                       {{on
                         "mousemove"
-                        (fn this.updateSelectedActionIndex actionItem)
+                        (fn this.updateFocusedActionIndex actionItem)
                       }}
                       class="say-contextual-actions-menu-entry au-u-text-left
                         {{if
-                          (this.isSelectedAction actionItem)
+                          (this.isFocusedAction actionItem)
                           'focused-menu-entry'
+                        }}
+                        {{if
+                          actionItem.selected
+                          'selected-menu-entry'
                         }}"
                       type="button"
                       title={{actionItem.description}}
@@ -456,7 +460,10 @@ export default class ContextualActionsMenu extends Component<Args> {
                         {{#if actionItem.icon}}
                           <AuIcon @size="large" @icon={{actionItem.icon}} />
                         {{/if}}
-                        <span>{{actionItem.label}}</span>
+                        <span class="au-u-flex-grow">{{actionItem.label}}</span>
+                        {{#if actionItem.selected}}
+                          <AuIcon @size="large" @icon="circle-check" class="au-u-flex-self-end" />
+                        {{/if}}
                       </div>
                     </button>
                   {{/each}}

--- a/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
+++ b/packages/ember-rdfa-editor/src/components/_private/common/contextual-actions-menu.gts
@@ -26,6 +26,7 @@ import { runTask } from 'ember-lifeline';
 import { eq, and } from 'ember-truth-helpers';
 import { getSlashCommandsPluginState } from '#root/plugins/slash-commands/index.ts';
 import { TextSelection } from 'prosemirror-state';
+import type { Option } from '#root/utils/option.ts';
 
 type GroupWithStatus = ContextualActionGroup & {
   isLoading: boolean;
@@ -41,7 +42,7 @@ type Args = {
   enableSearch?: boolean;
   searchQuery?: string;
 
-  onActionSelected?: (action: ContextualAction) => void;
+  onActionSelected?: (action: ContextualAction, keepOpen: boolean) => void;
   onClose?: () => void;
   onSearch?: (searchQuery: string) => void;
 };
@@ -76,7 +77,7 @@ export default class ContextualActionsMenu extends Component<Args> {
   actionToElement = new Map<ContextualAction, Element>();
 
   scrollActionIntoView = (actionIndex: number) => {
-    const focusedAction = this.getActionByIndex(actionIndex);
+    const { focusedAction } = this.getActionByIndex(actionIndex);
     if (focusedAction !== null && focusedAction !== undefined) {
       const focusedActionElement = this.actionToElement.get(focusedAction);
       focusedActionElement?.scrollIntoView({ block: 'center' });
@@ -114,11 +115,14 @@ export default class ContextualActionsMenu extends Component<Args> {
         case 'Enter': {
           event.preventDefault();
           if (this.focusedActionIndex === null) break;
-          const focusedAction = this.getActionByIndex(
+          const { focusedAction, focusedGroup } = this.getActionByIndex(
             this.focusedActionIndex,
           );
           if (focusedAction !== null && focusedAction !== undefined) {
-            this.args.onActionSelected?.(focusedAction);
+            this.args.onActionSelected?.(
+              focusedAction,
+              focusedGroup?.keepOpen ?? false,
+            );
           }
           break;
         }
@@ -158,19 +162,24 @@ export default class ContextualActionsMenu extends Component<Args> {
     };
   });
 
-  getActionByIndex(index: number) {
-    if (!this.groupedActions || this.focusedActionIndex === null) return null;
+  getActionByIndex(index: number): {
+    focusedAction: Option<ContextualAction>;
+    focusedGroup: Option<ContextualActionGroup>;
+  } {
+    if (!this.groupedActions || this.focusedActionIndex === null)
+      return { focusedAction: null, focusedGroup: null };
 
     let searchIndex = 0;
-    for (const group of this.groupedActions) {
-      for (const actionIter of group.actions) {
+    for (const focusedGroup of this.groupedActions) {
+      for (const actionIter of focusedGroup.actions) {
         if (searchIndex === index) {
-          return actionIter;
+          return { focusedAction: actionIter, focusedGroup };
         } else {
           searchIndex += 1;
         }
       }
     }
+    return { focusedAction: null, focusedGroup: null };
   }
 
   getIndexByAction(action: ContextualAction) {
@@ -288,8 +297,8 @@ export default class ContextualActionsMenu extends Component<Args> {
     },
   );
 
-  selectAction = (action: ContextualAction) => {
-    this.args.onActionSelected?.(action);
+  selectAction = (action: ContextualAction, keepOpen?: boolean) => {
+    this.args.onActionSelected?.(action, keepOpen ?? false);
   };
 
   isFocusedAction = (action: ContextualAction) => {
@@ -439,7 +448,10 @@ export default class ContextualActionsMenu extends Component<Args> {
                   {{#each group.actions as |actionItem|}}
                     <button
                       {{this.addActionElementToMap actionItem}}
-                      {{on "click" (fn this.selectAction actionItem)}}
+                      {{on
+                        "click"
+                        (fn this.selectAction actionItem group.keepOpen)
+                      }}
                       {{on
                         "mousemove"
                         (fn this.updateFocusedActionIndex actionItem)
@@ -449,10 +461,7 @@ export default class ContextualActionsMenu extends Component<Args> {
                           (this.isFocusedAction actionItem)
                           'focused-menu-entry'
                         }}
-                        {{if
-                          actionItem.selected
-                          'selected-menu-entry'
-                        }}"
+                        {{if actionItem.selected 'selected-menu-entry'}}"
                       type="button"
                       title={{actionItem.description}}
                     >
@@ -462,7 +471,11 @@ export default class ContextualActionsMenu extends Component<Args> {
                         {{/if}}
                         <span class="au-u-flex-grow">{{actionItem.label}}</span>
                         {{#if actionItem.selected}}
-                          <AuIcon @size="large" @icon="circle-check" class="au-u-flex-self-end" />
+                          <AuIcon
+                            @size="large"
+                            @icon="circle-check"
+                            class="au-u-flex-self-end"
+                          />
                         {{/if}}
                       </div>
                     </button>

--- a/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
+++ b/packages/ember-rdfa-editor/src/components/plugins/contextual-actions/container.gts
@@ -203,7 +203,7 @@ export default class ContextualActionsContainer extends Component<Args> {
   }
 
   @action
-  executeAction(action: ContextualAction) {
+  executeAction(action: ContextualAction, keepOpen: boolean) {
     if (
       this.menuWasOpenedBySlash &&
       this.slashCommandsPluginState?.preSlashEditorState
@@ -213,15 +213,19 @@ export default class ContextualActionsContainer extends Component<Args> {
       );
     }
     if ('command' in action) {
-      this.controller.focus();
+      if (!keepOpen) {
+        this.controller.focus();
+      }
       this.controller.doCommand(action.command);
     }
   }
 
   @action
-  selectAction(action: ContextualAction) {
-    this.executeAction(action);
-    this.closeContextMenu();
+  selectAction(action: ContextualAction, keepOpen: boolean) {
+    this.executeAction(action, keepOpen);
+    if (!keepOpen) {
+      this.closeContextMenu();
+    }
   }
 
   get slashCommandsPluginState() {

--- a/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
@@ -17,6 +17,7 @@ export type ContextualActionGroup = {
   label?: string;
   sticky?: 'bottom';
   priority?: number;
+  keepOpen?: boolean;
 
   loadingMessage?: string;
   searchDebounceMs?: number;

--- a/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/contextual-actions/index.ts
@@ -7,6 +7,7 @@ export type ContextualAction = {
   group: string;
   command: Command;
   description?: string;
+  selected?: boolean;
 
   priority?: number;
 };


### PR DESCRIPTION
### Overview
A couple of changes were needed to support multiple-choice context actions such as codelists:
- Showing which actions have already been selected
- Keeping the menu open after selecting an option as we need to be able to select (or deselect) more options without opening the menu each time

##### connected issues and PRs:
- Part of https://binnenland.atlassian.net/browse/GN-6010
- Required for (plugins PR TBC)
- Design: https://www.figma.com/design/C4QjSLpfzyLhwlQikhMVsW/GN-navigation

### Setup
N/A

### How to test/reproduce
Best tested as part of the plugins PR

### Challenges/uncertainties
It seems that calling `closeContextMenu` doesn't close the menu if the node stays selected, so it's up to action implementers to make sure the selection changes. This seems error prone, ideally this would be handled by the contextual-actions logic.

### Checks PR readiness
- [ ] UI: feedback for any loading/error states
- [x] Tested on Firefox and Chrome-based browsers
- [x] changelog
- [x] npm lint
- [x] no new deprecation warnings