### PR TITLE
Configure rdfa-parser with set of default prefixes to expand

### DIFF
--- a/.changeset/khaki-states-guess.md
+++ b/.changeset/khaki-states-guess.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': patch
+---
+
+Expand prefixes from a preconfigured list when loading RDFa into the editor to avoid problems from prefixes not being defined

--- a/.changeset/silly-bars-sip.md
+++ b/.changeset/silly-bars-sip.md
@@ -1,0 +1,5 @@
+---
+'@lblod/ember-rdfa-editor': minor
+---
+
+Add configuration option to allow configuration of prefixes to be expanded when parsing RDFa inserted into the editor

--- a/packages/ember-rdfa-editor/src/commands/insert-html-command.ts
+++ b/packages/ember-rdfa-editor/src/commands/insert-html-command.ts
@@ -15,6 +15,7 @@ export function insertHtml(
   marks?: Mark[],
   preserveWhitespace = false,
   shouldPreprocessRdfa = false,
+  defaultPrefixes?: Record<string, string>,
 ): Command {
   return function (state, dispatch, view) {
     if (dispatch) {
@@ -32,6 +33,7 @@ export function insertHtml(
         preprocessRDFa(
           'body' in htmlNode ? htmlNode.body : htmlNode,
           view ? getPathFromRoot(view.dom, false) : [],
+          defaultPrefixes,
         );
       }
       let fragment = ProseParser.fromSchema(state.schema).parseSlice(htmlNode, {

--- a/packages/ember-rdfa-editor/src/components/editor.ts
+++ b/packages/ember-rdfa-editor/src/components/editor.ts
@@ -8,7 +8,7 @@ import { tracked } from 'tracked-built-ins';
 import SayEditor, { type PluginConfig } from '#root/core/say-editor.ts';
 import type { NodeViewConstructor } from 'prosemirror-view';
 import { Schema } from 'prosemirror-model';
-import { getOwner } from '@ember/application';
+import { getOwner } from '@ember/owner';
 import type Owner from '@ember/owner';
 import type { DefaultAttrGenPuginOptions } from '#root/plugins/default-attribute-value-generation/index.ts';
 import SayController from '#root/core/say-controller.ts';
@@ -21,29 +21,39 @@ import type {
   NotificationOptions,
 } from '#root/plugins/notification/index.ts';
 import type IntlService from 'ember-intl/services/intl';
+/** @import { defaultPrefixes } from '#root/config/rdfa.ts' */
 
-export interface RdfaEditorArgs {
-  /**
-   * callback that is called with an interface to the editor after editor init completed
-   * @default 'default'
-   * @public
-   */
-  rdfaEditorInit(editor: SayController): void;
+export interface RdfaEditorSig {
+  Args: {
+    /**
+     * callback that is called with an interface to the editor after editor init completed
+     * @default 'default'
+     * @public
+     */
+    rdfaEditorInit(editor: SayController): void;
 
-  initializers?: Array<Promise<void>>;
-  schema: Schema;
-  baseIRI?: string;
-  plugins?: PluginConfig;
-  stealFocus?: boolean;
-  nodeViews?: (controller: SayController) => {
-    [node: string]: NodeViewConstructor;
+    initializers?: Array<Promise<void>>;
+    schema: Schema;
+    baseIRI?: string;
+    plugins?: PluginConfig;
+    stealFocus?: boolean;
+    nodeViews?: (controller: SayController) => {
+      [node: string]: NodeViewConstructor;
+    };
+    defaultAttrGenerators?: DefaultAttrGenPuginOptions;
+    keyMapOptions?: KeymapOptions;
+    editable?: boolean;
+    notificationCallback?: (notification: Notification) => void;
+    notificationToaster?: boolean;
+    /**
+     * An object mapping prefixes (without the trailing `:`) to their expanded versions. These are
+     * used to expand prefixes in any RDFa loaded into the editor. Can be overriden with an empty
+     * object. If not passed, a default list is used {@link defaultPrefixes}.
+     */
+    defaultPrefixes?: Record<string, string>;
   };
-  defaultAttrGenerators?: DefaultAttrGenPuginOptions;
-  keyMapOptions?: KeymapOptions;
-  editable?: boolean;
-  notificationCallback?: (notification: Notification) => void;
-  notificationToaster?: boolean;
 }
+export type RdfaEditorArgs = RdfaEditorSig['Args'];
 
 /**
  * RDFa editor
@@ -169,6 +179,7 @@ export default class RdfaEditor extends Component<RdfaEditorArgs> {
       editable: () => {
         return !(this.editable === false);
       },
+      defaultPrefixes: this.args.defaultPrefixes,
     });
     window.__PM = this.prosemirror;
     window.__PC = new SayController(this.prosemirror);

--- a/packages/ember-rdfa-editor/src/config/rdfa.ts
+++ b/packages/ember-rdfa-editor/src/config/rdfa.ts
@@ -62,6 +62,20 @@ const defaultPrefixes = {
   vcard: 'http://www.w3.org/2006/vcard/ns#',
   schema: 'http://schema.org/',
   ext: 'http://mu.semte.ch/vocabularies/ext/',
+  person: 'http://www.w3.org/ns/person#',
+  eli: 'http://data.europa.eu/eli/ontology#',
+  say: 'https://say.data.gift/ns/',
+  dateplugin: 'http://say.data.gift/manipulators/insertion/',
+  mandaat: 'http://data.vlaanderen.be/ns/mandaat#',
+  besluit: 'http://data.vlaanderen.be/ns/besluit#',
+  dossier: 'https://data.vlaanderen.be/ns/dossier',
+  persoon: 'http://data.vlaanderen.be/ns/persoon#',
+  besluittype: 'https://data.vlaanderen.be/id/concept/BesluitType/',
+  besluitpublicatie:
+    'https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie#',
+  mobiliteit: 'https://data.vlaanderen.be/ns/mobiliteit#',
+  lblodgn: 'http://data.lblod.info/vocabularies/gelinktnotuleren/',
+  lblodmow: 'http://data.lblod.info/vocabularies/mobiliteit/',
 };
 
 export { rdfaKeywords, prefixableRdfaKeywords, defaultPrefixes };

--- a/packages/ember-rdfa-editor/src/core/rdfa-processor.ts
+++ b/packages/ember-rdfa-editor/src/core/rdfa-processor.ts
@@ -87,7 +87,11 @@ export function isLinkTriple(triple: OutgoingTriple): triple is LinkTriple {
  * Function responsible for computing the properties and backlinks of a given document.
  * The properties and backlinks are stored in data-attributes in the nodes themselves.
  */
-export function preprocessRDFa(dom: Node, pathFromRoot?: Node[]) {
+export function preprocessRDFa(
+  dom: Node,
+  pathFromRoot?: Node[],
+  defaultPrefixes?: Record<string, string>,
+) {
   // parse the html
   const datastore = EditorStore.fromParse<Node>({
     parseRoot: true,
@@ -112,6 +116,7 @@ export function preprocessRDFa(dom: Node, pathFromRoot?: Node[]) {
     textContent(node: Node): string {
       return node.textContent || '';
     },
+    defaultPrefixes,
   });
 
   const seenExternalSubjects = new Set<string>();

--- a/packages/ember-rdfa-editor/src/core/say-controller.ts
+++ b/packages/ember-rdfa-editor/src/core/say-controller.ts
@@ -113,6 +113,7 @@ export default class SayController {
       shouldFocus = true,
       doNotClean = false,
       startsDirty = false,
+      defaultPrefixes,
     }: Exclude<SetHtmlOptions, 'range'> = {},
   ) {
     if (!startsDirty) {
@@ -122,6 +123,7 @@ export default class SayController {
       schema: this.schema,
       editorView: this.editor.mainView,
       parser: this.editor.parser,
+      defaultPrefixes,
       doNotClean,
     });
 

--- a/packages/ember-rdfa-editor/src/core/say-editor.ts
+++ b/packages/ember-rdfa-editor/src/core/say-editor.ts
@@ -50,6 +50,7 @@ export interface SayEditorArgs {
   ) => Record<string, NodeViewConstructor>;
   defaultAttrGenerators?: DefaultAttrGenPuginOptions;
   editable?: SayView['props']['editable'];
+  defaultPrefixes?: Record<string, string>;
 }
 
 export default class SayEditor {
@@ -84,6 +85,7 @@ export default class SayEditor {
     defaultAttrGenerators = [],
     keyMapOptions,
     editable,
+    defaultPrefixes,
   }: SayEditorArgs & { keyMapOptions?: KeymapOptions }) {
     this.logger = createLogger(this.constructor.name);
     this.owner = owner;
@@ -107,7 +109,11 @@ export default class SayEditor {
       );
 
       pluginConf = [
-        datastore({ pathFromRoot: this.pathFromRoot, baseIRI }),
+        datastore({
+          pathFromRoot: this.pathFromRoot,
+          baseIRI,
+          defaultPrefixes,
+        }),
         ...filteredPluginArr,
         dropCursor(),
         gapCursor(),
@@ -167,6 +173,7 @@ export default class SayEditor {
         preprocessRDFa(
           cleanedHTMLNode,
           editorView ? getPathFromRoot(editorView.dom, false) : [],
+          defaultPrefixes,
         );
 
         return cleanedHTMLNode.innerHTML;

--- a/packages/ember-rdfa-editor/src/core/say-view.ts
+++ b/packages/ember-rdfa-editor/src/core/say-view.ts
@@ -5,6 +5,7 @@ import { htmlToDoc, htmlToFragment } from '../utils/_private/html-utils.ts';
 import { SetDocAttributesStep } from '../utils/steps.ts';
 import { ProseParser } from '#root/prosemirror-aliases.ts';
 import { DOMSerializer } from 'prosemirror-model';
+/** @import { defaultPrefixes } from '#root/config/rdfa.ts' */
 
 export interface SetHtmlOptions {
   shouldFocus?: boolean;
@@ -20,6 +21,12 @@ export interface SetHtmlOptions {
    * document that has not yet been saved.
    */
   startsDirty?: boolean;
+  /**
+   * An object mapping prefixes (without the trailing `:`) to their expanded versions. These are
+   * used to expand prefixes in any RDFa loaded into the editor. Can be overriden with an empty
+   * object. If not passed, a default list is used {@link defaultPrefixes}.
+   */
+  defaultPrefixes?: Record<string, string>;
 }
 export type DocumentRange = {
   from: number;
@@ -67,6 +74,7 @@ export default class SayView extends EditorView {
         parser: this.domParser,
         editorView: this,
         doNotClean,
+        defaultPrefixes: options.defaultPrefixes,
       });
       tr.replaceRange(range.from, range.to, fragment);
     } else {
@@ -75,6 +83,7 @@ export default class SayView extends EditorView {
         parser: this.domParser,
         editorView: this,
         doNotClean,
+        defaultPrefixes: options.defaultPrefixes,
       });
       tr.step(new SetDocAttributesStep(doc.attrs));
       tr.replaceWith(0, tr.doc.nodeSize - 2, doc);

--- a/packages/ember-rdfa-editor/src/plugins/datastore/index.ts
+++ b/packages/ember-rdfa-editor/src/plugins/datastore/index.ts
@@ -48,6 +48,7 @@ export function getAppliedMarks(pnode: DatastoreResolvedPNode): Mark[] {
 export interface DatastorePluginArgs {
   pathFromRoot: Node[];
   baseIRI: string;
+  defaultPrefixes?: Record<string, string>;
 }
 
 export interface DatastorePluginState {
@@ -58,6 +59,7 @@ export interface DatastorePluginState {
 export function datastore({
   pathFromRoot,
   baseIRI,
+  defaultPrefixes,
 }: DatastorePluginArgs): ProsePlugin<DatastorePluginState> {
   const logger = createLogger('datastore');
   return new ProsePlugin<DatastorePluginState>({
@@ -72,6 +74,7 @@ export function datastore({
           pathFromRoot,
           baseIRI,
           logger,
+          defaultPrefixes,
         );
 
         const refman = new ProseReferenceManager();
@@ -86,6 +89,7 @@ export function datastore({
 
           pathFromDomRoot: pathFromRoot,
           baseIRI,
+          defaultPrefixes,
         });
         return {
           datastore,
@@ -104,6 +108,7 @@ export function datastore({
             pathFromRoot,
             baseIRI,
             logger,
+            defaultPrefixes,
           ),
           contextStore: oldStore.contextStore,
         };
@@ -119,6 +124,7 @@ function createDataStoreGetter(
   pathFromRoot: Node[],
   baseIRI: string,
   logger: Logger,
+  defaultPrefixes?: Record<string, string>,
 ) {
   const refman = new ProseReferenceManager();
   return function () {
@@ -132,7 +138,7 @@ function createDataStoreGetter(
         children: children(state.schema, refman),
         attributes,
         isText,
-
+        defaultPrefixes,
         pathFromDomRoot: pathFromRoot,
         baseIRI,
       });

--- a/packages/ember-rdfa-editor/src/plugins/rdfa-info/utils.ts
+++ b/packages/ember-rdfa-editor/src/plugins/rdfa-info/utils.ts
@@ -26,9 +26,30 @@ import type { RdfaInfo } from './plugin';
 
 export const rdfaInfoPluginKey = new PluginKey<RdfaInfo>('rdfa_info');
 
+// From https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes
+const knownProtocols = new Set([
+  'blob',
+  'data',
+  'file',
+  'ftp',
+  'http',
+  'https',
+  'javascript',
+  'mailto',
+  'ssh',
+  'tel',
+  'urn',
+  'ws',
+  'wss',
+]);
+
 // ### Lifted from @lblod/marawa as it was the only part we were still using
+// Modified to also include known protocols as otherwise was e.g. reporting mailto: links as
+// prefixed
 export function isFullUri(uri: string) {
-  return uri.includes('://');
+  if (uri.includes('://')) return true;
+  const potentialPrefix = uri.split(':')[0];
+  return knownProtocols.has(potentialPrefix);
 }
 /**
  * Returns whether a given URI is prefixed

--- a/packages/ember-rdfa-editor/src/utils/_private/html-utils.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/html-utils.ts
@@ -13,6 +13,7 @@ export function htmlToDoc(
     parser: ProseParser;
     editorView?: EditorView;
     doNotClean?: boolean;
+    defaultPrefixes?: Record<string, string>;
   },
 ) {
   const { parser } = options;
@@ -23,6 +24,7 @@ export function htmlToDoc(
   preprocessRDFa(
     parsed,
     options.editorView && getPathFromRoot(options.editorView.dom, false),
+    options.defaultPrefixes,
   );
   const topNodeMatch = matchTopNode(parsed, { schema: options.schema });
   let doc: PNode;
@@ -44,6 +46,7 @@ export function htmlToFragment(
     parser: ProseParser;
     editorView: EditorView;
     doNotClean?: boolean;
+    defaultPrefixes?: Record<string, string>;
   },
 ) {
   const { parser, editorView } = options;
@@ -51,7 +54,11 @@ export function htmlToFragment(
   const cleanedHTML = htmlCleaner.prepareHTML(html, false, options.doNotClean);
   const domParser = new DOMParser();
   const parsed = domParser.parseFromString(cleanedHTML, 'text/html').body;
-  preprocessRDFa(parsed, getPathFromRoot(editorView.dom, false));
+  preprocessRDFa(
+    parsed,
+    getPathFromRoot(editorView.dom, false),
+    options.defaultPrefixes,
+  );
   return parser.parseSlice(parsed, { preserveWhitespace: true });
 }
 

--- a/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/rdfa-parser.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/rdfa-parser.ts
@@ -82,6 +82,7 @@ export interface RdfaParseConfig<N> {
 
   baseIRI: string;
   pathFromDomRoot?: Node[];
+  defaultPrefixes?: Record<string, string>;
 }
 
 export interface QuadNodes<N> {
@@ -193,7 +194,7 @@ export class RdfaParser<N> {
           ? INITIAL_CONTEXT_XHTML['@context']
           : {}),
       },
-      prefixesCustom: defaultPrefixes,
+      prefixesCustom: options.defaultPrefixes ?? defaultPrefixes,
       skipElement: false,
       vocab: options.vocab,
       node: this.rootModelNode,
@@ -202,7 +203,11 @@ export class RdfaParser<N> {
 
   static parse<N>(config: RdfaParseConfig<N>): RdfaParseResponse<N> {
     const { pathFromDomRoot = [], root, baseIRI, parseRoot = true } = config;
-    const parser = new RdfaParser<N>({ rootModelNode: root, baseIRI });
+    const parser = new RdfaParser<N>({
+      rootModelNode: root,
+      baseIRI,
+      defaultPrefixes: config.defaultPrefixes,
+    });
     for (const domNode of pathFromDomRoot) {
       if (isElement(domNode)) {
         const attributeObj: Record<string, string> = {};
@@ -1482,6 +1487,8 @@ export interface IRdfaParserOptions<N> {
   htmlParseListener?: IHtmlParseListener;
 
   rootModelNode: N;
+
+  defaultPrefixes?: Record<string, string>;
 }
 
 /**

--- a/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/rdfa-parser.ts
+++ b/packages/ember-rdfa-editor/src/utils/_private/rdfa-parser/rdfa-parser.ts
@@ -31,6 +31,7 @@ import { postProcessTagAsRdfaNode } from './post-process-as-rdfa-nodes.ts';
 import { sayDataFactory } from '#root/core/say-data-factory/index.ts';
 import { LANG_STRING } from '../constants.ts';
 import { N3StoreWrapper } from '../datastore/n3-store-wrapper.ts';
+import { defaultPrefixes } from '#root/config/rdfa.ts';
 
 export type ModelTerm<N> =
   | ModelQuadObject<N>
@@ -192,7 +193,7 @@ export class RdfaParser<N> {
           ? INITIAL_CONTEXT_XHTML['@context']
           : {}),
       },
-      prefixesCustom: {},
+      prefixesCustom: defaultPrefixes,
       skipElement: false,
       vocab: options.vocab,
       node: this.rootModelNode,

--- a/test-app/tests/helpers/datastore.ts
+++ b/test-app/tests/helpers/datastore.ts
@@ -31,6 +31,7 @@ export function calculateDataset(html: string) {
     textContent(node: Node): string {
       return node.textContent || '';
     },
+    defaultPrefixes: {},
   });
   return datastore.dataset;
 }

--- a/test-app/tests/integration/rdfa/blackbox-test.ts
+++ b/test-app/tests/integration/rdfa/blackbox-test.ts
@@ -25,10 +25,13 @@ module('Integration | RDFa blackbox test ', function () {
         plugins: SAMPLE_PLUGINS,
         override: true,
       });
-      controller.initialize(html);
+      controller.initialize(html, { defaultPrefixes: {} });
       const outputHTML = controller.htmlContent;
       // run through the editor twice to test for stability
-      controller.initialize(outputHTML, { doNotClean: true });
+      controller.initialize(outputHTML, {
+        doNotClean: true,
+        defaultPrefixes: {},
+      });
 
       const finalHTML = controller.htmlContent;
       assert.strictEqual(finalHTML, outputHTML);

--- a/test-app/tests/unit/rdfa/rdfa-parsing-test.ts
+++ b/test-app/tests/unit/rdfa/rdfa-parsing-test.ts
@@ -188,7 +188,9 @@ module('rdfa | parsing', function () {
 
     assert.strictEqual(actualProps.length, 2);
     assert.deepArrayContains(actualProps, {
-      object: sayDataFactory.namedNode('besluit:Besluit'),
+      object: sayDataFactory.namedNode(
+        'http://data.vlaanderen.be/ns/besluit#Besluit',
+      ),
       predicate: rdf('type'),
     });
 
@@ -244,14 +246,16 @@ module('rdfa | parsing', function () {
 
     const expectedBacklinks: IncomingTriple[] = [];
     assert.deepArrayContains(actualProps, {
-      object: sayDataFactory.namedNode('ext:BesluitNieuweStijl'),
+      object: sayDataFactory.namedNode(
+        'http://mu.semte.ch/vocabularies/ext/BesluitNieuweStijl',
+      ),
       predicate: rdf('type'),
     });
     assert.deepArrayContains(actualProps, {
       object: sayDataFactory.namedNode(
         'http://publications.europa.eu/resource/authority/language/NLD',
       ),
-      predicate: 'eli:language',
+      predicate: 'http://data.europa.eu/eli/ontology#language',
     });
 
     assert.deepEqual(actualBacklinks, expectedBacklinks);


### PR DESCRIPTION
### Overview
Expands prefixes from a predefined list, or the one configured, when loading any html into the editor. This list was previously only being set in the 'seen prefixes' list after parsing was complete. The majority of the changes are to make this configurable, and are in a separate commit, so can be dumped if we think this is not something we want to expose. The changes should be backwards compatible as the configuration is always optional.

##### connected issues and PRs:
Fixes: https://binnenland.atlassian.net/browse/GN-6214

### Setup
Can be tested as-is, but it would make sense to also test with custom defaultPrefixes passed in through the RdfaEditor component's args (e.g. in the editable-node test-app page).

### How to test/reproduce
Paste any HTML (as `text/html`) into the editor, or using the html-editor and see that known prefixes are replaced by their full versions. This includes unknown prefixes which are defined in a `@prefix` attribute in the inserted html. Non-defined prefixes are simply ignored.

### Challenges/uncertainties
Knowing what to actually fix as we could also have fixed the 'output' of the editor to detect non-defined prefixes.

### Checks PR readiness
- [ ] UI: feedback for any loading/error states
- [ ] Tested on Firefox and Chrome-based browsers
- [x] changelog
- [x] npm lint
- [x] no new deprecation warnings
