### PR TITLE
Feat/make ar work with regulatory

### DIFF
--- a/.changeset/heavy-heads-rest.md
+++ b/.changeset/heavy-heads-rest.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add argument to build article structure function to build RB articles and improve selection handling when inserting articles freely

--- a/.changeset/mean-peaches-fix.md
+++ b/.changeset/mean-peaches-fix.md
@@ -1,0 +1,5 @@
+---
+'@lblod/say-roadsign-regulation-plugin': minor
+---
+
+Add multiple insertion argument to insert measure so it only modifies the selection once, and pass down the reg statement mode to build article structure

--- a/.changeset/thin-trams-yawn.md
+++ b/.changeset/thin-trams-yawn.md
@@ -1,0 +1,5 @@
+---
+'@lblod/say-ar-design-plugin': minor
+---
+
+The plugin now works without a besluit needed and inserts RB articles in this case

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/build-article-structure.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/build-article-structure.ts
@@ -11,7 +11,6 @@ import {
   RB_ARTICLE,
   type StructurePluginOptions,
   type StructureConfig,
-
 } from './structure-types.ts';
 
 export function generateStructureAttrs({
@@ -68,9 +67,9 @@ export function buildArticleStructure(
     const articleId = uuid();
     articleResource = `http://data.lblod.info/artikels/${uriGenerator === 'template-uuid4' ? '--ref-uuid4-' : ''}${articleId}`;
   }
-  let structureType = DECISION_ARTICLE
-  if(regulatoryArticle) {
-    structureType = RB_ARTICLE
+  let structureType = DECISION_ARTICLE;
+  if (regulatoryArticle) {
+    structureType = RB_ARTICLE;
   }
   return schema.node(
     'structure',

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/build-article-structure.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/build-article-structure.ts
@@ -8,8 +8,10 @@ import { SayDataFactory } from '#root/core/say-data-factory/index.ts';
 import { v4 as uuid } from 'uuid';
 import {
   DECISION_ARTICLE,
+  RB_ARTICLE,
   type StructurePluginOptions,
   type StructureConfig,
+
 } from './structure-types.ts';
 
 export function generateStructureAttrs({
@@ -56,6 +58,7 @@ export function buildArticleStructure(
    * document with this URI imported it works as expected. It creates valid RDFa in either case.
    */
   decisionUri?: string,
+  regulatoryArticle?: boolean,
 ) {
   const factory = new SayDataFactory();
   let articleResource: string;
@@ -65,10 +68,14 @@ export function buildArticleStructure(
     const articleId = uuid();
     articleResource = `http://data.lblod.info/artikels/${uriGenerator === 'template-uuid4' ? '--ref-uuid4-' : ''}${articleId}`;
   }
+  let structureType = DECISION_ARTICLE
+  if(regulatoryArticle) {
+    structureType = RB_ARTICLE
+  }
   return schema.node(
     'structure',
     generateStructureAttrs({
-      config: DECISION_ARTICLE,
+      config: structureType,
       subject: articleResource,
       properties: [
         {

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
@@ -1,4 +1,4 @@
-import { EditorState, TextSelection, Transaction } from 'prosemirror-state';
+import { EditorState, TextSelection, Transaction, Selection } from 'prosemirror-state';
 import { PNode } from '#root/prosemirror-aliases.ts';
 import { ELI, PROV } from '#root/utils/_private/lblod-utils/constants.ts';
 import { getOutgoingTriple } from '#root/utils/namespace.ts';
@@ -10,6 +10,7 @@ import { addPropertyToNode, findNodeByRdfaId } from '#root/utils/rdfa-utils.ts';
 import { SayDataFactory } from '#root/core/say-data-factory/index.ts';
 import { getNodesBySubject } from '#root/plugins/rdfa-info/index.ts';
 import { recalculateNumbers } from '#root/utils/_private/lblod-utils/recalculate-structure-numbers.ts';
+import { GapCursor } from '#root/plugins/gap-cursor/index.ts';
 
 export interface InsertArticleToDecisionArgs {
   node: PNode;
@@ -23,11 +24,13 @@ export interface InsertArticleToDecisionArgs {
    * - Otherwise, insert before the child at that index.
    */
   position?: number;
+  insertMultiple?: boolean
 }
 export interface InsertArticleFreelyArgs {
   node: PNode;
   insertFreely: true;
   decisionUri?: string;
+  insertMultiple?: boolean
 }
 
 export function insertArticle(
@@ -38,8 +41,16 @@ export function insertArticle(
     const tr = state.tr;
     let replacementTr: Transaction;
     let insertLocation: number | undefined;
+    let positionBeforeInsertion: number | undefined;
     if ('insertFreely' in args && args.insertFreely) {
-      replacementTr = tr.replaceSelectionWith(node);
+      console.log('document size before', tr.doc.nodeSize)
+      console.log('position before', tr.selection.$from.pos)
+      positionBeforeInsertion = tr.selection.$from.pos;
+      console.log('node size', node.nodeSize)
+
+      //if(positionBeforeInsertion === 1) {
+      replacementTr = tr.replaceWith(positionBeforeInsertion, positionBeforeInsertion, node);
+      //}
     } else {
       const { position } = args;
       const decision = getNodesBySubject(state, args.decisionUri)[0];
@@ -97,6 +108,23 @@ export function insertArticle(
           insertLocation + node.nodeSize - 1,
         ),
       );
+    } else {
+      console.log('selection without changing it', tr.selection)
+      console.log('setting selection')
+      console.log(positionBeforeInsertion + node.nodeSize + 1)
+      console.log('document node size', transaction.doc.nodeSize)
+      new GapCursor(transaction.doc.resolve(positionBeforeInsertion + node.nodeSize + 1))
+      try {
+        transaction.setSelection(
+           TextSelection.create(transaction.doc,
+          positionBeforeInsertion + node.nodeSize + 1,
+          positionBeforeInsertion + node.nodeSize + 1),
+
+        );
+      }catch(e) {
+        console.log(e)
+      }
+      console.log(transaction.selection)
     }
 
     transaction.scrollIntoView();

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
@@ -103,15 +103,13 @@ export function insertArticle(
         ),
       );
     } else if (positionBeforeInsertion) {
-
-        transaction.setSelection(
-          new GapCursor(
-            transaction.doc.resolve(
-              transaction.mapping.map(positionBeforeInsertion),
-            ),
+      transaction.setSelection(
+        new GapCursor(
+          transaction.doc.resolve(
+            transaction.mapping.map(positionBeforeInsertion),
           ),
-        );
-
+        ),
+      );
     }
 
     transaction.scrollIntoView();

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
@@ -112,7 +112,7 @@ export function insertArticle(
           insertLocation + node.nodeSize - 1,
         ),
       );
-    } else {
+    } else if (positionBeforeInsertion) {
       console.log('selection without changing it', tr.selection);
       console.log('setting selection');
       console.log(positionBeforeInsertion + node.nodeSize + 1);

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
@@ -1,7 +1,6 @@
 import { EditorState, TextSelection, Transaction } from 'prosemirror-state';
 import { PNode } from '#root/prosemirror-aliases.ts';
 import { ELI, PROV } from '#root/utils/_private/lblod-utils/constants.ts';
-import { getOutgoingTriple } from '#root/utils/namespace.ts';
 import {
   transactionCombinator,
   type TransactionMonad,
@@ -11,6 +10,15 @@ import { SayDataFactory } from '#root/core/say-data-factory/index.ts';
 import { getNodesBySubject } from '#root/plugins/rdfa-info/index.ts';
 import { recalculateNumbers } from '#root/utils/_private/lblod-utils/recalculate-structure-numbers.ts';
 import { GapCursor } from '#root/plugins/gap-cursor/index.ts';
+import {
+  getOutgoingTriple,
+  hasOutgoingNamedNodeTriple,
+} from '#root/utils/namespace.ts';
+import {
+  RDF
+} from '#root/utils/_private/lblod-utils/constants.ts';
+import { findAncestors } from '#root/utils/position-utils.ts';
+import { ResolvedPos } from 'prosemirror-model';
 
 export interface InsertArticleToDecisionArgs {
   node: PNode;
@@ -39,10 +47,10 @@ export function insertArticle(
     const tr = state.tr;
     let replacementTr: Transaction;
     let insertLocation: number | undefined;
-    let positionBeforeInsertion: number | undefined;
     if ('insertFreely' in args && args.insertFreely) {
-      positionBeforeInsertion = state.selection.from;
-      replacementTr = tr.replaceSelectionWith(node);
+      // Avoid insertion inside another article
+      insertLocation = getClosestValidPosition(state.selection.$from, node);
+      replacementTr = tr.replaceWith(insertLocation, insertLocation, node);
     } else {
       const { position } = args;
       const decision = getNodesBySubject(state, args.decisionUri)[0];
@@ -92,7 +100,7 @@ export function insertArticle(
       recalculateNumbers,
     ]);
 
-    if (insertLocation) {
+    if (!'insertFreely' in args || !args.insertFreely) {
       transaction.setSelection(
         TextSelection.create(
           transaction.doc,
@@ -100,11 +108,11 @@ export function insertArticle(
           insertLocation + node.nodeSize - 1,
         ),
       );
-    } else if (positionBeforeInsertion) {
+    } else  {
       transaction.setSelection(
         new GapCursor(
           transaction.doc.resolve(
-            transaction.mapping.map(positionBeforeInsertion),
+            transaction.mapping.map(insertLocation),
           ),
         ),
       );
@@ -151,4 +159,20 @@ function resolveInsertLocation(
   }
 
   return containerLocation.pos + containerNode.nodeSize - 1;
+}
+
+function getClosestValidPosition(position: ResolvedPos, node: PNode) {
+   const parentArticle = findAncestors(position, isSameArticleNode.bind(this, node))[0]
+   if(parentArticle) {
+    return parentArticle.pos + parentArticle.node.nodeSize;
+   } else {
+    return position.pos
+   }
+}
+
+
+export function isSameArticleNode(nodeA: PNode, nodeB: PNode) {
+  const rdfType = getOutgoingTriple(nodeA.attrs, RDF('type'))
+    ?.object.value;
+  return hasOutgoingNamedNodeTriple(nodeB.attrs, RDF('type'), rdfType)
 }

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
@@ -43,18 +43,9 @@ export function insertArticle(
     let insertLocation: number | undefined;
     let positionBeforeInsertion: number | undefined;
     if ('insertFreely' in args && args.insertFreely) {
-      console.log('document size before', tr.doc.nodeSize);
-      console.log('position before', tr.selection.$from.pos);
-      positionBeforeInsertion = tr.selection.$from.pos;
-      console.log('node size', node.nodeSize);
-
-      //if(positionBeforeInsertion === 1) {
-      replacementTr = tr.replaceWith(
-        positionBeforeInsertion,
-        positionBeforeInsertion,
-        node,
-      );
-      //}
+      positionBeforeInsertion = state.selection.from;
+      console.log(state.selection);
+      replacementTr = tr.replaceSelectionWith(node);
     } else {
       const { position } = args;
       const decision = getNodesBySubject(state, args.decisionUri)[0];
@@ -113,25 +104,19 @@ export function insertArticle(
         ),
       );
     } else if (positionBeforeInsertion) {
-      console.log('selection without changing it', tr.selection);
-      console.log('setting selection');
-      console.log(positionBeforeInsertion + node.nodeSize + 1);
-      console.log('document node size', transaction.doc.nodeSize);
-      new GapCursor(
-        transaction.doc.resolve(positionBeforeInsertion + node.nodeSize + 1),
-      );
+      console.log('setting gap cur');
       try {
         transaction.setSelection(
-          TextSelection.create(
-            transaction.doc,
-            positionBeforeInsertion + node.nodeSize + 1,
-            positionBeforeInsertion + node.nodeSize + 1,
+          new GapCursor(
+            transaction.doc.resolve(
+              transaction.mapping.map(positionBeforeInsertion),
+            ),
           ),
         );
+        console.log(transaction.selection);
       } catch (e) {
         console.log(e);
       }
-      console.log(transaction.selection);
     }
 
     transaction.scrollIntoView();

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
@@ -24,13 +24,11 @@ export interface InsertArticleToDecisionArgs {
    * - Otherwise, insert before the child at that index.
    */
   position?: number;
-  insertMultiple?: boolean;
 }
 export interface InsertArticleFreelyArgs {
   node: PNode;
   insertFreely: true;
   decisionUri?: string;
-  insertMultiple?: boolean;
 }
 
 export function insertArticle(

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
@@ -1,4 +1,4 @@
-import { EditorState, TextSelection, Transaction, Selection } from 'prosemirror-state';
+import { EditorState, TextSelection, Transaction } from 'prosemirror-state';
 import { PNode } from '#root/prosemirror-aliases.ts';
 import { ELI, PROV } from '#root/utils/_private/lblod-utils/constants.ts';
 import { getOutgoingTriple } from '#root/utils/namespace.ts';
@@ -24,13 +24,13 @@ export interface InsertArticleToDecisionArgs {
    * - Otherwise, insert before the child at that index.
    */
   position?: number;
-  insertMultiple?: boolean
+  insertMultiple?: boolean;
 }
 export interface InsertArticleFreelyArgs {
   node: PNode;
   insertFreely: true;
   decisionUri?: string;
-  insertMultiple?: boolean
+  insertMultiple?: boolean;
 }
 
 export function insertArticle(
@@ -43,13 +43,17 @@ export function insertArticle(
     let insertLocation: number | undefined;
     let positionBeforeInsertion: number | undefined;
     if ('insertFreely' in args && args.insertFreely) {
-      console.log('document size before', tr.doc.nodeSize)
-      console.log('position before', tr.selection.$from.pos)
+      console.log('document size before', tr.doc.nodeSize);
+      console.log('position before', tr.selection.$from.pos);
       positionBeforeInsertion = tr.selection.$from.pos;
-      console.log('node size', node.nodeSize)
+      console.log('node size', node.nodeSize);
 
       //if(positionBeforeInsertion === 1) {
-      replacementTr = tr.replaceWith(positionBeforeInsertion, positionBeforeInsertion, node);
+      replacementTr = tr.replaceWith(
+        positionBeforeInsertion,
+        positionBeforeInsertion,
+        node,
+      );
       //}
     } else {
       const { position } = args;
@@ -109,22 +113,25 @@ export function insertArticle(
         ),
       );
     } else {
-      console.log('selection without changing it', tr.selection)
-      console.log('setting selection')
-      console.log(positionBeforeInsertion + node.nodeSize + 1)
-      console.log('document node size', transaction.doc.nodeSize)
-      new GapCursor(transaction.doc.resolve(positionBeforeInsertion + node.nodeSize + 1))
+      console.log('selection without changing it', tr.selection);
+      console.log('setting selection');
+      console.log(positionBeforeInsertion + node.nodeSize + 1);
+      console.log('document node size', transaction.doc.nodeSize);
+      new GapCursor(
+        transaction.doc.resolve(positionBeforeInsertion + node.nodeSize + 1),
+      );
       try {
         transaction.setSelection(
-           TextSelection.create(transaction.doc,
-          positionBeforeInsertion + node.nodeSize + 1,
-          positionBeforeInsertion + node.nodeSize + 1),
-
+          TextSelection.create(
+            transaction.doc,
+            positionBeforeInsertion + node.nodeSize + 1,
+            positionBeforeInsertion + node.nodeSize + 1,
+          ),
         );
-      }catch(e) {
-        console.log(e)
+      } catch (e) {
+        console.log(e);
       }
-      console.log(transaction.selection)
+      console.log(transaction.selection);
     }
 
     transaction.scrollIntoView();

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
@@ -14,9 +14,7 @@ import {
   getOutgoingTriple,
   hasOutgoingNamedNodeTriple,
 } from '#root/utils/namespace.ts';
-import {
-  RDF
-} from '#root/utils/_private/lblod-utils/constants.ts';
+import { RDF } from '#root/utils/_private/lblod-utils/constants.ts';
 import { findAncestors } from '#root/utils/position-utils.ts';
 import { ResolvedPos } from 'prosemirror-model';
 
@@ -100,7 +98,7 @@ export function insertArticle(
       recalculateNumbers,
     ]);
 
-    if (!'insertFreely' in args || !args.insertFreely) {
+    if (!args.insertFreely) {
       transaction.setSelection(
         TextSelection.create(
           transaction.doc,
@@ -108,12 +106,10 @@ export function insertArticle(
           insertLocation + node.nodeSize - 1,
         ),
       );
-    } else  {
+    } else {
       transaction.setSelection(
         new GapCursor(
-          transaction.doc.resolve(
-            transaction.mapping.map(insertLocation),
-          ),
+          transaction.doc.resolve(transaction.mapping.map(insertLocation)),
         ),
       );
     }
@@ -162,17 +158,19 @@ function resolveInsertLocation(
 }
 
 function getClosestValidPosition(position: ResolvedPos, node: PNode) {
-   const parentArticle = findAncestors(position, isSameArticleNode.bind(this, node))[0]
-   if(parentArticle) {
+  const parentArticle = findAncestors(
+    position,
+    isSameArticleNode.bind(undefined, node),
+  )[0];
+  if (parentArticle) {
     return parentArticle.pos + parentArticle.node.nodeSize;
-   } else {
-    return position.pos
-   }
+  } else {
+    return position.pos;
+  }
 }
 
-
 export function isSameArticleNode(nodeA: PNode, nodeB: PNode) {
-  const rdfType = getOutgoingTriple(nodeA.attrs, RDF('type'))
-    ?.object.value;
-  return hasOutgoingNamedNodeTriple(nodeB.attrs, RDF('type'), rdfType)
+  const rdfType = getOutgoingTriple(nodeA.attrs, RDF('type'))?.object.value;
+  if (!rdfType) return false;
+  return hasOutgoingNamedNodeTriple(nodeB.attrs, RDF('type'), rdfType);
 }

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/insert-article.ts
@@ -44,7 +44,6 @@ export function insertArticle(
     let positionBeforeInsertion: number | undefined;
     if ('insertFreely' in args && args.insertFreely) {
       positionBeforeInsertion = state.selection.from;
-      console.log(state.selection);
       replacementTr = tr.replaceSelectionWith(node);
     } else {
       const { position } = args;
@@ -104,8 +103,7 @@ export function insertArticle(
         ),
       );
     } else if (positionBeforeInsertion) {
-      console.log('setting gap cur');
-      try {
+
         transaction.setSelection(
           new GapCursor(
             transaction.doc.resolve(
@@ -113,10 +111,7 @@ export function insertArticle(
             ),
           ),
         );
-        console.log(transaction.selection);
-      } catch (e) {
-        console.log(e);
-      }
+
     }
 
     transaction.scrollIntoView();

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/structure-types.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/structure-types.ts
@@ -128,7 +128,7 @@ export const DECISION_ARTICLE: StructureConfig = {
 
 export const RB_ARTICLE: StructureConfig = STRUCTURE_HIERARCHY.find(
   (structure) => structure.rdfType.full === SAY('Article').full,
-);
+) as StructureConfig;
 
 export function isHierarchyNode(node: PNode) {
   return STRUCTURE_HIERARCHY.some(({ rdfType }) =>

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/structure-types.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/structure-types.ts
@@ -126,6 +126,8 @@ export const DECISION_ARTICLE: StructureConfig = {
   absoluteNumbering: true,
 };
 
+export const RB_ARTICLE: StructureConfig = STRUCTURE_HIERARCHY.find((structure) => structure.rdfType.full === SAY('Article').full)
+
 export function isHierarchyNode(node: PNode) {
   return STRUCTURE_HIERARCHY.some(({ rdfType }) =>
     hasOutgoingNamedNodeTriple(node.attrs, RDF('type'), rdfType),

--- a/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/structure-types.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/lblod-utils/structure-types.ts
@@ -126,7 +126,9 @@ export const DECISION_ARTICLE: StructureConfig = {
   absoluteNumbering: true,
 };
 
-export const RB_ARTICLE: StructureConfig = STRUCTURE_HIERARCHY.find((structure) => structure.rdfType.full === SAY('Article').full)
+export const RB_ARTICLE: StructureConfig = STRUCTURE_HIERARCHY.find(
+  (structure) => structure.rdfType.full === SAY('Article').full,
+);
 
 export function isHierarchyNode(node: PNode) {
   return STRUCTURE_HIERARCHY.some(({ rdfType }) =>

--- a/packages/say-ar-design-plugin/src/components/insert-controls.gts
+++ b/packages/say-ar-design-plugin/src/components/insert-controls.gts
@@ -30,6 +30,7 @@ const InsertButton: TOC<{
     insertLoading?: boolean;
     onInsertAr: ArInsertFunc;
     insertPosition: ArticleInsertPosition | false;
+
   };
 }> = <template>
   <AuButton
@@ -71,6 +72,7 @@ export interface ArInsertControlArgs {
   onInsertAr: ArInsertFunc;
   insertLoading?: boolean;
   articles: ArticlePosition[];
+  regulatoryStatementMode?: boolean
 }
 type Sig = {
   Args: ArInsertControlArgs;
@@ -110,16 +112,25 @@ export class InsertControls extends Component<Sig> {
   }
 
   get options(): InsertPositionOption[] {
-    return [
-      this.afterLast,
-      this.beforeFirst,
-      this.onCursor,
-      ...this.articleOptions,
-    ];
+    if(this.args.regulatoryStatementMode) {
+      return [this.onCursor]
+    } else {
+      return [
+        this.afterLast,
+        this.beforeFirst,
+        this.onCursor,
+        ...this.articleOptions,
+      ];
+    }
   }
 
   get selected(): InsertPositionOption {
-    return this._selected ?? this.afterLast;
+    if(this._selected) {
+      return this._selected
+    } else {
+      return this.args.regulatoryStatementMode ? this.onCursor : this.afterLast;
+    }
+
   }
 
   setSelected = (val: InsertPositionOption | null) => {

--- a/packages/say-ar-design-plugin/src/components/insert-controls.gts
+++ b/packages/say-ar-design-plugin/src/components/insert-controls.gts
@@ -29,7 +29,7 @@ const InsertButton: TOC<{
     arDesign: ArDesign;
     insertLoading?: boolean;
     onInsertAr: ArInsertFunc;
-    insertPosition: ArticleInsertPosition;
+    insertPosition: ArticleInsertPosition | false;
   };
 }> = <template>
   <AuButton
@@ -110,7 +110,12 @@ export class InsertControls extends Component<Sig> {
   }
 
   get options(): InsertPositionOption[] {
-    return [this.afterLast, this.beforeFirst, this.onCursor, ...this.articleOptions];
+    return [
+      this.afterLast,
+      this.beforeFirst,
+      this.onCursor,
+      ...this.articleOptions,
+    ];
   }
 
   get selected(): InsertPositionOption {

--- a/packages/say-ar-design-plugin/src/components/insert-controls.gts
+++ b/packages/say-ar-design-plugin/src/components/insert-controls.gts
@@ -30,7 +30,6 @@ const InsertButton: TOC<{
     insertLoading?: boolean;
     onInsertAr: ArInsertFunc;
     insertPosition: ArticleInsertPosition | false;
-
   };
 }> = <template>
   <AuButton
@@ -72,7 +71,7 @@ export interface ArInsertControlArgs {
   onInsertAr: ArInsertFunc;
   insertLoading?: boolean;
   articles: ArticlePosition[];
-  regulatoryStatementMode?: boolean
+  regulatoryStatementMode?: boolean;
 }
 type Sig = {
   Args: ArInsertControlArgs;
@@ -112,8 +111,8 @@ export class InsertControls extends Component<Sig> {
   }
 
   get options(): InsertPositionOption[] {
-    if(this.args.regulatoryStatementMode) {
-      return [this.onCursor]
+    if (this.args.regulatoryStatementMode) {
+      return [this.onCursor];
     } else {
       return [
         this.afterLast,
@@ -125,12 +124,11 @@ export class InsertControls extends Component<Sig> {
   }
 
   get selected(): InsertPositionOption {
-    if(this._selected) {
-      return this._selected
+    if (this._selected) {
+      return this._selected;
     } else {
       return this.args.regulatoryStatementMode ? this.onCursor : this.afterLast;
     }
-
   }
 
   setSelected = (val: InsertPositionOption | null) => {

--- a/packages/say-ar-design-plugin/src/components/insert-controls.gts
+++ b/packages/say-ar-design-plugin/src/components/insert-controls.gts
@@ -93,6 +93,13 @@ export class InsertControls extends Component<Sig> {
     };
   }
 
+  get onCursor(): InsertPositionOption {
+    return {
+      value: false,
+      label: this.intl.t('ar-importer.controls.on-cursor'),
+    };
+  }
+
   get articleOptions(): InsertPositionOption[] {
     return this.args.articles.map((_, i) => ({
       value: new ArticleInsertPosition(i),
@@ -103,7 +110,7 @@ export class InsertControls extends Component<Sig> {
   }
 
   get options(): InsertPositionOption[] {
-    return [this.afterLast, this.beforeFirst, ...this.articleOptions];
+    return [this.afterLast, this.beforeFirst, this.onCursor, ...this.articleOptions];
   }
 
   get selected(): InsertPositionOption {

--- a/packages/say-ar-design-plugin/src/components/preview.gts
+++ b/packages/say-ar-design-plugin/src/components/preview.gts
@@ -10,7 +10,6 @@ import { ArrowLeftIcon } from '@appuniversum/ember-appuniversum/components/icons
 import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
 import type ArImporterService from '../services/ar-importer.ts';
 import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
-import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import {
   InsertControls,
   type ArInsertControlArgs,

--- a/packages/say-ar-design-plugin/src/components/preview.gts
+++ b/packages/say-ar-design-plugin/src/components/preview.gts
@@ -28,7 +28,6 @@ export default class ArPreview extends Component<ArPreviewSignature> {
   @service declare arImporter: ArImporterService;
 
   preview = trackedFunction(this, async () => {
-    console.log('linked');
     try {
       return this.arImporter.generatePreview(
         this.args.arDesign,

--- a/packages/say-ar-design-plugin/src/components/preview.gts
+++ b/packages/say-ar-design-plugin/src/components/preview.gts
@@ -10,6 +10,7 @@ import { ArrowLeftIcon } from '@appuniversum/ember-appuniversum/components/icons
 import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
 import type ArImporterService from '../services/ar-importer.ts';
 import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
+import SayController from '@lblod/ember-rdfa-editor/core/say-controller';
 import {
   InsertControls,
   type ArInsertControlArgs,
@@ -20,9 +21,9 @@ type ArPreviewSignature = {
   Args: ArInsertControlArgs & {
     onReturnToOverview: () => unknown;
     processDocumentHeadlessly: ProcessDocumentHeadlessly;
+    controller: SayController;
   };
   Element: HTMLDivElement;
-  controller: SayController;
 };
 
 export default class ArPreview extends Component<ArPreviewSignature> {

--- a/packages/say-ar-design-plugin/src/components/preview.gts
+++ b/packages/say-ar-design-plugin/src/components/preview.gts
@@ -28,6 +28,7 @@ export default class ArPreview extends Component<ArPreviewSignature> {
   @service declare arImporter: ArImporterService;
 
   preview = trackedFunction(this, async () => {
+    console.log('linked')
     try {
       return this.arImporter.generatePreview(
         this.args.arDesign,

--- a/packages/say-ar-design-plugin/src/components/preview.gts
+++ b/packages/say-ar-design-plugin/src/components/preview.gts
@@ -22,6 +22,7 @@ type ArPreviewSignature = {
     processDocumentHeadlessly: ProcessDocumentHeadlessly;
   };
   Element: HTMLDivElement;
+  controller: SayController;
 };
 
 export default class ArPreview extends Component<ArPreviewSignature> {
@@ -33,6 +34,7 @@ export default class ArPreview extends Component<ArPreviewSignature> {
       return this.arImporter.generatePreview(
         this.args.arDesign,
         this.args.processDocumentHeadlessly,
+        this.args.controller,
       );
     } catch (e) {
       console.error('Error generating preview', e);

--- a/packages/say-ar-design-plugin/src/components/preview.gts
+++ b/packages/say-ar-design-plugin/src/components/preview.gts
@@ -20,7 +20,7 @@ type ArPreviewSignature = {
   Args: ArInsertControlArgs & {
     onReturnToOverview: () => unknown;
     processDocumentHeadlessly: ProcessDocumentHeadlessly;
-    regulatoryStatementMode?: boolean
+    regulatoryStatementMode?: boolean;
   };
   Element: HTMLDivElement;
 };

--- a/packages/say-ar-design-plugin/src/components/preview.gts
+++ b/packages/say-ar-design-plugin/src/components/preview.gts
@@ -28,7 +28,7 @@ export default class ArPreview extends Component<ArPreviewSignature> {
   @service declare arImporter: ArImporterService;
 
   preview = trackedFunction(this, async () => {
-    console.log('linked')
+    console.log('linked');
     try {
       return this.arImporter.generatePreview(
         this.args.arDesign,

--- a/packages/say-ar-design-plugin/src/components/preview.gts
+++ b/packages/say-ar-design-plugin/src/components/preview.gts
@@ -20,6 +20,7 @@ type ArPreviewSignature = {
   Args: ArInsertControlArgs & {
     onReturnToOverview: () => unknown;
     processDocumentHeadlessly: ProcessDocumentHeadlessly;
+    regulatoryStatementMode?: boolean
   };
   Element: HTMLDivElement;
 };
@@ -88,6 +89,7 @@ export default class ArPreview extends Component<ArPreviewSignature> {
           @onInsertAr={{@onInsertAr}}
           @insertLoading={{@insertLoading}}
           @articles={{@articles}}
+          @regulatoryStatementMode={{@regulatoryStatementMode}}
         />
       </AuToolbar>
     </div>

--- a/packages/say-ar-design-plugin/src/components/preview.gts
+++ b/packages/say-ar-design-plugin/src/components/preview.gts
@@ -21,7 +21,6 @@ type ArPreviewSignature = {
   Args: ArInsertControlArgs & {
     onReturnToOverview: () => unknown;
     processDocumentHeadlessly: ProcessDocumentHeadlessly;
-    controller: SayController;
   };
   Element: HTMLDivElement;
 };
@@ -35,7 +34,6 @@ export default class ArPreview extends Component<ArPreviewSignature> {
       return this.arImporter.generatePreview(
         this.args.arDesign,
         this.args.processDocumentHeadlessly,
-        this.args.controller,
       );
     } catch (e) {
       console.error('Error generating preview', e);

--- a/packages/say-ar-design-plugin/src/components/sidebar-widget.gts
+++ b/packages/say-ar-design-plugin/src/components/sidebar-widget.gts
@@ -25,7 +25,7 @@ export type ArDesignSidebarWidgetSig = {
       decisionUri: string;
       decisionType?: string;
     };
-    regulatoryStatementMode?: boolean
+    regulatoryStatementMode?: boolean;
   };
   Element: HTMLLIElement;
 };
@@ -41,7 +41,7 @@ export default class ArDesignSidebarWidget extends Component<ArDesignSidebarWidg
     this.modalOpen = false;
   };
   get disableInsert() {
-    if(this.args.regulatoryStatementMode) return false
+    if (this.args.regulatoryStatementMode) return false;
     const decisionContext = this.args.decisionContext;
     return decisionContext
       ? !!decisionContext.decisionType &&

--- a/packages/say-ar-design-plugin/src/components/sidebar-widget.gts
+++ b/packages/say-ar-design-plugin/src/components/sidebar-widget.gts
@@ -25,6 +25,7 @@ export type ArDesignSidebarWidgetSig = {
       decisionUri: string;
       decisionType?: string;
     };
+    regulatoryStatementMode?: boolean
   };
   Element: HTMLLIElement;
 };
@@ -40,6 +41,7 @@ export default class ArDesignSidebarWidget extends Component<ArDesignSidebarWidg
     this.modalOpen = false;
   };
   get disableInsert() {
+    if(this.args.regulatoryStatementMode) return false
     const decisionContext = this.args.decisionContext;
     return decisionContext
       ? !!decisionContext.decisionType &&
@@ -77,6 +79,7 @@ export default class ArDesignSidebarWidget extends Component<ArDesignSidebarWidg
           @designQuery={{@designQuery}}
           @processDocumentHeadlessly={{@processDocumentHeadlessly}}
           @decisionContext={{@decisionContext}}
+          @regulatoryStatementMode={{@regulatoryStatementMode}}
         />
       </modal.Body>
     </AuModal>

--- a/packages/say-ar-design-plugin/src/components/widget-contents.gts
+++ b/packages/say-ar-design-plugin/src/components/widget-contents.gts
@@ -57,7 +57,6 @@ export default class ArWidgetContents extends Component<Sig> {
   arDesignsQuery = restartableTask(async () => {
     await timeout(FILTER_TIMEOUT_MS);
     const { pageNumber, pageSize, sort, nameFilter } = this;
-    console.log('query');
     try {
       return this.args.designQuery({ pageNumber, pageSize, sort, nameFilter });
     } catch (e) {
@@ -87,7 +86,6 @@ export default class ArWidgetContents extends Component<Sig> {
   };
 
   selectDesign = (design: ArDesign) => {
-    console.log('select');
     this.selectedDesign = design;
   };
 

--- a/packages/say-ar-design-plugin/src/components/widget-contents.gts
+++ b/packages/say-ar-design-plugin/src/components/widget-contents.gts
@@ -129,6 +129,7 @@ export default class ArWidgetContents extends Component<Sig> {
         @insertLoading={{this.insertAr.isRunning}}
         @articles={{@articles}}
         @processDocumentHeadlessly={{@processDocumentHeadlessly}}
+        @controller={{@controller}}
       />
     {{else}}
       <ArDesignOverview

--- a/packages/say-ar-design-plugin/src/components/widget-contents.gts
+++ b/packages/say-ar-design-plugin/src/components/widget-contents.gts
@@ -129,7 +129,6 @@ export default class ArWidgetContents extends Component<Sig> {
         @insertLoading={{this.insertAr.isRunning}}
         @articles={{@articles}}
         @processDocumentHeadlessly={{@processDocumentHeadlessly}}
-        @controller={{@controller}}
       />
     {{else}}
       <ArDesignOverview

--- a/packages/say-ar-design-plugin/src/components/widget-contents.gts
+++ b/packages/say-ar-design-plugin/src/components/widget-contents.gts
@@ -57,7 +57,7 @@ export default class ArWidgetContents extends Component<Sig> {
   arDesignsQuery = restartableTask(async () => {
     await timeout(FILTER_TIMEOUT_MS);
     const { pageNumber, pageSize, sort, nameFilter } = this;
-    console.log('query')
+    console.log('query');
     try {
       return this.args.designQuery({ pageNumber, pageSize, sort, nameFilter });
     } catch (e) {
@@ -87,7 +87,7 @@ export default class ArWidgetContents extends Component<Sig> {
   };
 
   selectDesign = (design: ArDesign) => {
-    console.log('select')
+    console.log('select');
     this.selectedDesign = design;
   };
 

--- a/packages/say-ar-design-plugin/src/components/widget-contents.gts
+++ b/packages/say-ar-design-plugin/src/components/widget-contents.gts
@@ -32,6 +32,7 @@ type Sig = {
       decisionUri: string;
       decisionType?: string;
     };
+    regulatoryStatementMode?: boolean;
   };
 };
 
@@ -111,6 +112,7 @@ export default class ArWidgetContents extends Component<Sig> {
         insertPos,
         this.args.controller,
         this.args.decisionContext?.decisionUri,
+        this.args.regulatoryStatementMode,
       );
       if (skipWarnings || monadsResult.warnings.length === 0) {
         this.doInsert(monadsResult.result);
@@ -127,6 +129,7 @@ export default class ArWidgetContents extends Component<Sig> {
         @insertLoading={{this.insertAr.isRunning}}
         @articles={{@articles}}
         @processDocumentHeadlessly={{@processDocumentHeadlessly}}
+        @regulatoryStatementMode={{@regulatoryStatementMode}}
       />
     {{else}}
       <ArDesignOverview

--- a/packages/say-ar-design-plugin/src/components/widget-contents.gts
+++ b/packages/say-ar-design-plugin/src/components/widget-contents.gts
@@ -57,6 +57,7 @@ export default class ArWidgetContents extends Component<Sig> {
   arDesignsQuery = restartableTask(async () => {
     await timeout(FILTER_TIMEOUT_MS);
     const { pageNumber, pageSize, sort, nameFilter } = this;
+    console.log('query')
     try {
       return this.args.designQuery({ pageNumber, pageSize, sort, nameFilter });
     } catch (e) {
@@ -86,6 +87,7 @@ export default class ArWidgetContents extends Component<Sig> {
   };
 
   selectDesign = (design: ArDesign) => {
+    console.log('select')
     this.selectedDesign = design;
   };
 

--- a/packages/say-ar-design-plugin/src/plugin/types.ts
+++ b/packages/say-ar-design-plugin/src/plugin/types.ts
@@ -7,12 +7,12 @@ export type ArticlePosition = { node: PNode; pos: number };
 
 export type InsertPositionOption = {
   label: string;
-  value: ArticleInsertPosition;
+  value: ArticleInsertPosition | false;
 };
 
 export type ArInsertFunc = (
   arDesign: ArDesign,
-  insertPosition: ArticleInsertPosition,
+  insertPosition: ArticleInsertPosition | false,
   skipWarnings?: boolean,
 ) => void;
 

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -254,9 +254,11 @@ export default class ArImporterService extends Service {
     );
     console.log(monads)
     console.log(warnings)
+    console.log(processDocumentHeadlessly)
     const document = processDocumentHeadlessly(`<div></div>`, (state) =>
       transactionCombinator<boolean>(state)(monads),
     );
+    console.log(document)
     return { result: document, warnings };
   }
 

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -116,6 +116,7 @@ export default class ArImporterService extends Service {
     controller?: SayController,
     decisionUriOverride?: string,
   ): Promise<GenerateImportResult> {
+    console.log('generating insertion monads')
     let decisionUri = decisionUriOverride;
     let insertPositionArgs: InsertPositionArgs;
     if (!decisionUri && controller) {
@@ -145,7 +146,7 @@ export default class ArImporterService extends Service {
     try {
       const warnings: string[] = [];
       const measureDesigns = await design.measureDesigns;
-      const monads = measureDesigns.flatMap((measureDesign) => {
+      const monads = measureDesigns.flatMap((measureDesign, index, array) => {
         const {
           measureConcept,
           trafficSignals,
@@ -227,6 +228,7 @@ export default class ArImporterService extends Service {
             ...insertPositionArgs,
             articleUriGenerator: () =>
               `http://data.lblod.info/artikels/${uuidv4()}`,
+            multipleInsertion: index !== (array.length - 1)
           }),
         ];
       });
@@ -249,12 +251,14 @@ export default class ArImporterService extends Service {
         state: EditorState,
       ) => TransactionCombinatorResult<boolean>,
     ) => string,
+    controller: SayController
   ): Promise<ImportResult<string>> {
     console.log('generating preview');
     console.log(design);
     const { result: monads, warnings } = await this.generateInsertionMonads(
       design,
       afterLastArticle,
+      controller
     );
     console.log(monads);
     console.log(warnings);

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -247,10 +247,13 @@ export default class ArImporterService extends Service {
       ) => TransactionCombinatorResult<boolean>,
     ) => string,
   ): Promise<ImportResult<string>> {
+    console.log('generating preview')
     const { result: monads, warnings } = await this.generateInsertionMonads(
       design,
       false,
     );
+    console.log(monads)
+    console.log(warnings)
     const document = processDocumentHeadlessly(`<div></div>`, (state) =>
       transactionCombinator<boolean>(state)(monads),
     );

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -24,9 +24,7 @@ import type TrafficSignal from '../plugin/models/traffic-signal.ts';
 import type VariableInstance from '../plugin/models/variable-instance.ts';
 import { v4 as uuidv4 } from 'uuid';
 import { TRAFFIC_SIGNAL_EXISTING_STATUSES } from '../plugin/constants.ts';
-import {
-  ArticleInsertPosition,
-} from '../plugin/utils/article-insert-position.ts';
+import { ArticleInsertPosition } from '../plugin/utils/article-insert-position.ts';
 
 export type ImportResult<R> = {
   result: R;
@@ -186,7 +184,7 @@ export default class ArImporterService extends Service {
             signal.designStatus &&
             TRAFFIC_SIGNAL_EXISTING_STATUSES.includes(signal.designStatus),
         );
-        console.log('calling insert measure')
+        console.log('calling insert measure');
         return [
           ...(!controller && onlyExistingSignals
             ? [
@@ -256,7 +254,7 @@ export default class ArImporterService extends Service {
     console.log(design);
     const { result: monads, warnings } = await this.generateInsertionMonads(
       design,
-      false
+      false,
     );
     console.log(monads);
     console.log(warnings);

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -24,7 +24,10 @@ import type TrafficSignal from '../plugin/models/traffic-signal.ts';
 import type VariableInstance from '../plugin/models/variable-instance.ts';
 import { v4 as uuidv4 } from 'uuid';
 import { TRAFFIC_SIGNAL_EXISTING_STATUSES } from '../plugin/constants.ts';
-import { ArticleInsertPosition } from '../plugin/utils/article-insert-position.ts';
+import {
+  afterLastArticle,
+  ArticleInsertPosition,
+} from '../plugin/utils/article-insert-position.ts';
 
 export type ImportResult<R> = {
   result: R;
@@ -248,9 +251,10 @@ export default class ArImporterService extends Service {
     ) => string,
   ): Promise<ImportResult<string>> {
     console.log('generating preview');
+    console.log(design);
     const { result: monads, warnings } = await this.generateInsertionMonads(
       design,
-      false,
+      afterLastArticle,
     );
     console.log(monads);
     console.log(warnings);

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -112,25 +112,29 @@ export default class ArImporterService extends Service {
     /** If controller is not passed, this is a preview */
     controller?: SayController,
     decisionUriOverride?: string,
-    regulatoryStatementMode?: boolean
+    regulatoryStatementMode?: boolean,
   ): Promise<GenerateImportResult> {
     let decisionUri = decisionUriOverride;
     let insertPositionArgs: InsertPositionArgs;
     if (!decisionUri && controller) {
       const decisionRange = getCurrentBesluitRange(controller);
       decisionUri = decisionRange?.node.attrs['subject'] as string;
-      if (!regulatoryStatementMode && (!decisionRange || typeof decisionUri !== 'string' || !insertPos)) {
+      if (
+        !regulatoryStatementMode &&
+        (!decisionRange || typeof decisionUri !== 'string' || !insertPos)
+      ) {
         this._notifyError(controller, 'ar-importer.message.error-no-decision');
         return { result: [], warnings: [] };
       } else {
-        if(regulatoryStatementMode) {
+        if (regulatoryStatementMode) {
           insertPositionArgs = {
-           insertFreely: true,
-          }
+            insertFreely: true,
+          };
         } else {
+          // insertPos should be handled by the previous if, so just keep TS happy here
           insertPositionArgs = {
             insertFreely: false,
-            position: insertPos && insertPos.insertMeasureIndex,
+            position: insertPos ? insertPos.insertMeasureIndex : 0,
             decisionUri,
           };
         }
@@ -233,7 +237,7 @@ export default class ArImporterService extends Service {
             articleUriGenerator: () =>
               `http://data.lblod.info/artikels/${uuidv4()}`,
             multipleInsertion: !isLastMeasureInserted,
-            regulatoryStatementMode
+            regulatoryStatementMode,
           }),
         ];
       });

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -113,7 +113,6 @@ export default class ArImporterService extends Service {
     controller?: SayController,
     decisionUriOverride?: string,
   ): Promise<GenerateImportResult> {
-    console.log('generating insertion monads');
     let decisionUri = decisionUriOverride;
     let insertPositionArgs: InsertPositionArgs;
     if (!decisionUri && controller) {
@@ -184,7 +183,6 @@ export default class ArImporterService extends Service {
             signal.designStatus &&
             TRAFFIC_SIGNAL_EXISTING_STATUSES.includes(signal.designStatus),
         );
-        console.log('calling insert measure');
         const isLastMeasureInserted = index === array.length - 1;
         return [
           ...(!controller && onlyExistingSignals
@@ -251,19 +249,13 @@ export default class ArImporterService extends Service {
       ) => TransactionCombinatorResult<boolean>,
     ) => string,
   ): Promise<ImportResult<string>> {
-    console.log('generating preview');
-    console.log(design);
     const { result: monads, warnings } = await this.generateInsertionMonads(
       design,
       false,
     );
-    console.log(monads);
-    console.log(warnings);
-    console.log(processDocumentHeadlessly);
     const document = processDocumentHeadlessly(`<div></div>`, (state) =>
       transactionCombinator<boolean>(state)(monads),
     );
-    console.log(document);
     return { result: document, warnings };
   }
 

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -247,18 +247,18 @@ export default class ArImporterService extends Service {
       ) => TransactionCombinatorResult<boolean>,
     ) => string,
   ): Promise<ImportResult<string>> {
-    console.log('generating preview')
+    console.log('generating preview');
     const { result: monads, warnings } = await this.generateInsertionMonads(
       design,
       false,
     );
-    console.log(monads)
-    console.log(warnings)
-    console.log(processDocumentHeadlessly)
+    console.log(monads);
+    console.log(warnings);
+    console.log(processDocumentHeadlessly);
     const document = processDocumentHeadlessly(`<div></div>`, (state) =>
       transactionCombinator<boolean>(state)(monads),
     );
-    console.log(document)
+    console.log(document);
     return { result: document, warnings };
   }
 

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -25,7 +25,6 @@ import type VariableInstance from '../plugin/models/variable-instance.ts';
 import { v4 as uuidv4 } from 'uuid';
 import { TRAFFIC_SIGNAL_EXISTING_STATUSES } from '../plugin/constants.ts';
 import {
-  afterLastArticle,
   ArticleInsertPosition,
 } from '../plugin/utils/article-insert-position.ts';
 
@@ -116,7 +115,7 @@ export default class ArImporterService extends Service {
     controller?: SayController,
     decisionUriOverride?: string,
   ): Promise<GenerateImportResult> {
-    console.log('generating insertion monads')
+    console.log('generating insertion monads');
     let decisionUri = decisionUriOverride;
     let insertPositionArgs: InsertPositionArgs;
     if (!decisionUri && controller) {
@@ -228,7 +227,7 @@ export default class ArImporterService extends Service {
             ...insertPositionArgs,
             articleUriGenerator: () =>
               `http://data.lblod.info/artikels/${uuidv4()}`,
-            multipleInsertion: index !== (array.length - 1)
+            multipleInsertion: index !== array.length - 1,
           }),
         ];
       });
@@ -251,14 +250,11 @@ export default class ArImporterService extends Service {
         state: EditorState,
       ) => TransactionCombinatorResult<boolean>,
     ) => string,
-    controller: SayController
   ): Promise<ImportResult<string>> {
     console.log('generating preview');
     console.log(design);
     const { result: monads, warnings } = await this.generateInsertionMonads(
       design,
-      afterLastArticle,
-      controller
     );
     console.log(monads);
     console.log(warnings);

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -145,7 +145,7 @@ export default class ArImporterService extends Service {
     try {
       const warnings: string[] = [];
       const measureDesigns = await design.measureDesigns;
-      const monads = measureDesigns.flatMap((measureDesign, index, array) => {
+      const monads = measureDesigns.flatMap((measureDesign) => {
         const {
           measureConcept,
           trafficSignals,
@@ -186,6 +186,7 @@ export default class ArImporterService extends Service {
             signal.designStatus &&
             TRAFFIC_SIGNAL_EXISTING_STATUSES.includes(signal.designStatus),
         );
+        console.log('calling insert measure')
         return [
           ...(!controller && onlyExistingSignals
             ? [
@@ -255,6 +256,7 @@ export default class ArImporterService extends Service {
     console.log(design);
     const { result: monads, warnings } = await this.generateInsertionMonads(
       design,
+      false
     );
     console.log(monads);
     console.log(warnings);

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -112,21 +112,28 @@ export default class ArImporterService extends Service {
     /** If controller is not passed, this is a preview */
     controller?: SayController,
     decisionUriOverride?: string,
+    regulatoryStatementMode?: boolean
   ): Promise<GenerateImportResult> {
     let decisionUri = decisionUriOverride;
     let insertPositionArgs: InsertPositionArgs;
     if (!decisionUri && controller) {
       const decisionRange = getCurrentBesluitRange(controller);
       decisionUri = decisionRange?.node.attrs['subject'] as string;
-      if (!decisionRange || typeof decisionUri !== 'string' || !insertPos) {
+      if (!regulatoryStatementMode && (!decisionRange || typeof decisionUri !== 'string' || !insertPos)) {
         this._notifyError(controller, 'ar-importer.message.error-no-decision');
         return { result: [], warnings: [] };
       } else {
-        insertPositionArgs = {
-          insertFreely: false,
-          position: insertPos.insertMeasureIndex,
-          decisionUri,
-        };
+        if(regulatoryStatementMode) {
+          insertPositionArgs = {
+           insertFreely: true,
+          }
+        } else {
+          insertPositionArgs = {
+            insertFreely: false,
+            position: insertPos && insertPos.insertMeasureIndex,
+            decisionUri,
+          };
+        }
       }
     } else {
       insertPositionArgs =
@@ -226,6 +233,7 @@ export default class ArImporterService extends Service {
             articleUriGenerator: () =>
               `http://data.lblod.info/artikels/${uuidv4()}`,
             multipleInsertion: !isLastMeasureInserted,
+            regulatoryStatementMode
           }),
         ];
       });

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -143,7 +143,7 @@ export default class ArImporterService extends Service {
     try {
       const warnings: string[] = [];
       const measureDesigns = await design.measureDesigns;
-      const monads = measureDesigns.flatMap((measureDesign) => {
+      const monads = measureDesigns.flatMap((measureDesign, index, array) => {
         const {
           measureConcept,
           trafficSignals,
@@ -185,6 +185,7 @@ export default class ArImporterService extends Service {
             TRAFFIC_SIGNAL_EXISTING_STATUSES.includes(signal.designStatus),
         );
         console.log('calling insert measure');
+        const isLastMeasureInserted = index === array.length - 1;
         return [
           ...(!controller && onlyExistingSignals
             ? [
@@ -226,7 +227,7 @@ export default class ArImporterService extends Service {
             ...insertPositionArgs,
             articleUriGenerator: () =>
               `http://data.lblod.info/artikels/${uuidv4()}`,
-            multipleInsertion: true,
+            multipleInsertion: !isLastMeasureInserted,
           }),
         ];
       });

--- a/packages/say-ar-design-plugin/src/services/ar-importer.ts
+++ b/packages/say-ar-design-plugin/src/services/ar-importer.ts
@@ -227,7 +227,7 @@ export default class ArImporterService extends Service {
             ...insertPositionArgs,
             articleUriGenerator: () =>
               `http://data.lblod.info/artikels/${uuidv4()}`,
-            multipleInsertion: index !== array.length - 1,
+            multipleInsertion: true,
           }),
         ];
       });

--- a/packages/say-ar-design-plugin/translations/en-us.yaml
+++ b/packages/say-ar-design-plugin/translations/en-us.yaml
@@ -30,6 +30,7 @@ ar-importer:
     last: After the last article
     after-article-x: After article {articleNumber}
     select-position: Choose insertion point
+    on-cursor: On cursor
   preview:
     return-to-overview: Return to overview
     only-existing-label: existing

--- a/packages/say-ar-design-plugin/translations/nl-be.yaml
+++ b/packages/say-ar-design-plugin/translations/nl-be.yaml
@@ -30,6 +30,7 @@ ar-importer:
     last: Na het laatste artikel
     after-article-x: Na artikel {articleNumber}
     select-position: Kies invoegpositie
+    on-cursor: Bij de cursor
   preview:
     return-to-overview: Terug naar overzicht
     only-existing-label: bestaand

--- a/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
@@ -282,9 +282,6 @@ export default function insertMeasure({
         }),
       ),
     ]);
-    console.log('multiple insertion');
-    console.log(args.multipleInsertion);
-    console.log(transaction.selection);
     if (!args.multipleInsertion) {
       console.log('setting new selection');
 

--- a/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
@@ -281,9 +281,11 @@ export default function insertMeasure({
       ),
     ]);
     if (!args.multipleInsertion) {
-      transaction.setSelection(
-        Selection.fromJSON(transaction.doc, resultingSelection.toJSON()),
-      );
+      transaction
+        .setSelection(
+          Selection.fromJSON(transaction.doc, resultingSelection.toJSON()),
+        )
+        .scrollIntoView();
     }
     return {
       initialState: state,

--- a/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
@@ -237,7 +237,10 @@ export default function insertMeasure({
     const articleNode = buildArticleStructure(
       state.schema,
       articleUriGenerator,
+      undefined,
+      true
     ).copy(Fragment.from(measureNode));
+    console.log(articleNode)
     const insertArticleArgs = args.insertFreely
       ? ({
           node: articleNode,
@@ -281,7 +284,10 @@ export default function insertMeasure({
     ]);
     console.log('multiple insertion')
     console.log(args.multipleInsertion)
+    console.log(transaction.selection)
     if (!args.multipleInsertion) {
+      console.log('setting new selection')
+
       transaction.setSelection(
         Selection.fromJSON(transaction.doc, resultingSelection.toJSON()),
       );

--- a/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
@@ -279,6 +279,8 @@ export default function insertMeasure({
         }),
       ),
     ]);
+    console.log('multiple insertion')
+    console.log(args.multipleInsertion)
     if (!args.multipleInsertion) {
       transaction.setSelection(
         Selection.fromJSON(transaction.doc, resultingSelection.toJSON()),

--- a/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
@@ -90,7 +90,6 @@ export default function insertMeasure({
   articleUriGenerator,
   ...args
 }: InsertMeasureArgs): TransactionMonad<boolean> {
-  console.log('inserting measure');
   return function (state: EditorState) {
     const measureConcept =
       'measureConcept' in args
@@ -240,7 +239,6 @@ export default function insertMeasure({
       undefined,
       true,
     ).copy(Fragment.from(measureNode));
-    console.log(articleNode);
     const insertArticleArgs = args.insertFreely
       ? ({
           node: articleNode,
@@ -253,7 +251,6 @@ export default function insertMeasure({
           insertFreely: false,
           position: args.position,
         } satisfies InsertArticleToDecisionArgs);
-    console.log(insertArticleArgs);
     const initialTransaction =
       insertArticle(insertArticleArgs)(state).transaction;
     const resultingSelection = initialTransaction.selection;
@@ -283,8 +280,6 @@ export default function insertMeasure({
       ),
     ]);
     if (!args.multipleInsertion) {
-      console.log('setting new selection');
-
       transaction.setSelection(
         Selection.fromJSON(transaction.doc, resultingSelection.toJSON()),
       );

--- a/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
@@ -89,6 +89,7 @@ export default function insertMeasure({
   articleUriGenerator,
   ...args
 }: InsertMeasureArgs): TransactionMonad<boolean> {
+  console.log('inserting measure')
   return function (state: EditorState) {
     const measureConcept =
       'measureConcept' in args
@@ -248,6 +249,7 @@ export default function insertMeasure({
           insertFreely: false,
           position: args.position,
         } satisfies InsertArticleToDecisionArgs);
+    console.log(insertArticleArgs)
     const initialTransaction =
       insertArticle(insertArticleArgs)(state).transaction;
     const resultingSelection = initialTransaction.selection;
@@ -276,9 +278,11 @@ export default function insertMeasure({
         }),
       ),
     ]);
-    transaction.setSelection(
-      Selection.fromJSON(transaction.doc, resultingSelection.toJSON()),
-    );
+    if(!args.multipleInsertion) {
+       transaction.setSelection(
+        Selection.fromJSON(transaction.doc, resultingSelection.toJSON()),
+      );
+    }
     return {
       initialState: state,
       transaction,

--- a/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
@@ -71,7 +71,7 @@ type InsertMeasureArgs = {
   templateString: string;
   articleUriGenerator?: () => string;
   multipleInsertion?: boolean;
-  regulatoryStatementMode?: boolean
+  regulatoryStatementMode?: boolean;
 } & InsertPositionArgs &
   (
     | {

--- a/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
@@ -71,6 +71,7 @@ type InsertMeasureArgs = {
   templateString: string;
   articleUriGenerator?: () => string;
   multipleInsertion?: boolean;
+  regulatoryStatementMode?: boolean
 } & InsertPositionArgs &
   (
     | {
@@ -237,7 +238,7 @@ export default function insertMeasure({
       state.schema,
       articleUriGenerator,
       undefined,
-      true,
+      args.regulatoryStatementMode,
     ).copy(Fragment.from(measureNode));
     const insertArticleArgs = args.insertFreely
       ? ({

--- a/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
@@ -70,6 +70,7 @@ type InsertMeasureArgs = {
   variables: Record<string, VariableInstance & { __rdfaId: string }>;
   templateString: string;
   articleUriGenerator?: () => string;
+  multipleInsertion?: boolean;
 } & InsertPositionArgs &
   (
     | {
@@ -89,7 +90,7 @@ export default function insertMeasure({
   articleUriGenerator,
   ...args
 }: InsertMeasureArgs): TransactionMonad<boolean> {
-  console.log('inserting measure')
+  console.log('inserting measure');
   return function (state: EditorState) {
     const measureConcept =
       'measureConcept' in args
@@ -249,7 +250,7 @@ export default function insertMeasure({
           insertFreely: false,
           position: args.position,
         } satisfies InsertArticleToDecisionArgs);
-    console.log(insertArticleArgs)
+    console.log(insertArticleArgs);
     const initialTransaction =
       insertArticle(insertArticleArgs)(state).transaction;
     const resultingSelection = initialTransaction.selection;
@@ -278,8 +279,8 @@ export default function insertMeasure({
         }),
       ),
     ]);
-    if(!args.multipleInsertion) {
-       transaction.setSelection(
+    if (!args.multipleInsertion) {
+      transaction.setSelection(
         Selection.fromJSON(transaction.doc, resultingSelection.toJSON()),
       );
     }

--- a/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
+++ b/packages/say-roadsign-regulation-plugin/src/plugin/actions/insert-measure.ts
@@ -238,9 +238,9 @@ export default function insertMeasure({
       state.schema,
       articleUriGenerator,
       undefined,
-      true
+      true,
     ).copy(Fragment.from(measureNode));
-    console.log(articleNode)
+    console.log(articleNode);
     const insertArticleArgs = args.insertFreely
       ? ({
           node: articleNode,
@@ -282,11 +282,11 @@ export default function insertMeasure({
         }),
       ),
     ]);
-    console.log('multiple insertion')
-    console.log(args.multipleInsertion)
-    console.log(transaction.selection)
+    console.log('multiple insertion');
+    console.log(args.multipleInsertion);
+    console.log(transaction.selection);
     if (!args.multipleInsertion) {
-      console.log('setting new selection')
+      console.log('setting new selection');
 
       transaction.setSelection(
         Selection.fromJSON(transaction.doc, resultingSelection.toJSON()),

--- a/test-app/app/templates/lblod-plugins.gts
+++ b/test-app/app/templates/lblod-plugins.gts
@@ -725,7 +725,7 @@ export default class LblodPluginsTemplate extends Component {
                     @controller={{container.controller}}
                     @designQuery={{this.arDesignTest}}
                     @processDocumentHeadlessly={{this.processDocumentHeadlessly}}
-                    @decisionContext={{this.pluginConfig.arDesign.decision}}
+                    @regulatoryStatementMode={{true}}
                   />
                 </Item>
               </Sb.Collapsible>

--- a/test-app/app/templates/lblod-plugins.gts
+++ b/test-app/app/templates/lblod-plugins.gts
@@ -261,6 +261,13 @@ export default class LblodPluginsTemplate extends Component {
       fullLengthArticles: false,
       onlyArticleSpecialName: true,
     } satisfies StructurePluginOptions,
+    arDesign: {
+      decision: {
+        decisionUri: 'decisionUri',
+        decisionType:
+          'https://data.vlaanderen.be/id/concept/Verkeerstekenontwerpstatus/fc1036e7-703b-4290-b732-49abb39d0588',
+      },
+    },
   };
 
   rdfa = {
@@ -568,6 +575,82 @@ export default class LblodPluginsTemplate extends Component {
                 },
               ],
             },
+
+            {
+              id: 'test',
+              uri: 'test',
+              trafficSignals: [
+                {
+                  id: 'test',
+                  uri: 'test',
+                  designStatus:
+                    'https://data.vlaanderen.be/id/concept/Verkeerstekenontwerpstatus/fc1036e7-703b-4290-b732-49abb39d0588',
+                  trafficSignalConcept: {
+                    id: 'test',
+                    uri: 'test',
+                    code: 'Parkeerautomaat',
+                    type: 'https://data.vlaanderen.be/ns/mobiliteit#Verkeersbordconcept',
+                    categories: [
+                      {
+                        id: 'test',
+                        uri: 'http://data.vlaanderen.be/id/concept/Verkeersbordcategorie/29ea3335e357e414d07229242607b352941c0c21e78760600cc0f5270f18c38b',
+                        label: 'StilstaanParkeerBord',
+                      },
+                    ],
+                  },
+                },
+              ],
+              measureConcept: {
+                id: 'test',
+                uri: 'test',
+                label: 'E9a-GVIId-GVIId-GXa-GXd-GXb-Parkeerautomaat',
+                templateString:
+                  '${locatie} \nhet parkeren is toegelaten; \nhet parkeren is voorbehouden voor ${categorie_voertuig}; \nhet parkeren is betalend; de parkeerreglementering is beperkt in de tijd ${maximumduur_betalend_parkeren}; \nhet begin van de parkeerreglementering wordt aangeduid; \nde parkeerreglementering geldt over een afstand van meer dan 300 meter; \nhet einde van de parkeerreglementering wordt aangeduid; \nbestuurders moeten parkeren op de wijze en onder de voorwaarden die op de parkeerautomaat zijn vermeld.',
+                rawTemplateString:
+                  '${locatie} \n${E9a}; \n${GVIId}; \n${GVIId2}; \n${GXa}; \n${GXd}; \n${GXb}; \n${Parkeerautomaat}.',
+              },
+              unusedSignalConcepts: [],
+              unIncludedSignalConcepts: [],
+              variableInstances: [
+                {
+                  id: 'test1',
+                  uri: 'test1',
+                  variable: {
+                    id: 'test1',
+                    uri: 'test1',
+                    type: 'codelist',
+                    label: 'categorie_voertuig',
+                    source: 'https://roadsigns.lblod.info/sparql',
+                    codelist:
+                      'http://lblod.data.gift/concept-schemes/61AE3534BF5C750009000050',
+                  },
+                },
+                {
+                  id: 'test2',
+                  uri: 'test2',
+                  variable: {
+                    id: 'test2',
+                    uri: 'test2',
+                    type: 'codelist',
+                    label: 'maximumduur_betalend_parkeren',
+                    source: 'https://roadsigns.lblod.info/sparql',
+                    codelist:
+                      'http://lblod.data.gift/concept-schemes/98ce0acb-a92d-4641-860e-d7f581810686',
+                  },
+                },
+                {
+                  id: 'test3',
+                  uri: 'test3',
+                  variable: {
+                    id: 'test3',
+                    uri: 'test3',
+                    type: 'location',
+                    label: 'locatie',
+                    source: 'https://roadsigns.lblod.info/sparql',
+                  },
+                },
+              ],
+            },
           ]),
         },
       ],
@@ -642,6 +725,7 @@ export default class LblodPluginsTemplate extends Component {
                     @controller={{container.controller}}
                     @designQuery={{this.arDesignTest}}
                     @processDocumentHeadlessly={{this.processDocumentHeadlessly}}
+                    @decisionContext={{this.pluginConfig.arDesign.decision}}
                   />
                 </Item>
               </Sb.Collapsible>


### PR DESCRIPTION
### Overview
This PR mainly does 2 things, first fixes a bug on inserting a AR design at cursor position (previously only used in the preview mode) which made articles be inside each other.
Second it adds all the logic needed to insert AR designs without a besluit being present,

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6156


### Setup
None

### How to test/reproduce
The test page is setup so now the AR designs are added in this new way. So just empty the editor and insert a new AR design, this should work as expected

### Challenges/uncertainties
The test page change should be reverted before merging the PR is just done for easier testing



### Checks PR readiness
- [x] UI: feedback for any loading/error states
- [x] Tested on Firefox and Chrome-based browsers
- [x] changelog
- [x] npm lint
- [x] no new deprecation warnings
